### PR TITLE
rose sgc

### DIFF
--- a/bin/rose-sgc
+++ b/bin/rose-sgc
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+#-------------------------------------------------------------------------------
+# (C) British Crown Copyright 2012-3 Met Office.
+# 
+# This file is part of Rose, a framework for scientific suites.
+# 
+# Rose is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# 
+# Rose is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+# 
+# You should have received a copy of the GNU General Public License
+# along with Rose. If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Alias of "rose suite-gcontrol".
+#-------------------------------------------------------------------------------
+exec $(dirname $0)/rose-suite-gcontrol "$@"

--- a/doc/rose-command.html
+++ b/doc/rose-command.html
@@ -115,6 +115,10 @@
       <dd>Run a suitable suite with a specified set of source tree(s).
       Default</dd>
 
+      <dt><a href="#rose-sgc">rose sgc</a></dt>
+
+      <dd>(=suite-gcontrol)</dd>
+
       <dt><a href="#rose-suite-gcontrol">rose suite-gcontrol</a></dt>
 
       <dd>Launch suite engine's suite control GUI for a suite.</dd>
@@ -1063,6 +1067,10 @@
 
       <dd>Specify a task name or group to run.</dd>
     </dl>
+
+    <h2 id="rose-sgc">rose sgc</h2>
+
+    <p>See <a href="#rose-suite-gcontrol">rose suite-gcontrol</a>.</p>
 
     <h2 id="rose-suite-gcontrol">rose suite-gcontrol</h2>
 


### PR DESCRIPTION
Adds `rose sgc` - a shorthand of `rose suite-gcontrol`
