### PR TITLE
Update the names of projects in rose-stem

### DIFF
--- a/lib/python/rose/stem.py
+++ b/lib/python/rose/stem.py
@@ -188,19 +188,16 @@ class StemRunner(object):
         rc, output, stderr = self.popen.run('fcm', 'loc-layout', item)
         if rc != 0:
             raise ProjectNotFoundException(item, stderr)
-        result = re.search(r'url:\s*svn://(.*)', output)
+        result = re.search(r'url:\s*(svn://.*)', output)
         
         # Split the URL into forward-slash separated items to generate a 
         # unique name for this project
         if result:
             urlstring = result.group(1)
-            pieces = urlstring.split('/')
-            pieces[1] = re.sub(r'_svn', r'', pieces[1])
-            item = urlstring
-            if len(pieces) < 2 or pieces[1] == pieces[2]:
-                project = pieces[1]
-            else:
-                project = pieces[1] + '_' + pieces[2]
+            rc, kpoutput, stderr = self.popen.run('fcm', 'kp', urlstring)
+            kpresult = re.search(r'location{primary}\[(.*)\]\s*=', kpoutput)
+            if kpresult:
+                project = kpresult.group(1)
         if not project:
             raise ProjectNotFoundException(item)
 
@@ -340,6 +337,7 @@ def main():
         except Exception as e:
             stem.reporter(e)
             sys.exit(1)
+
 
     # Get the suiterunner object and execute
     runner = rose.run.SuiteRunner(event_handler=stem.reporter, 


### PR DESCRIPTION
A minor change to alter the syntax of a few FCM source trees. Rather than doing fairly complicated logic to generate a string from the repository and project names, this version calls 'fcm kp' to look for the FCM unique keyword for the project and uses that.

Major projects such as OPS, VAR, UM won't be affected by this change, and neither will UM_ADMIN, VAR_ADMIN, etc, as the generated names already matched the FCM keywords. As far as I know only GCOM and DrHook will be affected, and I don't think anyone is using those in anger yet.

Tested using my rose-stem prototype with the verbose flag to check what variables are being set, GCOM is now being set with "URL_GCOM" rather than "URL_UM_GCOM". 

@steoxley has also checked this, @matthewrmshin, please can you take a look when you get chance, thanks.
