### PR TITLE
rose config edit, rosie go - fix splashscreen

### DIFF
--- a/lib/python/rose/gtk/splash.py
+++ b/lib/python/rose/gtk/splash.py
@@ -125,6 +125,8 @@ if __name__ == "__main__":
     update_thread.start()
     try:
         gtk.main()
+    except KeyboardInterrupt:
+        pass
     finally:
         stop_event.set()
         update_thread.join()


### PR DESCRIPTION
This tidies up errors from:
- keyboard interrupt of the splash screen
- the splash screen call to <code>gtk.main_quit()</code>, in the case where <code>gtk.main()</code> has stopped running (happens for large suites in config-edit).
