### PR TITLE
rose config-edit: fix section ignore

### DIFF
--- a/lib/python/rose/config_editor/main.py
+++ b/lib/python/rose/config_editor/main.py
@@ -1104,7 +1104,7 @@ class MainController(object):
                         if ns not in triggered_ns_list:
                             triggered_ns_list.append(ns)
                         var.ignored_reason.pop(
-                                    rose.var.IGNORED_BY_SECTION)
+                                    rose.variable.IGNORED_BY_SECTION)
             elif section in trigger.ignored_dict:
                 # Trigger-ignored sections
                 parents = trigger.ignored_dict.get(section, {})


### PR DESCRIPTION
This fixes a typo in config-edit for the trigger-enabling of a section. @matthewrmshin, please review.
