### PR TITLE
rose.task_utils.fcm_make: $PWD/fcm-make.cfg

### DIFF
--- a/lib/python/rose/task_utils/fcm_make.py
+++ b/lib/python/rose/task_utils/fcm_make.py
@@ -42,10 +42,12 @@ class FCMMakeTaskUtil(AppRunner):
             target += ":" + os.path.join(t.suite_dir_rel, "share", t.task_name)
             # FIXME: name-space for environment variable?
             env_export("MIRROR_TARGET", target, self.event_handler)
-        cfg_at_etc = os.path.join(t.suite_dir, "etc", t.task_name + ".cfg")
         cfg = ""
-        if os.access(cfg_at_etc, os.F_OK | os.R_OK):
-            cfg = " -f %s" % cfg_at_etc
+        for c in [os.path.abspath("fcm-make.cfg"),
+                  os.path.join(t.suite_dir, "etc", t.task_name + ".cfg")]:
+            if os.access(c, os.F_OK | os.R_OK):
+                cfg = " -f %s" % c
+                break
         dir = os.path.join(t.suite_dir, "share", t.task_name)
         n_jobs = os.getenv("ROSE_TASK_N_JOBS", "4")
         cmd = "fcm make%s -C %s -j %s" % (cfg, dir, n_jobs)


### PR DESCRIPTION
Look for $PWD/fcm-make.cfg because the comand's -C option changes
directory to point to the suite's share directory.

@benfitzpatrick, please review.
