### PR TITLE
rose documentation: fix image link

### DIFF
--- a/doc/rose-rug-suites.html
+++ b/doc/rose-rug-suites.html
@@ -138,9 +138,9 @@
     <div class="slide">
     <h2 id="background">Background</h2>
 
-    <p class="caption">cylc original name inspiration:</p><img src=
-    "http://dvice.com/pics/Battlestar-Galactica-lifesize-Cylon.jpg" alt=
-    "cylon from Battlestar Galactica" /></div>
+    <p class="caption">Original name inspiration:</p><img src=
+    "http://upload.wikimedia.org/wikipedia/en/1/1e/Cylon_Centurion.png" alt=
+    "Battlestar Galactica Cylon (re-imagined)" /></div>
 
     <div class="slide">
       <h3 class="alwayshidden">Background - NIWA</h3>


### PR DESCRIPTION
This fixes a broken link, and hopefully has a more permanent target.

@arjclark, please review.
