### PR TITLE
rose suite-gcontrol: fix

### DIFF
--- a/lib/python/rose/suite_engine_procs/cylc.py
+++ b/lib/python/rose/suite_engine_procs/cylc.py
@@ -178,7 +178,7 @@ class CylcProcessor(SuiteEngineProcessor):
         if not host:
             # Try the "rose-suite.host" file in the suite log directory
             try:
-                host_file = os.path.join(log_dir, "rose-suite.host")
+                host_file = os.path.join(log_dir, "rose-suite-run.host")
                 host = open(host_file).read().strip()
             except IOError:
                 host = "localhost"


### PR DESCRIPTION
This fixes the "Launch Suite Control GUI"  button in <code>rosie go</code> and <code>rose config-edit</code>.
