### PR TITLE
rosie-ws: more configurable

### DIFF
--- a/bin/rosie-lookup
+++ b/bin/rosie-lookup
@@ -78,5 +78,9 @@
 #
 #     --verbose; -v
 #         Display full info for each returned suite.
+#
+#     --ws-root=URL
+#         Specify the root URL of a Rosie web service. (Override the setting in
+#         the site/user configuration [rosie-ws-client]ws-root-default=URL.) 
 #-------------------------------------------------------------------------------
 exec python -m rosie.ws_client lookup "$@"

--- a/bin/rosie-ls
+++ b/bin/rosie-ls
@@ -58,5 +58,9 @@
 #
 #     --verbose; -v
 #         Display full info for each returned suite.
+#
+#     --ws-root=URL
+#         Specify the root URL of a Rosie web service. (Override the setting in
+#         the site/user configuration [rosie-ws-client]ws-root-default=URL.) 
 #-------------------------------------------------------------------------------
 exec python -m rosie.ws_client local_suites "$@"

--- a/doc/rose-command.html
+++ b/doc/rose-command.html
@@ -1841,6 +1841,12 @@ abc01 from daisy
       <dt><kbd>--verbose; -v</kbd></dt>
 
       <dd>Display full info for each returned suite.</dd>
+
+      <dt><kbd>--ws-root=URL</kbd></dt>
+
+      <dd>Specify the root URL of a Rosie web service. (Override the setting in
+      the site/user configuration
+      <var>[rosie-ws-client]ws-root-default=URL</var>.)</dd>
     </dl>
 
     <h2 id="rosie-ls">rosie ls</h2>
@@ -1905,6 +1911,12 @@ abc01 from daisy
       <dt><kbd>--verbose; -v</kbd></dt>
 
       <dd>Display full info for each returned suite.</dd>
+
+      <dt><kbd>--ws-root=URL</kbd></dt>
+
+      <dd>Specify the root URL of a Rosie web service. (Override the setting in
+      the site/user configuration
+      <var>[rosie-ws-client]ws-root-default=URL</var>.)</dd>
     </dl>
   </div>
 </body>

--- a/etc/rose.conf.example
+++ b/etc/rose.conf.example
@@ -141,6 +141,8 @@
 #
 ## Adhoc Rosie web server log directory
 #  log-dir = /path/to/log/directory
+## Adhoc Rosie web server port
+#  port = 8080
 [rosie-ws]
 
 # Configuration related to Rosie client commands

--- a/lib/python/rose/opt_parse.py
+++ b/lib/python/rose/opt_parse.py
@@ -378,7 +378,11 @@ class RoseOptionParser(OptionParser):
                        {"action": "store_false",
                         "dest": "web_browser_mode",
                         "default": True,
-                        "help": "Do not open web browser."}]}
+                        "help": "Do not open web browser."}],
+               "ws_root": [
+                       ["--ws-root"],
+                       {"metavar": "URL",
+                        "help": "Specify the web service root URL."}]}
 
     def __init__(self, *args, **kwargs):
         if hasattr(kwargs, "prog"):

--- a/lib/python/rosie/browser/search.py
+++ b/lib/python/rosie/browser/search.py
@@ -18,7 +18,7 @@
 # along with Rose. If not, see <http://www.gnu.org/licenses/>.
 #-----------------------------------------------------------------------------
 
-import rosie.ws_client
+from rosie.ws_client import RosieWSClient
 
 
 class SearchManager():
@@ -26,7 +26,7 @@ class SearchManager():
     """Wrapper class for running searches."""
 
     def __init__(self, prefix):
-        self.ws_client = rosie.ws_client.Client(prefix=prefix)
+        self.ws_client = RosieWSClient(prefix=prefix)
 
     def address_lookup(self, **items):
         """Return search results for a url lookup."""
@@ -38,7 +38,7 @@ class SearchManager():
 
     def set_datasource(self, prefix):
         """Set the datasource."""
-        self.ws_client = rosie.ws_client.Client(prefix=prefix)
+        self.ws_client = RosieWSClient(prefix=prefix)
 
     def ws_query(self, filters, **items):
         """Return search results for a query.""" 

--- a/lib/python/rosie/browser/suite.py
+++ b/lib/python/rosie/browser/suite.py
@@ -24,7 +24,7 @@ import gtk
 
 import rose.gtk.util
 import rosie.browser
-import rosie.vc
+from rosie.vc import RosieVCClient, LocalCopyStatusError
 
 
 class SuiteDirector():
@@ -34,7 +34,7 @@ class SuiteDirector():
     def __init__(self, event_handler):
         self.last_vc_event = ""
         self.event_logged = False
-        self.vc_client = rosie.vc.Client(event_handler=event_handler)
+        self.vc_client = RosieVCClient(event_handler=event_handler)
         
     def checkout(self, *args, **kwargs):
         """Check out a suite."""

--- a/lib/python/rosie/vc.py
+++ b/lib/python/rosie/vc.py
@@ -163,7 +163,7 @@ class SuiteDeleteEvent(Event):
         return "%s: deleted" % id.to_origin()
 
 
-class Client(object):
+class RosieVCClient(object):
 
     """Client for version control functionalities."""
 
@@ -376,7 +376,7 @@ def checkout(argv):
     opts, args = opt_parser.parse_args(argv)
     verbosity = opts.verbosity - opts.quietness
     report = Reporter(verbosity)
-    client = Client(event_handler=report, force_mode=opts.force_mode)
+    client = RosieVCClient(event_handler=report, force_mode=opts.force_mode)
     SuiteId.svn.event_handler = client.event_handler # FIXME: ugly?
     for arg in args:
         try:
@@ -395,7 +395,7 @@ def create(argv):
     opts, args = opt_parser.parse_args(argv)
     verbosity = opts.verbosity - opts.quietness
     report = Reporter(verbosity)
-    client = Client(event_handler=report)
+    client = RosieVCClient(event_handler=report)
     SuiteId.svn.event_handler = client.event_handler # FIXME: ugly?
     from_id = None
     if args:
@@ -450,7 +450,7 @@ def delete(argv):
                                                    "local_only")
     opts, args = opt_parser.parse_args(argv)
     report = Reporter(opts.verbosity - opts.quietness)
-    client = Client(event_handler=report, force_mode=opts.force_mode)
+    client = RosieVCClient(event_handler=report, force_mode=opts.force_mode)
     SuiteId.svn.event_handler = client.event_handler # FIXME
     if not args:
         args.append(SuiteId(location=os.getcwd()))

--- a/lib/python/rosie/ws.py
+++ b/lib/python/rosie/ws.py
@@ -193,9 +193,9 @@ def start(is_main=False):
 
     # CherryPy quick server configuration
     rose_conf = ResourceLocator.default().get_conf()
-    if is_main and rose_conf.get(["rosie-ws", "log-dir"]) is not None:
-        node = rose_conf.get(["rosie-ws", "log-dir"])
-        log_dir = env_var_process(os.path.expanduser(node.value))
+    if is_main and rose_conf.get_value(["rosie-ws", "log-dir"]) is not None:
+        log_dir_value = rose_conf.get_value(["rosie-ws", "log-dir"])
+        log_dir = env_var_process(os.path.expanduser(log_dir_value))
         log_file = os.path.join(log_dir, "server.log")
         log_error_file = os.path.join(log_dir, "server.err.log")
         cherrypy.config["log.error_file"] = log_error_file
@@ -222,8 +222,9 @@ def start(is_main=False):
                     "tools.staticfile.on": True,
                     "tools.staticfile.filename": ICON_PATH}}
     if is_main:
+        port = int(rose_conf.get_value(["rosie-ws", "port"], 8080))
         config.update({"global": {"server.socket_host": "0.0.0.0",
-                                  "server.socket_port": int(8080)}})
+                                  "server.socket_port": port}})
 
     # Start server or return WSGI application
     if is_main:


### PR DESCRIPTION
`rosie-ws-client`: allow override of `ws-root`. (Not done for `rosie go`.)

`rosie-ws`: allow ad-hoc server port to be configurable.
