### PR TITLE
metomi/rose#331: tidy use of delimiters

### DIFF
--- a/doc/rose-configuration.html
+++ b/doc/rose-configuration.html
@@ -951,14 +951,14 @@ sort-key = do-not-like-00
         value of other settings with their IDs. E.g.:</p>
         <pre class="prettyprint lang-rose_conf">
 [namelist:test=my_test_var]
-fail-if = this &lt; namelist:test=control_lt_var
+fail-if = this &lt; namelist:test=control_lt_var;
 </pre>
 
         <p>means that an error will be flagged if the numeric value of
         <var>my_test_var</var> is less than the numeric value of
         <var>control_lt_var</var>.</p>
         <pre class="prettyprint lang-rose_conf">
-fail-if = this != 1 + namelist:test=ctrl_var_1 * (namelist:test=ctrl_var_2 - this)
+fail-if = this != 1 + namelist:test=ctrl_var_1 * (namelist:test=ctrl_var_2 - this);
 </pre>
 
         <p>shows a more complex operation, again with numeric values.</p>
@@ -966,34 +966,36 @@ fail-if = this != 1 + namelist:test=ctrl_var_1 * (namelist:test=ctrl_var_2 - thi
         <p>To check array elements, the ID should be expressed with a bracketed
         index, as in the configuration:</p>
         <pre class="prettyprint lang-rose_conf">
-fail-if = this(2) != "'0A'" and this(4) == "'0A'"
+fail-if = this(2) != "'0A'" and this(4) == "'0A'";
 </pre>
 
         <p>Array elements can also be checked using <code>any</code> and
         <code>all</code>. E.g.:</p>
         <pre class="prettyprint lang-rose_conf">
-fail-if = any(namelist:test=ctrl_array &lt; this)
-fail-if = all(this == 0)
+fail-if = any(namelist:test=ctrl_array &lt; this);
+fail-if = all(this == 0);
 </pre>
 
         <p>Expressions can be chained together and brackets used:</p>
         <pre class="prettyprint lang-rose_conf">
-fail-if = this(4) == "'0A'" and (namelist:test=ctrl_var_1 != "'N'" or namelist:test=ctrl_var_2 != "'Y'" or all(namelist:test=ctrl_arr_3 == 'N'))
+fail-if = this(4) == "'0A'" and (namelist:test=ctrl_var_1 != "'N'" or namelist:test=ctrl_var_2 != "'Y'" or all(namelist:test=ctrl_arr_3 == 'N'));
 </pre>
 
         <p>Multiple failure conditions can be added, by using a semicolon as
-        the separator. This is essentially similar to chaining them together
-        with <code>or</code>, but the system can process each expression one by
-        one to target the error message.</p>
+        the separator - the semicolon is optional for a single statement or
+        the last in a block, but is recommended. Multiple failure conditions are essentially
+        similar to chaining them together with <code>or</code>, but the system
+        can process each expression one by one to target the error
+        message.</p>
         <pre class="prettyprint lang-rose_conf">
-fail-if = this &gt; 0; this % 2 == 1; this * 3 &gt; 100
+fail-if = this &gt; 0; this % 2 == 1; this * 3 &gt; 100;
 </pre>
 
         <p>You can add a message to the error or warning message to make it
         clearer by adding a hash followed by the comment at the end of a
         configuration metadata line:</p>
         <pre class="prettyprint lang-rose_conf">
-fail-if = any(namelist:test=ctrl_array % this == 0) # Needs to be common divisor for ctrl_array
+fail-if = any(namelist:test=ctrl_array % this == 0); # Needs to be common divisor for ctrl_array
 </pre>
 
         <p>When using multiple failure conditions, different messages can be
@@ -1007,7 +1009,7 @@ fail-if = this &gt; 0; # Needs to be less than or equal to 0
         <p>A slightly different usage of this functionality can do things like
         warn of deprecated content:</p>
         <pre class="prettyprint lang-rose_conf">
-warn-if = True  # This option is deprecated
+warn-if = True;  # This option is deprecated
 </pre>
 
         <p>This would always evaluate True and give a warning if the setting is
@@ -1074,16 +1076,22 @@ warn-if = True  # This option is deprecated
 
         <p>The trigger expression is a list of settings triggered by (different
         values of) this setting. If the values are not given, the setting will
-        be triggered only if the current setting is enabled. The syntax for
-        giving values is the same as the setting "values" defined above. The
-        trigger syntax looks like:</p>
+        be triggered only if the current setting is enabled.</p>
+        
+        <p>The syntax contains id-values pairs, where the values part is optional.
+        Each pair must be separated by a semi-colon. Within each pair, any values
+        must be separated from the id by a colon and a space (<samp>: </samp>).
+        Values must be formatted in the same way as the setting "values"
+        defined above (i.e. comma separated).</p>
+       
+        <p>The trigger syntax looks like:</p>
         <pre class="prettyprint lang-rose_conf">
 [namelist:trig_nl=trigger_variable]
 trigger = namelist:dep_nl=A;
           namelist:dep_nl=B;
           namelist:value_nl=X: 10;
           env=Y: 20, 30, 40;
-          namelist:value_nl=Z: 20
+          namelist:value_nl=Z: 20;
 </pre>
 
         <p>In this example:</p>
@@ -1125,23 +1133,21 @@ trigger = namelist:dep_nl=A;
           </li>
         </ul>
 
-        <p>Settings mentioned in a in trigger expressions will have their
+        <p>Settings mentioned in trigger expressions will have their
         default state set to ignored unless explicitly triggered. The config
         editor will issue warnings if variables or sections are in the
         incorrect state when it loads a configuration. Triggering thereafter
-        will work as normal. Map expressions are not supported for derived type
-        or array type settings, because of the difficulty of expressing their
-        values.</p>
+        will work as normal.</p>
 
         <p>Where multiple triggers act on a setting, the setting is triggered
         only if all triggers are active (i.e. an <em>AND</em> relationship).
         For example, for the two triggers here:</p>
         <pre class="prettyprint lang-rose_conf">
 [env=IS_WATER]
-trigger = env=IS_ICE: true
+trigger = env=IS_ICE: true;
 
 [env=IS_COLD]
-trigger = env=IS_ICE: true
+trigger = env=IS_ICE: true;
 </pre>
 
         <p>the setting <var>env=IS_ICE</var> is only enabled if both
@@ -1153,7 +1159,7 @@ trigger = env=IS_ICE: true
         <pre class="prettyprint lang-rose_conf">
 [env=SNOWFLAKE_SIDES]
 trigger = env=CUSTOM_SNOWFLAKE_GEOMETRY: this != 6;
-          env=SILLY_SNOWFLAKE_GEOMETRY: this &lt; 2
+          env=SILLY_SNOWFLAKE_GEOMETRY: this &lt; 2;
 </pre>
 
         <p>In this example, the setting

--- a/doc/rose-rug-advanced-tutorials-fail-if.html
+++ b/doc/rose-rug-advanced-tutorials-fail-if.html
@@ -109,7 +109,7 @@
 
       <p>You can reference setting values by using their ids - for example:</p>
       <pre class="prettyprint lang-rose_conf">
-fail-if=namelist:coffee=cup_volume &lt; namelist:coffee=machine_output_volume
+fail-if=namelist:coffee=cup_volume &lt; namelist:coffee=machine_output_volume;
 </pre>
     </div>
 
@@ -120,10 +120,17 @@ fail-if=namelist:coffee=cup_volume &lt; namelist:coffee=machine_output_volume
       (metadata section) id - e.g.:</p>
       <pre class="prettyprint lang-rose_conf">
 [namelist:coffee=daily_amount]
-fail-if=namelist:coffee=daily_min &lt;= this &lt;= namelist:coffee=daily_max
+fail-if=namelist:coffee=daily_min &lt;= this &lt;= namelist:coffee=daily_max;
 </pre>
 
       <p>There is also some array shorthand, which we'll demonstrate later.</p>
+    </div>
+
+    <div class="slide">
+      <h3 class="alwayshidden">Syntax - Delimiters</h3>
+
+      <p>Note that the <samp>;</samp> at the end is optional when we only have
+      one expression (it's a delimiter), but it's better style to keep it.</p>
     </div>
 
     <div class="slide">
@@ -208,7 +215,7 @@ specific_impulse_s=311.0
       <p>Add the following lines to the metadata section
       <samp>[namelist:rocket=total_weight_kg]</samp>:</p>
       <pre class="prettyprint lang-rose_conf">
-fail-if=this &lt; namelist:rocket=fuelless_weight_kg * 2.7183**(env=ORBITAL_SPEED_MS / (9.8 * namelist:rocket=specific_impulse_s))
+fail-if=this &lt; namelist:rocket=fuelless_weight_kg * 2.7183**(env=ORBITAL_SPEED_MS / (9.8 * namelist:rocket=specific_impulse_s));
 </pre>
 
       <p>This states the relationship between these settings (a rearrangement
@@ -252,7 +259,7 @@ fail-if=this &lt; namelist:rocket=fuelless_weight_kg * 2.7183**(env=ORBITAL_SPEE
 
       <p>Change the fail-if line to:</p>
       <pre class="prettyprint lang-rose_conf">
-fail-if=this &lt; namelist:rocket=fuelless_weight_kg * 2.7183**(env=ORBITAL_SPEED_MS / (9.8 * namelist:rocket=specific_impulse_s))  # Fuel mass ratio or specific impulse too low to achieve orbit.
+fail-if=this &lt; namelist:rocket=fuelless_weight_kg * 2.7183**(env=ORBITAL_SPEED_MS / (9.8 * namelist:rocket=specific_impulse_s));  # Fuel mass ratio or specific impulse too low to achieve orbit.
 </pre>
 
       <p>If you reload the metadata and run the check again, the error messages
@@ -287,7 +294,7 @@ fail-if=this &lt; namelist:rocket=fuelless_weight_kg * 2.7183**(env=ORBITAL_SPEE
       editor, and add this line to the
       <samp>[namelist:rocket=battery_levels]</samp> section:</p>
       <pre class="prettyprint lang-rose_conf">
-warn-if=namelist:rocket=battery_levels(1) &lt; 75 or namelist:rocket=battery_levels(2) &lt; 75
+warn-if=namelist:rocket=battery_levels(1) &lt; 75 or namelist:rocket=battery_levels(2) &lt; 75;
 </pre>
 
       <p>This uses a special syntax for referencing the individual array
@@ -304,7 +311,7 @@ warn-if=namelist:rocket=battery_levels(1) &lt; 75 or namelist:rocket=battery_lev
       <p>We already know the shorthand syntax <samp>this</samp>, so rephrase
       the metadata to:</p>
       <pre class="prettyprint lang-rose_conf">
-warn-if=this(1) &lt; 75 or this(2) &lt; 75
+warn-if=this(1) &lt; 75 or this(2) &lt; 75;
 </pre>
     </div>
 
@@ -326,7 +333,7 @@ warn-if=this(1) &lt; 75 or this(2) &lt; 75
 
       <p>We can change the <samp>warn-if</samp> setting to:</p>
       <pre class="prettyprint lang-rose_conf">
-warn-if=any(this &lt; 75)
+warn-if=any(this &lt; 75);
 </pre>
 
       <p>which will flag a warning if any <var>battery_levels</var> array
@@ -342,7 +349,7 @@ warn-if=any(this &lt; 75)
       <var>battery_levels</var> example again, change the setting to:</p>
       <pre class="prettyprint lang-rose_conf">
 warn-if=any(this &lt; 75);
-        all(this &gt; 95)
+        all(this &gt; 95);
 </pre>
 
       <p>This gives a warning if any elements are less than 75, and a separate
@@ -355,8 +362,8 @@ warn-if=any(this &lt; 75);
 
       <p>You can add separate helper messages for each expression:</p>
       <pre class="prettyprint lang-rose_conf">
-warn-if=any(this &lt; 75);  # Battery level low
-        all(this &gt; 95)   # Don't over-charge!
+warn-if=any(this &lt; 75);   # Battery level low
+        all(this &gt; 95);   # Don't over-charge!
 </pre>
 
       <p>Try adding the above lines to the metadata, saving, and playing about

--- a/doc/rose-rug-advanced-tutorials-trigger.html
+++ b/doc/rose-rug-advanced-tutorials-trigger.html
@@ -126,7 +126,7 @@
       <p>Under <samp>[namelist:pizza_order=pizza_type]</samp>, add:</p>
       <pre class="prettyprint lang-rose_conf">
 trigger=namelist:pizza_order=extra_chicken: 'BBQ Chicken';
-        namelist:pizza_order=pepperoni_multiple: 'Pepperoni', 'BBQ Chicken'
+        namelist:pizza_order=pepperoni_multiple: 'Pepperoni', 'BBQ Chicken';
 </pre>
 
       <p>This states which values of <var>pizza_type</var> are relevant for
@@ -144,7 +144,7 @@ trigger=namelist:pizza_order=extra_chicken: 'BBQ Chicken';
       <samp>[env=BUDGET]</samp>:</p>
       <pre class="prettyprint lang-rose_conf">
 trigger=namelist:pizza_order=truffle: this &gt; 25;
-        namelist:side_order: this &gt;= 10
+        namelist:side_order: this &gt;= 10;
 </pre>
 
       <p>What we've done here is used a small subset of the Rose configuration
@@ -286,7 +286,7 @@ trigger=namelist:pizza_order=truffle: .false.
       <pre class="prettyprint lang-rose_conf">
 trigger=namelist:pizza_order=truffle: this &gt; 25;
         namelist:side_order: this &gt;= 10;
-        namelist:pizza_order=pizza_type: this &gt;= 5
+        namelist:pizza_order=pizza_type: this &gt;= 5;
 </pre>
 
       <p>When <var>env=BUDGET</var> is less than 5,
@@ -338,7 +338,7 @@ values='Garlic','Sour Cream','Salsa','Brown Sauce','Mustard'
       <pre class="prettyprint lang-rose_conf">
 trigger=namelist:pizza_order=extra_chicken: 'BBQ Chicken';
         namelist:pizza_order=pepperoni_multiple: 'Pepperoni', 'BBQ Chicken';
-        namelist:pizza_order=dip_type
+        namelist:pizza_order=dip_type;
 </pre>
 
       <p>This means that <var>namelist:pizza_order=dip_type</var> is dependent

--- a/t/rose-macro/11-trigger-change.t
+++ b/t/rose-macro/11-trigger-change.t
@@ -191,7 +191,7 @@ type = logical
 [namelist:triggering_dict=D_trig_E_1_2_F_2_3]
 type = integer
 trigger = namelist:triggering_dict=E: 1, 2;
-          namelist:triggering_dict=F: 2, 3
+          namelist:triggering_dict=F: 2, 3;
 
 [namelist:triggering_dict=E]
 type = logical
@@ -201,8 +201,7 @@ type = logical
 
 [namelist:triggering_cascade=A_trig_B_4_V_3]
 type = integer
-trigger = namelist:triggering_cascade=B_trig_C_1: 4;
-          namelist:triggering_cascade=V_trig_W: 3;
+trigger = namelist:triggering_cascade=B_trig_C_1: 4; namelist:triggering_cascade=V_trig_W: 3;
 
 [namelist:triggering_cascade=B_trig_C_1]
 type = integer
@@ -215,7 +214,7 @@ trigger = namelist:triggering_cascade=D_trig_F_3;
 
 [namelist:triggering_cascade=D_trig_F_3]
 type = integer
-trigger = namelist:triggering_cascade=F: 3
+trigger = namelist:triggering_cascade=F: 3;
 
 [namelist:triggering_cascade=E_trig_G_4]
 type = integer


### PR DESCRIPTION
This addresses #331.

<samp>trigger</samp> expressions do actually require semi-colons in the current formulation, but occasionally it may work with newlines as an accident. The ability to use newline delimited value lists may be useful.

On the other hand, semi-colons are not necessary for <samp>fail-if/warn-if</samp>, if expressions are newline-separated.

I've changed both the <samp>trigger</samp> and the <samp>fail-if/warn-if</samp> expression examples to always have semi-colons. This applies even for single expressions, and the last expression in a group - it's better style.
