### PR TITLE
rose suite-log-view: fix job file name matching.

### DIFF
--- a/lib/python/rose/suite_engine_procs/cylc.py
+++ b/lib/python/rose/suite_engine_procs/cylc.py
@@ -67,7 +67,7 @@ class CylcProcessor(SuiteEngineProcessor):
 
     REC_TASK_LOG_FILE_TAIL = re.compile("(\d+\.\d+)(?:\.(.*))?")
 
-    LOG_TASK_TIMESTAMP_THRESHOLD = 2.0
+    LOG_TASK_TIMESTAMP_THRESHOLD = 5.0
 
     def get_task_log_dir_rel(self, suite):
         """Return the relative path to the log directory for suite tasks."""


### PR DESCRIPTION
Increase Δt threshold for matching job file names, because it appears to be
taking longer between a task submit is reported in the Cylc suite log
and Cylc creating the job script.
