### PR TITLE
rose documentation: fix syntax highlighting for incorrect ignore use

### DIFF
--- a/etc/rose-conf.lang
+++ b/etc/rose-conf.lang
@@ -61,7 +61,7 @@
       <match>^ +[\w-].*$</match>
     </context>
     <context id="ignored-option" style-ref="ignored-option" end-at-line-end="false">
-      <start>^!!?.*$</start>
+      <start>^!!?\S.*$</start>
       <end>^(?=[[\w-#!])</end>
     </context>
     <context id="ignored-section" style-ref="ignored-section" end-at-line-end="false">

--- a/etc/rose-conf.vim
+++ b/etc/rose-conf.vim
@@ -40,7 +40,7 @@ syn sync fromstart
 syn match roselinecomment '^#.*$'
 syn region roseignoredsection start='^\[!!\?[^!].*\]' end='^\ze\[' contains=roselinecomment
 syn match rosesection '^\[[^!].*\]$'
-syn region roseignoredoption start='^!!\?[^!].*$' end='^\ze\S'
+syn region roseignoredoption start='^!!\?\(\w\|-\).*$' end='^\ze\S'
 syn match roserhsvaluecont '^\s\s*\w.*$'
 syn match roserhsvalue '^[^=]*=\zs.*$'
 


### PR DESCRIPTION
Currently,

```
foo=A
!    =B
     =C
```

(note: GH messes with the indent)

in a file edited with a Rose syntax highlighting plugin will have the <samp>!</samp> line highlighted as an ignored option, when in fact it is a syntax error for a value.

This makes sure that ignored options always have a non-whitespace, non-<samp>!</samp> character following the one or two <samp>!</samp> ignore characters.

@arjclark, please review.
