### PR TITLE
#177 - implement pickup 'HEAD'

### DIFF
--- a/lib/python/rose/__init__.py
+++ b/lib/python/rose/__init__.py
@@ -36,6 +36,7 @@ SUB_CONFIGS_DIR = 'app'
 SUB_CONFIG_FILE_DIR = 'file'
 INFO_CONFIG_NAME = 'rose-suite.info'
 TOP_CONFIG_NAME = 'rose-suite.conf'
+META_DEFAULT_VN_DIR = "HEAD"
 
 # Configuration specification names
 CONFIG_SECT_CMD = 'command'

--- a/lib/python/rose/config_editor/main.py
+++ b/lib/python/rose/config_editor/main.py
@@ -1973,14 +1973,6 @@ def get_number_of_configs(config_directory_path=None):
     return number_to_load
 
 
-def load_site_config_path():
-    """Load any metadata path specified in a user or site configuration."""
-    conf = rose.resource.ResourceLocator.default().get_conf()
-    path = conf.get_value([rose.CONFIG_SECT_TOP, rose.CONFIG_OPT_META_PATH])
-    if path is not None:
-        sys.path.insert(0, path)
-
-
 if __name__ == '__main__':
     if (gtk.pygtk_version[0] < rose.config_editor.MIN_PYGTK_VERSION[0]
         or gtk.pygtk_version[1] < rose.config_editor.MIN_PYGTK_VERSION[1]):
@@ -2000,7 +1992,7 @@ if __name__ == '__main__':
     if args:
         opt_parser.print_usage(sys.stderr)
         sys.exit(2)
-    load_site_config_path()
+    rose.macro.add_site_meta_path()
     if opts.meta_path is not None:
         opts.meta_path.reverse()
         for child_paths in [arg.split(":") for arg in opts.meta_path]:

--- a/lib/python/rose/config_editor/util.py
+++ b/lib/python/rose/config_editor/util.py
@@ -141,6 +141,15 @@ def launch_node_info_dialog(node, changes, search_function):
                                        search_function)
 
 
+def launch_error_dialog(exception=None, text=""):
+    """This will be replaced by rose.reporter utilities."""
+    if text:
+        text += "\n"
+    if exception is not None:
+        text += type(exception).__name__ + ": " + str(exception)
+    rose.gtk.util.run_dialog(rose.gtk.util.DIALOG_TYPE_ERROR,
+                             text, rose.config_editor.DIALOG_TITLE_ERROR)
+
 def wrap_string(text, maxlen=72, indent0=0, maxlines=4, sep=","):
     """Return a wrapped string - 'textwrap' is not flexible enough for this."""
     lines = [""]

--- a/lib/python/rose/upgrade.py
+++ b/lib/python/rose/upgrade.py
@@ -212,8 +212,8 @@ class MacroUpgradeManager(object):
 
     def load_all_tags(self):
         """Load an ordered list of the available upgrade macros."""
-        meta_path = rose.macro.load_meta_path(self.app_config,
-                                              is_upgrade=True)
+        meta_path, warning = rose.macro.load_meta_path(self.app_config,
+                                                       is_upgrade=True)
         if meta_path is None:
             raise OSError(rose.macro.ERROR_LOAD_CONF_META_NODE)
         sys.path.append(os.path.abspath(meta_path))


### PR DESCRIPTION
This addresses the code part of #177.

It allows metadata to be specified using the agreed format. It also centralises the metadata searching and loading - the centralised event handling will need to be replaced in #20.

A documentation (<code>Metadata Install</code>) pull request will follow.

@matthewrmshin, please review.
