### PR TITLE
Fix config-edit 'ignore' menu

### DIFF
--- a/demo/rose-config-edit/demo_meta/app/test3-trigger/meta/rose-meta.conf
+++ b/demo/rose-config-edit/demo_meta/app/test3-trigger/meta/rose-meta.conf
@@ -228,6 +228,21 @@ type = logical
 [namelist:trigger_env_var]
 help = This tests triggering from variables containing environment variables
 
+[namelist:trigger_compulsory_optional]
+
+[namelist:trigger_compulsory_optional=comp_var]
+compulsory = true
+trigger = namelist:trigger_compulsory_optional=subject_var: .true.
+type = logical
+
+[namelist:trigger_compulsory_optional=opt_var]
+trigger = namelist:trigger_compulsory_optional=subject_var: .true.
+type = logical
+
+[namelist:trigger_compulsory_optional=subject_var]
+compulsory = true
+type = integer
+
 [namelist:trig_dupl]
 duplicate = true
 

--- a/demo/rose-config-edit/demo_meta/app/test3-trigger/rose-app.conf
+++ b/demo/rose-config-edit/demo_meta/app/test3-trigger/rose-app.conf
@@ -16,6 +16,10 @@ IS_WET = true
 [file:file1]
 source=namelist:nl1
 
+[namelist:trigger_compulsory_optional]
+comp_var = .true.
+!!subject_var = 2
+
 [namelist:triggering_list]
 A_trig_B = .true.
 B_triglist_X_Y = .true.

--- a/lib/python/rose/config_editor/menuwidget.py
+++ b/lib/python/rose/config_editor/menuwidget.py
@@ -226,7 +226,7 @@ class MenuWidget(gtk.HBox):
                                           title, search_function))
         if 'action="Ignore"' in option_ui:
             ignore_item = uimanager.get_widget('/Options/Ignore')
-            if rose.config_editor.WARNING_TYPE_IGNORED in errors:
+            if rose.config_editor.WARNING_TYPE_ENABLED in errors:
                 # It is an enabled variable that should be trigger-ignored.
                 new_reason = {rose.variable.IGNORED_BY_SYSTEM:
                               rose.config_editor.IGNORED_STATUS_MANUAL}


### PR DESCRIPTION
This fixes the ignore menu for erroneously-enabled (should be trigger-ignored) variables. It should trigger-ignore them.

@matthewrmshin, please review.
