### PR TITLE
rose suite-log-view: fix version link

### DIFF
--- a/lib/html/rose-suite-log-view/index.html
+++ b/lib/html/rose-suite-log-view/index.html
@@ -465,7 +465,7 @@ $(function() {
 <div id="body-header">
 <p>
   rose:
-  <a href="source.html?path=rose-suite.version">suite version</a>
+  <a href="source.html?path=rose-suite-run.version">suite-run version</a>
 | <a href="source.html?path=rose-suite-run.conf">suite-run.conf</a>
 | <a href="source.html?path=rose-suite-run.log">suite-run log</a>
 | cylc:


### PR DESCRIPTION
This fixes the link to the version file in the output viewer.
