### PR TITLE
rose suite-scan fix

### DIFF
--- a/lib/python/rose/suite_engine_procs/cylc.py
+++ b/lib/python/rose/suite_engine_procs/cylc.py
@@ -360,7 +360,7 @@ class CylcProcessor(SuiteEngineProcessor):
             hosts = ["localhost"]
         host_proc_dict = {}
         for host in sorted(hosts):
-            timeout = "--pyro-timeout={0}".format(self.PYRO_TIMEOUT)
+            timeout = "--pyro-timeout=%s" % self.PYRO_TIMEOUT
             proc = self.popen.run_bg("cylc", "scan", "--host=" + host, timeout)
             host_proc_dict[host] = proc
         ret = []


### PR DESCRIPTION
Adds a pyro timeout to cylc scan calls so that rose suite-scan can exit in event of hung ports.
