### PR TITLE
metomi/rose#304: improve value macro

### DIFF
--- a/lib/python/rose/config_editor/loader.py
+++ b/lib/python/rose/config_editor/loader.py
@@ -158,6 +158,8 @@ class ConfigDataManager(object):
         self.tree_update = tree_trig_update
         self.signal_load_event = signal_load_event
         self.config = {}  # Stores configuration name: object
+        self._builtin_value_macro = rose.macros.value.ValueChecker()  # value
+        self.builtin_macros = {}  # Stores other Rose built-in macro instances
         self.trigger = {}  # Stores trigger macro instances per configuration
         self.trigger_id_trees = {}  # Stores trigger dependencies
         self.trigger_id_value_lookup = {}  # Stores old values of trigger vars
@@ -265,6 +267,7 @@ class ConfigDataManager(object):
         self.config[name] = ConfigData(config, s_config, config_directory,
                                        meta_config, meta_id, meta_files,
                                        macros, is_top_level, is_discovery)
+        self.load_builtin_macros(name)
         self.load_file_metadata(name)
         self.filter_meta_config(name)
         
@@ -304,6 +307,14 @@ class ConfigDataManager(object):
         rose.macro.standard_format_config(config)
         rose.macro.standard_format_config(master_config)
         return config, master_config
+
+    def load_builtin_macros(self, config_name):
+        """Load Rose builtin macros."""
+        self.builtin_macros[config_name] = {
+                     rose.META_PROP_COMPULSORY:
+                     rose.macros.compulsory.CompulsoryChecker(),
+                     rose.META_PROP_TYPE:
+                     self._builtin_value_macro}
 
     def load_sections_from_config(self, config_name, save=False):
         """Return maps of section objects from the configuration."""

--- a/lib/python/rose/config_editor/main.py
+++ b/lib/python/rose/config_editor/main.py
@@ -103,11 +103,6 @@ class MainController(object):
         self.redo_stack = [] # Nothing to redo yet
         self.find_hist = {'regex': '', 'ids': []}
         self.util = rose.config_editor.util.Lookup()
-        self.macros = {
-             rose.META_PROP_COMPULSORY:
-             rose.macros.compulsory.CompulsoryChecker,
-             rose.META_PROP_TYPE:
-             rose.macros.value.ValueChecker}
         self.metadata_off = False
 
         self.loader_update = loader_update
@@ -1520,6 +1515,7 @@ class MainController(object):
                 meta_files = self.data.load_meta_files(config, directory)
                 macros = rose.macro.load_meta_macro_modules(meta_files)
             config_data.meta = meta_config
+            self.data.load_builtin_macros(config_name)
             self.data.load_file_metadata(config_name)
             self.data.filter_meta_config(config_name)
             # Load section and variable data into the object.
@@ -1753,7 +1749,7 @@ class MainController(object):
                    
     def perform_error_check(self, namespace=None, is_loading=False):
         """Loop through system macros and sum errors."""
-        for macro_name in self.macros:
+        for macro_name in [rose.META_PROP_COMPULSORY, rose.META_PROP_TYPE]:
             # We may need to speed up trigger for large configs.
             self.perform_macro_validation(macro_name, namespace, is_loading)
 
@@ -1773,7 +1769,7 @@ class MainController(object):
                 config = self.data.dump_to_internal_config(config_name,
                                                            namespace)
             meta = self.data.config[config_name].meta
-            checker = self.macros[macro_type]()
+            checker = self.data.builtin_macros[config_name][macro_type]
             bad_list = checker.validate(config, meta)
             self.apply_macro_validation(config_name, macro_type, bad_list,
                                         namespace, is_loading)


### PR DESCRIPTION
This addresses the <samp>range</samp> issue for derived types (#304). The value macro will now perform proper caching of known good and known bad value-metadata pairings, which should significantly speed up loading/editing a large number of similar configurations.

@arjclark, please review.
