### PR TITLE
rose suite-run: wait for `cylc run` to complete.

### DIFF
--- a/doc/rose-rug-in-depth-topics.html
+++ b/doc/rose-rug-in-depth-topics.html
@@ -274,7 +274,6 @@ type = logical
       <pre>
 [rose-suite-run]
 hosts = localhost
-num-ping-try-max = 10
 </pre><br />
       <pre>
 [rose-config-edit]

--- a/etc/rose.conf.example
+++ b/etc/rose.conf.example
@@ -88,9 +88,6 @@
 ## DIR is the root location of a suite's "work" directory (default=$HOME)
 #  root-dir-work=hpc*=$WORKING
 #               =*=$DATADIR
-## Maxium number of times to ping a suite to see if it is running (default=3)
-#  num-ping-try-max=3
-[rose-suite-run]
 
 # Configuration related to "rose task-run".
 #

--- a/lib/html/rose-suite-log-view/index.html
+++ b/lib/html/rose-suite-log-view/index.html
@@ -469,8 +469,7 @@ $(function() {
 | <a href="source.html?path=rose-suite-run.conf">suite-run.conf</a>
 | <a href="source.html?path=rose-suite-run.log">suite-run log</a>
 | cylc:
-  <a href="source.html?path=cylc-run.log">run log</a>
-| <a href="source.html?path=suite/log">suite log</a>
+  <a href="source.html?path=suite/log">suite log</a>
 | <a href="source.html?path=suite/out">suite out</a>
 | <a href="source.html?path=suite/err">suite err</a>
 </p>

--- a/lib/python/rose/run.py
+++ b/lib/python/rose/run.py
@@ -99,18 +99,6 @@ class SuiteLogArchiveEvent(Event):
         return "%s <= %s" % self.args
 
 
-class SuitePingTryMaxEvent(Event):
-
-    """An event raised when the suite ping did not succeed after the maximum
-    number of attempts.
-    """
-
-    TYPE = Event.TYPE_ERR
-
-    def __str__(self):
-        return "Suite ping did not succeed after %d attempts" % self.args[0]
-
-
 class Dummy(object):
 
     """Convert a dict into an object."""
@@ -376,11 +364,8 @@ class SuiteRunner(Runner):
 
     """Invoke a Rose suite."""
 
-    SLEEP_PING = 1.0
     SLEEP_PIPE = 0.05
     NAME = "suite"
-    NUM_LOG_MAX = 5
-    NUM_PING_TRY_MAX = 3
     OPTIONS = ["conf_dir", "defines", "defines_suite", "force_mode",
                "gcontrol_mode", "host", "install_only_mode",
                "log_archive_mode", "log_keep", "log_name", "name", "new_mode",
@@ -639,19 +624,6 @@ class SuiteRunner(Runner):
             self.suite_engine_proc.run(
                     suite_name, host, environ, opts.run_mode, args)
             open("rose-suite-run.host", "w").write(host + "\n")
-
-            # Check that the suite is running
-            keys = ["rose-suite-run", "num-ping-try-max"]
-            num_ping_try_max = conf.get_value(keys, self.NUM_PING_TRY_MAX)
-            num_ping_try_max = int(num_ping_try_max)
-            for num_ping_try in range(1, num_ping_try_max + 1):
-                if self.suite_engine_proc.ping(suite_name, [host]):
-                    break
-                elif num_ping_try < num_ping_try_max:
-                    sleep(self.SLEEP_PING)
-                else:
-                    event = SuitePingTryMaxEvent(num_ping_try_max)
-                    self.event_handler(event)
             self.suite_log_view_gen(suite_name)
 
         # Launch the monitoring tool


### PR DESCRIPTION
cylc/cylc#252 means that we are no longer required to run `cylc run` in
`nohup` and have its standard output and error redirected.
