### PR TITLE
Fix for refreshing search/query/url/localsuites bug.

### DIFF
--- a/lib/python/rosie/browser/main.py
+++ b/lib/python/rosie/browser/main.py
@@ -67,6 +67,7 @@ class MainWindow(gtk.Window):
     def __init__(self, opts=None, args=None):
 
         super(MainWindow, self).__init__()
+        self.refresh_url = ""
         self.search_manager = rosie.browser.search.SearchManager(opts.prefix)        
         locator = ResourceLocator(paths=sys.path)
         self.config = locator.get_conf()
@@ -142,6 +143,7 @@ class MainWindow(gtk.Window):
         """Run a search based on the address bar."""
         self.local_updater.update_now()
         address_url = self.nav_bar.address_box.child.get_text()
+        self.refresh_url = address_url
 
         if not address_url.endswith("&format=json"):
             address_url += "&format=json"
@@ -226,6 +228,7 @@ class MainWindow(gtk.Window):
     def display_local_suites(self, a_widget=None):
         """Get and display the locally stored suites."""
         self.nav_bar.address_box.child.set_text("")
+        self.refresh_url = ""
         self.statusbar.set_status_text(rosie.browser.STATUS_FETCHING, 
                                        instant=True)
         self.statusbar.set_progressbar_pulsing(True)
@@ -679,7 +682,8 @@ class MainWindow(gtk.Window):
                 if url.endswith("&format=json"):
                     url = url.replace("&format=json", "")
                 
-                self.nav_bar.address_box.child.set_text(url)   
+                self.nav_bar.address_box.child.set_text(url)
+                self.refresh_url = url   
                 if record == True:
                     recorded = self.hist.record_search("query", repr(filters), 
                                                         self.search_history)
@@ -712,6 +716,7 @@ class MainWindow(gtk.Window):
 
     def handle_refresh(self, *args):
         """Handles refreshing the search results."""
+        self.nav_bar.address_box.child.set_text(self.refresh_url)
         if self.nav_bar.address_box.child.get_text() == "":
             self.display_local_suites()
         else:
@@ -755,6 +760,7 @@ class MainWindow(gtk.Window):
             if url.endswith("&format=json"):
                 url = url.replace("&format=json", "")
             self.nav_bar.address_box.child.set_text(url)
+            self.refresh_url = url
             if record == True:
                 recorded = self.hist.record_search("search", repr(search_text),
                                                    self.search_history)


### PR DESCRIPTION
Fixes a bug in refreshing whereby if you alter the url in the address bar that will be the search that's run by refresh.

Now resets the search url to that of the last executed search (inline with firefox, ie, chrome etc).
