### PR TITLE
rose config_cli: style changes

### DIFF
--- a/lib/python/rose/config_cli.py
+++ b/lib/python/rose/config_cli.py
@@ -21,7 +21,6 @@
 
 from rose.config import ConfigDumper, ConfigLoader, ConfigNode
 from rose.opt_parse import RoseOptionParser
-from rose.popen import RosePopener
 from rose.reporter import Reporter, Event
 from rose.resource import ResourceLocator
 import rose.macro
@@ -58,7 +57,6 @@ def main():
                               "meta_key")
     opts, args = opt_parser.parse_args()
     report = Reporter(opts.verbosity - opts.quietness)
-    popen = RosePopener(event_handler=report)
 
     rose.macro.add_site_meta_paths()
     rose.macro.add_env_meta_paths()


### PR DESCRIPTION
Style changes made as follows:
- NoMedata event added
- os.path.abspath(rel_path) used instead of cwd + "/" + rel_path
- os.path.join used
- POpen and Reporter used
- System exits rather than returning None when both files and meta-key are used
- os.sep used where "/" was previously used in setting up rel_path
- older %s formatting used for making message to be consistent with usage later on
