### PR TITLE
metomi/rose#273: geditor: don't use EDITOR/VISUAL.

### DIFF
--- a/lib/python/rose/popen.py
+++ b/lib/python/rose/popen.py
@@ -91,8 +91,7 @@ class RosePopener(object):
                       "--rsh=ssh -oBatchMode=yes"],
             "ssh": ["ssh", "-oBatchMode=yes"],
             "terminal": ["xterm"]}
-    ENVS_OF_CMDS = {"editor": ["VISUAL", "EDITOR"],
-                    "geditor": ["VISUAL", "EDITOR"]}
+    ENVS_OF_CMDS = {"editor": ["VISUAL", "EDITOR"]}
 
     @classmethod
     def list_to_shell_str(cls, args):


### PR DESCRIPTION
This should make it less likely for users to specify a terminal based text editor for geditor.
