### PR TITLE
metomi/rose#102 rosie portable urls: &format=json handling

### DIFF
--- a/lib/python/rosie/browser/main.py
+++ b/lib/python/rosie/browser/main.py
@@ -143,6 +143,9 @@ class MainWindow(gtk.Window):
         self.local_updater.update_now()
         address_url = self.nav_bar.address_box.child.get_text()
 
+        if not address_url.endswith("&format=json"):
+            address_url += "&format=json"
+
         # if the url string doesn't begin with a valid prefix       
         if not (address_url.find("http://") == 0 or 
                 address_url.find("search?s=") == 0 or 
@@ -671,6 +674,9 @@ class MainWindow(gtk.Window):
                 items.update({"all_revs": ""})
             try:
                 results, url = self.search_manager.ws_query(filters, **items)
+                if url.endswith("&format=json"):
+                    url = url.replace("&format=json", "")
+                
                 self.nav_bar.address_box.child.set_text(url)   
                 if record == True:
                     recorded = self.hist.record_search("query", repr(filters), 
@@ -742,6 +748,8 @@ class MainWindow(gtk.Window):
             items.update({"all_revs": ""})
         try:
             results, url = self.search_manager.ws_search(search_text, **items)
+            if url.endswith("&format=json"):
+                url = url.replace("&format=json", "")
             self.nav_bar.address_box.child.set_text(url)
             if record == True:
                 recorded = self.hist.record_search("search", repr(search_text),

--- a/lib/python/rosie/ws_client.py
+++ b/lib/python/rosie/ws_client.py
@@ -232,6 +232,9 @@ def lookup(argv):
     if opts.url:
         ws_client = Client()
         addr = args[0]
+        if not addr.endswith("&format=json"):
+            addr += "&format=json"
+        
         if opts.debug_mode:
             results = ws_client.address_search(None,url=addr)
             url = addr
@@ -479,6 +482,8 @@ def _display_maps(opts, ws_client, dict_rows, url=None, local_suites=None):
            report(suite, clip=terminal_cols)
         report(SuiteInfo(dict_row), prefix="")
     if url is not None:
+        if url.endswith("&format=json"):
+            url = url.replace("&format=json", "")
         report(URLEvent(url + "\n"), prefix="")
 
 


### PR DESCRIPTION
Adjusted code as follows:
- `rosie go` strips "&format=json" from returned urls
- `rosie go` inserts "&format=json" on end of urls if it is not there when running a search
- `rosie lookup` strips "&format=json" from returned urls
- `rosie lookup` inserts "&format=json" on end of urls if it is not there when running a search

This change will not result in any history problems in `rosie go`
