### PR TITLE
Bugfix for ws_client.align() to cope with 0 length items.

### DIFF
--- a/lib/python/rosie/ws_client.py
+++ b/lib/python/rosie/ws_client.py
@@ -385,7 +385,7 @@ def get_local_status(suites, prefix, idx, branch, revision):
 
 def align(res, keys):
     """Function to align results to be displayed by display map"""
-    if len(res) == 1:
+    if len(res) <= 1:
         return res
     for k in keys:
         if k != "date":


### PR DESCRIPTION
For whatever reason, this capability has been lost and error reintroduced.
- fixes attempting to align empty results items
