### PR TITLE
#166: fix choices widget

### DIFF
--- a/lib/python/rose/config_editor/valuewidget/choice.py
+++ b/lib/python/rose/config_editor/valuewidget/choice.py
@@ -81,7 +81,7 @@ class ChoicesValueWidget(gtk.HBox):
                "choices": [
                        ["--choices"],
                        {"action": "append",
-                        "default": [],
+                        "default": None,
                         "metavar": "CHOICE"}],
                "editable": [
                        ["--editable"],
@@ -103,15 +103,16 @@ class ChoicesValueWidget(gtk.HBox):
         self.metadata = metadata
         self.set_value = set_value
         self.hook = hook
-
+        
         self.opt_parser = rose.opt_parse.RoseOptionParser()
         self.opt_parser.OPTIONS = self.OPTIONS
         self.opt_parser.add_my_options(*self.OPTIONS.keys())
         opts, args = self.opt_parser.parse_args(shlex.split(arg_str))
         self.all_group = opts.all_group
         self.groups = []
-        for choices in opts.choices:
-            self.groups.extend(rose.variable.array_split(choices))
+        if opts.choices is not None:
+            for choices in opts.choices:
+                self.groups.extend(rose.variable.array_split(choices))
         self.should_edit = opts.editable
         self.value_format = opts.format
         self.should_guess_groups = opts.guess_groups

--- a/lib/python/rose/config_editor/variable.py
+++ b/lib/python/rose/config_editor/variable.py
@@ -111,7 +111,7 @@ class VariableWidget(object):
             if len(info) > 1:
                 widget_path, widget_args = info
             else:
-                widget_path, widget_args = info[0], []
+                widget_path, widget_args = info[0], None
             files = self.var_ops.get_var_metadata_files(variable)
             lib = os.path.join("lib", "python", "widget")
             is_builtin = False

--- a/lib/python/rose/opt_parse.py
+++ b/lib/python/rose/opt_parse.py
@@ -25,7 +25,11 @@ from rose.resource import ResourceLocator
 
 class RoseOptionParser(OptionParser):
 
-    """Option parser base class for Rose command utilities."""
+    """Option parser base class for Rose command utilities.
+    
+    Warning: do not use a list or dict as a default.
+
+    """
 
     OPTIONS = {"all": [
                        ["--all", "-a"],


### PR DESCRIPTION
This addresses #166. Using a list or a dict as a default in <code>OptionParser</code> is not a good idea, as it appears to invoke this kind of behaviour: http://stackoverflow.com/questions/1132941/least-astonishment-in-python-the-mutable-default-argument
