### PR TITLE
rose utils: alter README path

### DIFF
--- a/lib/python/rose/__init__.py
+++ b/lib/python/rose/__init__.py
@@ -81,3 +81,6 @@ TYPE_LOGICAL_TRUE_TITLE = 'true'
 FILE_VAR_CHECKSUM = 'checksum'
 FILE_VAR_MODE = 'mode'
 FILE_VAR_SOURCE = 'source'
+
+# Paths in the Rose distribution.
+FILEPATH_README = "README.md"

--- a/lib/python/rose/gtk/util.py
+++ b/lib/python/rose/gtk/util.py
@@ -780,7 +780,8 @@ def run_about_dialog(name=None, copyright=None,
     about_dialog = gtk.AboutDialog()
     about_dialog.set_transient_for(parent_window)
     about_dialog.set_name(name)
-    licence_path = os.path.join(os.getenv("ROSE_HOME"), "README")
+    licence_path = os.path.join(os.getenv("ROSE_HOME"),
+                                rose.FILEPATH_README)
     about_dialog.set_license(open(licence_path, "r").read())
     about_dialog.set_copyright(copyright)
     resource_loc = rose.resource.ResourceLocator(paths=sys.path)


### PR DESCRIPTION
This fixes the "License" button in the <code>rosie go</code> and <code>rose config-edit</code> about dialogs.
