### PR TITLE
rose documentation: fix api upgrade

### DIFF
--- a/doc/rose-api.html
+++ b/doc/rose-api.html
@@ -715,7 +715,7 @@ class Upgrade272to273(rose.upgrade.MacroUpgrade):
         app config-like patch files, containing settings to be added
         (<samp>rose-macro-add.conf</samp>) and settings to be removed
         (<samp>rose-macro-remove.conf</samp>). If downgrading
-        (<samp>downgrade</samp> set to <samp>False</samp>), the settings in
+        (<samp>downgrade</samp> set to <samp>True</samp>), the settings in
         <samp>rose-macro-remove.conf</samp> will be added, and the ones in
         <samp>rose-macro-add.conf</samp> removed.</p>
         <pre class="prettyprint">


### PR DESCRIPTION
This fixes an incorrect statement in the API documentation - when downgrading, <var>downgrade</var> should be <samp>True</samp>!

@arjclark, please review.
