### PR TITLE
rose task-run: allow empty site/user configuration.

### DIFF
--- a/lib/python/rose/run.py
+++ b/lib/python/rose/run.py
@@ -1078,20 +1078,22 @@ class TaskRunner(Runner):
         # Prepend PATH-like variable, site/user configuration
         conf = ResourceLocator.default().get_conf()
         my_conf = conf.get(["rose-task-run"], no_ignore=True)
-        for key, node in sorted(my_conf.value.items()):
-            if node.is_ignored() or not key.startswith("path-prepend"):
-                continue
-            env_key = "PATH"
-            if key != "path-prepend":
-                env_key = key[len("path-prepend."):]
-            values = []
-            for v in node.value.split():
-                if os.path.exists(v):
-                    values.append(v)
-            if os.getenv(env_key):
-                values.append(os.getenv(env_key))
-            if values:
-                env_export(env_key, os.pathsep.join(values), self.event_handler)
+        if my_conf is not None:
+            for key, node in sorted(my_conf.value.items()):
+                if node.is_ignored() or not key.startswith("path-prepend"):
+                    continue
+                env_key = "PATH"
+                if key != "path-prepend":
+                    env_key = key[len("path-prepend."):]
+                values = []
+                for v in node.value.split():
+                    if os.path.exists(v):
+                        values.append(v)
+                if os.getenv(env_key):
+                    values.append(os.getenv(env_key))
+                if values:
+                    env_export(env_key, os.pathsep.join(values),
+                               self.event_handler)
 
         # Prepend PATH with paths determined by default or specified globs
         paths = []


### PR DESCRIPTION
This one-liner should stop `rose task-run` from failing if the site and user configurations are both empty.
