### PR TITLE
rose suite-log-view: ignore task job status files.

### DIFF
--- a/lib/python/rose/suite_engine_procs/cylc.py
+++ b/lib/python/rose/suite_engine_procs/cylc.py
@@ -274,6 +274,8 @@ class CylcProcessor(SuiteEngineProcessor):
                     key = path[len(root) + 1:]
                     if not key:
                         key = "script"
+                    elif key == "status":
+                        continue
                     submit["files"][key] = {"n_bytes": os.stat(path).st_size}
         return data
 


### PR DESCRIPTION
Closes #464.
