### PR TITLE
rose config-edit: fail if errors should disappear

### DIFF
--- a/lib/python/rose/config_editor/menu.py
+++ b/lib/python/rose/config_editor/menu.py
@@ -633,7 +633,8 @@ class Handler(object):
                                                 s.section, s.option)
             return_value.sort(lambda x, y: sorter(to_id(x), to_id(y)))
             self.handle_macro_validation(config_name, macro_fullname,
-                                         config, return_value)
+                                         config, return_value,
+                                         no_display=(not return_value))
 
     def clear_page_menu(self, menubar, add_menuitem):
         """Clear all page add variable items."""


### PR DESCRIPTION
At the moment, errors reported by <code>fail-if</code> are not removed if the error condition is corrected and the fail-if mechanism is run again ( they should be fixed).

@matthewrmshin, please review.
