### PR TITLE
metomi/rose#77: update documentation

### DIFF
--- a/doc/rose-api.html
+++ b/doc/rose-api.html
@@ -324,7 +324,7 @@ class UsernameValueWidget(gtk.HBox):
     the lines:</p>
     <pre>
 [env=HELLO_GREETER]
-widget[config-edit] = username.UsernameValueWidget
+widget[rose-config-edit] = username.UsernameValueWidget
 </pre>
 
     <p>This means that we've set our widget up for the option
@@ -350,11 +350,11 @@ rose edit
 
     <p>The procedure for implementing a custom value widget is as follows:</p>
 
-    <p>Assign a <var>widget[config-edit]</var> attribute to the relevant
+    <p>Assign a <var>widget[rose-config-edit]</var> attribute to the relevant
     variable in the metadata configuration, e.g.</p>
     <pre>
 [namelist:VerifConNL/ScalarAreaCodes]
-widget[config-edit]=module_name.AreaCodeChooser
+widget[rose-config-edit]=module_name.AreaCodeChooser
 </pre>
 
     <p>where the widget class lives in the module <var>module_name</var> under
@@ -411,12 +411,12 @@ set_value("20")
         is an optional argument that stores any text given after the widget in
         the metadata:
         <pre>
-widget[config-edit] = modulename.ClassName arg1 arg2 arg3 ...
+widget[rose-config-edit] = modulename.ClassName arg1 arg2 arg3 ...
 </pre>would give a <code>arg_str</code> of <code>"arg1 arg2 arg3
 ..."</code>. This could help configure your widget - for example, for a table
 based widget, you might give the column names:
         <pre>
-widget[config-edit] = table.TableValueWidget NAME ID WEIGHTING
+widget[rose-config-edit] = table.TableValueWidget NAME ID WEIGHTING
 </pre>This means that you can write a generic widget and then configure it for
 different cases.
       </dd>
@@ -572,7 +572,7 @@ def handle_type_error(self, is_in_error):
     metadata configuration, e.g.</p>
     <pre>
     [ns:namelist/STASHNUM]
-    widget[config-edit]=module_name.MyGreatBigTable
+    widget[rose-config-edit]=module_name.MyGreatBigTable
 </pre>
 
     <p>The widget class should have a constructor of the form</p>

--- a/doc/rose-configuration.html
+++ b/doc/rose-configuration.html
@@ -1037,7 +1037,13 @@ trigger = env=CUSTOM_SNOWFLAKE_GEOMETRY: this != 6;
         specified after the widget name. E.g. to set up a hypothetical table
         with named columns X, Y, VCT, and Level, we may do:</p>
         <pre>
-widget[config-edit] = table X Y VCT Level
+widget[rose-config-edit] = table X Y VCT Level
+</pre>
+        <p>You may override to a Rose built-in widget by specifying a full
+        <code>rose</code> class path in Python - for example, to always show
+        radiobuttons for an option with <code>values</code> set:</p>
+        <pre>
+widget[rose-config-edit] = rose.config_editor.valuewidget.radiobuttons
 </pre>
       </dd>
     </dl>

--- a/lib/python/rose/config_editor/__init__.py
+++ b/lib/python/rose/config_editor/__init__.py
@@ -404,7 +404,7 @@ FLAG_TYPE_NO_META = "No metadata flag"
 
 # Relevant metadata properties
 
-META_PROP_WIDGET = "widget[config-edit]"
+META_PROP_WIDGET = "widget[rose-config-edit]"
 
 # Miscellaneous
 COPYRIGHT = '(C) British Crown Copyright 2012 Met Office.'


### PR DESCRIPTION
This addresses issue metomi/rose#77. The metadata syntax for `widget` is changed, and the documentation has been updated to reflect this. The documentation now notifies users of the rose builtin widget override ability.
