### PR TITLE
metomi/rose#81 rosie ls - fix `ws_client.info` call

### DIFF
--- a/lib/python/rosie/db.py
+++ b/lib/python/rosie/db.py
@@ -279,7 +279,7 @@ class DAO(object):
         rows = self._execute(statement)
         results = self._rows_to_maps(rows, list(from_obj.c))
         if not results:
-            return []
+            return {}
         return results[0]
 
     def query(self, filters, all_revs=False):


### PR DESCRIPTION
Change for review:
- `ws_client.info` call omitted in changes made previously for metomi/rose#79 and merged in by metomi/rose#80
- `ws_client.info` return statement changed from `[]` to `{}`

Have been unable to find any code that would be affected by this change.
