### PR TITLE
rose config-edit: fix single radio button

### DIFF
--- a/lib/python/rose/config_editor/valuewidget/radiobuttons.py
+++ b/lib/python/rose/config_editor/valuewidget/radiobuttons.py
@@ -54,6 +54,8 @@ class RadioButtonsValueWidget(gtk.HBox):
             if item == self.value:
                 radio_button.set_active(True)
             radio_button.connect('toggled', self.setter)
+            radio_button.connect('button-press-event', self.setter)
+            radio_button.connect('activate', self.setter)
             self.pack_start(radio_button, False, False, 10)
             radio_button.show()
             radio_button.connect('focus-in-event',
@@ -62,7 +64,7 @@ class RadioButtonsValueWidget(gtk.HBox):
         if len(var_values) == 1 and self.value == var_values[0]:
             radio_button.set_sensitive(False)
 
-    def setter(self, widget):
+    def setter(self, widget, event=None):
         if widget.get_active():
             self.value = widget.get_label()
             self.set_value(self.value)


### PR DESCRIPTION
This fixes the config editor problem where a single radiobutton cannot change a variable value if it is in error - the 'toggled' signal does not get passed from an inconsistent state.

@matthewrmshin, please review.
