### PR TITLE
rose app-run: fix fcm make opt jobs

### DIFF
--- a/lib/python/rose/apps/fcm_make.py
+++ b/lib/python/rose/apps/fcm_make.py
@@ -29,7 +29,7 @@ class FCMMakeApp(BuiltinApp):
 
     """Run "fcm make"."""
 
-    OPT_JOBS = 4
+    OPT_JOBS = "4"
     SCHEME = "fcm_make"
     SCHEME2 = SCHEME + "2"
 


### PR DESCRIPTION
This fixes a bug in the builtin app fcm_make. @arjclark, please review.
