### PR TITLE
rose_init_site: remove site specific stuff.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
 *.py[co]
 *.swp
 etc/rose.conf
+lib/bash/rose_init_site
+lib/python/cherrypy
+lib/python/jinja2
+lib/python/requests
+lib/python/sqlalchemy

--- a/lib/bash/rose_init_site.example
+++ b/lib/bash/rose_init_site.example
@@ -24,17 +24,7 @@
 #     . $ROSE_HOME/lib/bash/rose_init_site
 #
 # DESCRIPTION
-#     Ugly part of rose_init. Implements site specified settings that need to be
-#     configured before "rose config" can even be used.
+#     Site specified PATH, PYTHONPATH, etc.
 #-------------------------------------------------------------------------------
-# Met Office HPC IBM Power 6: requires this version of python.
-if [[ ${PATH:-} != */opt/python/2.6.6/bin:* && -d /opt/python/2.6.6/bin ]]; then
-    PATH=/opt/python/2.6.6/bin:$PATH
-fi
-# Some Python modules are installed here.
-if [[ -z ${PYTHONPATH:-} ]]; then
-    PYTHONPATH=~fcm/lib/python
-elif [[ ${PYTHONPATH:-} != *~fcm/lib/python:* && -d ~fcm/lib/python ]]; then
-    PYTHONPATH=~fcm/lib/python:$PYTHONPATH
-fi
-export PATH PYTHONPATH
+#PYTHONPATH=/path/to/site/specific/python/lib:$PYTHONPATH
+#PATH=/path/to/site/specific/bin:$PATH


### PR DESCRIPTION
This has missed our import review.

Team, beware that after this change, and before the relevant libraries are installed on site, we'll need to set `PYTHONPATH` or symlink in the relevant library into `lib/python/` for things to work.

@benfitzpatrick, please review.
