### PR TITLE
rose *-run: process file install target names.

### DIFF
--- a/lib/python/rose/config_processors/file.py
+++ b/lib/python/rose/config_processors/file.py
@@ -104,7 +104,10 @@ class ConfigProcessorForFile(ConfigProcessorBase):
         # Ensure that everything is overwritable
         # Ensure that container directories exist
         for key, node in sorted(nodes.items()):
-            name = key[len(self.PREFIX):]
+            try:
+                name = env_var_process(key[len(self.PREFIX):])
+            except UnboundEnvironmentVariableError as e:
+                raise ConfigProcessError([key], key, e)
             if os.path.exists(name) and kwargs.get("no_overwrite_mode"):
                 e = FileOverwriteError(name)
                 raise ConfigProcessError([key], None, e)
@@ -114,7 +117,9 @@ class ConfigProcessorForFile(ConfigProcessorBase):
         sources = {}
         targets = {}
         for key, node in sorted(nodes.items()):
-            name = key[len(self.PREFIX):]
+            # N.B. no need to catch UnboundEnvironmentVariableError here
+            #      because any exception should been caught earlier.
+            name = env_var_process(key[len(self.PREFIX):])
             targets[name] = Loc(name)
             targets[name].action_key = Loc.A_INSTALL
             targets[name].mode = node.get_value(["mode"])

--- a/t/rose-app-run/05-file.t
+++ b/t/rose-app-run/05-file.t
@@ -44,7 +44,7 @@ Hello and good bye.
 __CONTENT__
 OUT=$(cd config/file && cat hello1 hello2 hello3/text)
 #-------------------------------------------------------------------------------
-tests 47
+tests 50
 #-------------------------------------------------------------------------------
 # Normal mode with free format files.
 TEST_KEY=$TEST_KEY_BASE
@@ -196,6 +196,22 @@ run_pass "$TEST_KEY.db" test -f ".rose-config_processors-file.db"
 run_pass "$TEST_KEY.hello1" test -f "$TEST_DIR/test-root/hello1"
 run_pass "$TEST_KEY.hello2" test -f "$TEST_DIR/test-root/hello2"
 run_pass "$TEST_KEY.hello3" test -f "$TEST_DIR/test-root/hello3/text"
+teardown
+#-------------------------------------------------------------------------------
+# Normal mode with environment variable substituion syntax in target name.
+TEST_KEY=$TEST_KEY_BASE-target-env-syntax
+setup
+HELLO=hello \
+HELLO_NUM=4 \
+    run_pass "$TEST_KEY" rose app-run --config=../config -q \
+        --command-key=test-sources \
+        '--define=[file:${HELLO}$HELLO_NUM/text]source=/etc/passwd /etc/profile'
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<__OUT__
+$OUT
+$(</etc/passwd)
+$(</etc/profile)
+__OUT__
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
 teardown
 #-------------------------------------------------------------------------------
 exit


### PR DESCRIPTION
File install target names in section headers can now contain environment
variable syntax.

This fixes metomi/rose#385.
