### PR TITLE
Fix mis-displaying message for suite output being opened.

### DIFF
--- a/lib/python/rosie/browser/main.py
+++ b/lib/python/rosie/browser/main.py
@@ -858,8 +858,6 @@ class MainWindow(gtk.Window):
         output_path = os.path.join(output_dir, "index.html") 
         try:
             urllib.urlopen(output_path)
-            self.statusbar.set_status_text(rosie.browser.STATUS_OPENING_LOG, 
-                                       instant=True)
         except IOError as e:
             if test:
                 return False


### PR DESCRIPTION
Fixes displaying that suite output has been opened in a browser window when simply selecting a suite from the results list but not clicking view output.
