### PR TITLE
rose env-cat: new command.

### DIFF
--- a/bin/rose-env-cat
+++ b/bin/rose-env-cat
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+#-------------------------------------------------------------------------------
+# (C) British Crown Copyright 2012-3 Met Office.
+# 
+# This file is part of Rose, a framework for scientific suites.
+# 
+# Rose is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# 
+# Rose is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+# 
+# You should have received a copy of the GNU General Public License
+# along with Rose. If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# NAME
+#     rose env-cat
+#
+# SYNOPSIS
+#     rose env-cat [OPTIONS] [FILE ...]
+#
+# DESCRIPTION
+#     Substitute environment variables in input files and print.
+#
+#     If no argument is specified, read from STDIN. One FILE argument may be
+#     "-", which means read from STDIN.
+#
+#     The command will look for $NAME or ${NAME} syntax and substitute them
+#     with the value of the environment variable NAME. A backslash in front of
+#     the syntax, e.g. \$NAME or \${NAME} will escape the substitution.
+#
+# OPTIONS
+#     --unbound=STRING, --undef=STRING
+#         The command will normally fail on unbound (or undefined) variables.
+#         If this option is specified, the command will substitute an unbound
+#         variable with the value of STRING, (which can be an empty string),
+#         instead of failing.
+#-------------------------------------------------------------------------------
+exec python -m rose.env_cat "$@"

--- a/doc/rose-command.html
+++ b/doc/rose-command.html
@@ -83,6 +83,10 @@
 
       <dd>(=config-edit)</dd>
 
+      <dt><a href="#rose-env-cat">rose env-cat</a></dt>
+
+      <dd>Substitute environment variables in input files and print.</dd>
+
       <dt><a href="#rose-host-select">rose host-select</a></dt>
 
       <dd>Select a host from a set of groups or names by load or by
@@ -620,6 +624,40 @@
     <h2 id="rose-edit">rose edit</h2>
 
     <p>See <a href="#rose-config-edit">rose config-edit</a>.</p>
+
+    <h2 id="rose-env-cat">rose env-cat</h2>
+
+    <h3>NAME</h3>
+
+    <p><kbd>rose env-cat</kbd></p>
+
+    <h3>SYNOPSIS</h3>
+
+    <p><kbd>rose env-cat [OPTIONS] [FILE ...]</kbd></p>
+
+    <h3>DESCRIPTION</h3>
+
+    <p>Substitute environment variables in input files and print.</p>
+
+    <p>If no argument is specified, read from <var>STDIN</var>. One
+    <var>FILE</var> argument may be <kbd>-</kbd>, which means read from
+    <var>STDIN</var>.</p>
+
+    <p>The command will look for <kbd>$NAME</kbd> or <kbd>${NAME}</kbd> syntax
+    and substitute them with the value of the environment variable
+    <var>NAME</var>. A backslash in front of the syntax, e.g. <kbd>\$NAME</kbd>
+    or <kbd>\${NAME}</kbd> will escape the substitution.</p>
+
+    <h3>OPTIONS</h3>
+
+    <dl>
+      <dt><kbd>--unbound=STRING</kbd>, <kbd>--undef=STRING</kbd></dt>
+
+      <dd>The command will normally fail on unbound (or undefined) variables.
+      If this option is specified, the command will substitute an unbound
+      variable with the value of <var>STRING</var>, (which can be an empty
+      string), instead of failing.</dd>
+    </dl>
 
     <h2 id="rose-host-select">rose host-select</h2>
 

--- a/lib/python/rose/ana.py
+++ b/lib/python/rose/ana.py
@@ -29,7 +29,7 @@ import sys
 
 # Rose modules
 import rose.config
-import rose.env
+from rose.env import env_var_process
 from rose.opt_parse import RoseOptionParser
 from rose.popen import RosePopener, RosePopenError
 from rose.reporter import Reporter, Event
@@ -210,8 +210,7 @@ class Analyse(object):
         if hasattr(task, filevar):
             configvar = var + "fileconfig"
             setattr(task, configvar, getattr(task, filevar))
-            filenames = glob.glob(rose.env.env_var_process(getattr(task, 
-                        filevar)))
+            filenames = glob.glob(env_var_process(getattr(task, filevar)))
             if len(filenames) > 0:
                 setattr(task, filevar, filenames[0])
         return task

--- a/lib/python/rose/env.py
+++ b/lib/python/rose/env.py
@@ -130,13 +130,11 @@ def env_var_process(s, unbound=None):
             tail = ""
     return ret
 
+
 environment_variable_process = env_var_process
+
 
 def contains_env_var(s):
     """Check if a string contains an environment variable."""
     match = _RE.match(s)
     return (match and len(match.groupdict()["escape"]) % 2 == 0)
-
-
-if __name__ == "__main__":
-    print(map(environment_variable_process, sys.argv[1:]))

--- a/lib/python/rose/env_cat.py
+++ b/lib/python/rose/env_cat.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+#-----------------------------------------------------------------------------
+# (C) British Crown Copyright 2012-3 Met Office.
+# 
+# This file is part of Rose, a framework for scientific suites.
+# 
+# Rose is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# 
+# Rose is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+# 
+# You should have received a copy of the GNU General Public License
+# along with Rose. If not, see <http://www.gnu.org/licenses/>.
+#-----------------------------------------------------------------------------
+"""Implements "rose env-cat"."""
+
+
+from rose.env import env_var_process, UnboundEnvironmentVariableError
+from rose.opt_parse import RoseOptionParser
+import sys
+
+
+def main():
+    """Implement "rose env-cat"."""
+    opt_parser = RoseOptionParser()
+    opt_parser.add_my_options("unbound")
+    opts, args = opt_parser.parse_args()
+    if not args:
+        args = ["-"]
+    for arg in args:
+        if arg == "-":
+            f = sys.stdin
+        else:
+            f = open(arg)
+        line_num = 0
+        while True:
+            line_num += 1
+            line = f.readline()
+            if not line:
+                break
+            try:
+                sys.stdout.write(env_var_process(line, opts.unbound))
+            except UnboundEnvironmentVariableError as e:
+                name = arg
+                if arg == "-":
+                    name = "<STDIN>"
+                sys.exit("%s:%s: %s" % (name, line_num, str(e)))
+        f.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/lib/python/rose/macros/trigger.py
+++ b/lib/python/rose/macros/trigger.py
@@ -18,13 +18,8 @@
 # along with Rose. If not, see <http://www.gnu.org/licenses/>.
 #-----------------------------------------------------------------------------
 
-import re
-
-import rose.env
 import rose.macro
 import rose.macros.rule
-
-import value
 
 
 class TriggerMacro(rose.macro.MacroBase):

--- a/lib/python/rose/opt_parse.py
+++ b/lib/python/rose/opt_parse.py
@@ -420,6 +420,10 @@ class RoseOptionParser(OptionParser):
                        ["--to-web"],
                        {"action": "store_true", 
                         "help": "Convert ID to the web source URL"}],
+               "unbound": [
+                       ["--unbound", "--undef"],
+                       {"metavar": "STRING",
+                        "help": "Substitute unbound variables with STRING"}],
                "upper": [
                        ["--upper", "-u"],
                        {"action": "store_const",

--- a/lib/python/rosie/ws_client.py
+++ b/lib/python/rosie/ws_client.py
@@ -37,7 +37,6 @@ import sys
 import time
 
 import rose.config
-import rose.env
 from rosie.suite_id import SuiteId, SuiteIdError
 from rose.opt_parse import RoseOptionParser
 from rose.popen import RosePopener

--- a/t/rose-env-cat/00-null.t
+++ b/t/rose-env-cat/00-null.t
@@ -1,0 +1,42 @@
+#!/bin/bash
+#-------------------------------------------------------------------------------
+# (C) British Crown Copyright 2012-3 Met Office.
+# 
+# This file is part of Rose, a framework for scientific suites.
+# 
+# Rose is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# 
+# Rose is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+# 
+# You should have received a copy of the GNU General Public License
+# along with Rose. If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test "rose env-cat" with no file.
+#-------------------------------------------------------------------------------
+. $(dirname $0)/test_header
+#-------------------------------------------------------------------------------
+tests 6
+#-------------------------------------------------------------------------------
+# Pipe from /dev/null
+TEST_KEY=$TEST_KEY_BASE
+setup
+run_pass "$TEST_KEY" rose env-cat </dev/null
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+teardown
+#-------------------------------------------------------------------------------
+# Arg 1 is /dev/null
+TEST_KEY=$TEST_KEY_BASE-arg
+setup
+run_pass "$TEST_KEY" rose env-cat /dev/null
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+teardown
+#-------------------------------------------------------------------------------
+exit

--- a/t/rose-env-cat/01-basic.t
+++ b/t/rose-env-cat/01-basic.t
@@ -1,0 +1,120 @@
+#!/bin/bash
+#-------------------------------------------------------------------------------
+# (C) British Crown Copyright 2012-3 Met Office.
+# 
+# This file is part of Rose, a framework for scientific suites.
+# 
+# Rose is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# 
+# Rose is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+# 
+# You should have received a copy of the GNU General Public License
+# along with Rose. If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test "rose env-cat" with no file.
+#-------------------------------------------------------------------------------
+. $(dirname $0)/test_header
+#-------------------------------------------------------------------------------
+tests 18
+export USER=${USER:-$(whoami)}
+export HOME=${HOME:-$(cd ~$USER && pwd)}
+#-------------------------------------------------------------------------------
+# Read from STDIN.
+TEST_KEY=$TEST_KEY_BASE-stdin
+setup
+run_pass "$TEST_KEY" rose env-cat <<'__STDIN__'
+I am \$USER $USER.
+my \$HOME is at ${HOME}.
+__STDIN__
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<__OUT__
+I am \$USER $USER.
+my \$HOME is at ${HOME}.
+__OUT__
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+teardown
+#-------------------------------------------------------------------------------
+# Read from STDIN as -.
+TEST_KEY=$TEST_KEY_BASE-stdin-2
+setup
+run_pass "$TEST_KEY" rose env-cat - <<'__STDIN__'
+I am \$USER $USER.
+my \$HOME is at ${HOME}.
+__STDIN__
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<__OUT__
+I am \$USER $USER.
+my \$HOME is at ${HOME}.
+__OUT__
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+teardown
+#-------------------------------------------------------------------------------
+# Files
+TEST_KEY=$TEST_KEY_BASE-files
+setup
+cat >file1 <<'__FILE__'
+I am \$USER $USER.
+my \$HOME is at ${HOME}.
+__FILE__
+cat >file2 <<'__FILE__'
+The \$PATH to enlightenment is ${PATH}.
+$PWD is where I am working at the moment. Not sure if I am at $HOME or not.
+__FILE__
+run_pass "$TEST_KEY" rose env-cat file1 file2
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<__OUT__
+I am \$USER $USER.
+my \$HOME is at ${HOME}.
+The \$PATH to enlightenment is ${PATH}.
+$PWD is where I am working at the moment. Not sure if I am at $HOME or not.
+__OUT__
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+teardown
+#-------------------------------------------------------------------------------
+# Unbound
+TEST_KEY=$TEST_KEY_BASE-unbound
+setup
+run_fail "$TEST_KEY" rose env-cat <<'__STDIN__'
+I am OK.
+I am $NOT_OK.
+__STDIN__
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<'__OUT__'
+I am OK.
+__OUT__
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" <<'__ERR__'
+<STDIN>:2: [UNDEFINED ENVIRONMENT VARIABLE] NOT_OK
+__ERR__
+teardown
+#-------------------------------------------------------------------------------
+# Unbound-OK, empty substitution
+TEST_KEY=$TEST_KEY_BASE-unbound-ok
+setup
+run_pass "$TEST_KEY" rose env-cat --unbound= <<'__STDIN__'
+I am OK.
+I am $NOT_OK.
+__STDIN__
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<'__OUT__'
+I am OK.
+I am .
+__OUT__
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+teardown
+#-------------------------------------------------------------------------------
+# Unbound-OK, non-empty substitution.
+TEST_KEY=$TEST_KEY_BASE-unbound-ok-2
+setup
+run_pass "$TEST_KEY" rose env-cat --unbound=undef <<'__STDIN__'
+I am OK.
+I am $NOT_OK.
+__STDIN__
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<'__OUT__'
+I am OK.
+I am undef.
+__OUT__
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+teardown
+#-------------------------------------------------------------------------------
+exit

--- a/t/rose-env-cat/test_header
+++ b/t/rose-env-cat/test_header
@@ -1,0 +1,33 @@
+#!/bin/bash
+#-------------------------------------------------------------------------------
+# (C) British Crown Copyright 2012-3 Met Office.
+# 
+# This file is part of Rose, a framework for scientific suites.
+# 
+# Rose is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# 
+# Rose is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+# 
+# You should have received a copy of the GNU General Public License
+# along with Rose. If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Provides header for "rose config-dump" tests.
+#-------------------------------------------------------------------------------
+. $(dirname $0)/../lib/bash/test_header
+TEST_KEY_BASE=$(basename $0 .t)
+
+function setup() {
+    mkdir $TEST_DIR/run
+    cd $TEST_DIR/run
+}
+
+function teardown() {
+    cd $TEST_DIR
+    rm -rf $TEST_DIR/run
+}

--- a/t/rose-env-cat/tests
+++ b/t/rose-env-cat/tests
@@ -1,0 +1,20 @@
+#!/bin/bash
+#-------------------------------------------------------------------------------
+# (C) British Crown Copyright 2012-3 Met Office.
+# 
+# This file is part of Rose, a framework for scientific suites.
+# 
+# Rose is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# 
+# Rose is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+# 
+# You should have received a copy of the GNU General Public License
+# along with Rose. If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+prove -r $(dirname $0) "$@"


### PR DESCRIPTION
New command to parse the content of text files, substituting `$NAME` and `${NAME}` syntax with the value of the corresponding environment variable.
