### PR TITLE
Fix suite hook error reporting

### DIFF
--- a/lib/python/rose/suite_engine_procs/cylc.py
+++ b/lib/python/rose/suite_engine_procs/cylc.py
@@ -26,7 +26,7 @@ import pwd
 import re
 import rose.config
 from rose.popen import RosePopenError
-from rose.reporter import Event
+from rose.reporter import Event, Reporter
 from rose.suite_engine_proc \
         import SuiteEngineProcessor, SuiteScanResult, TaskProps
 import socket


### PR DESCRIPTION
This fixes error handling for <code>rose suite-hook</code>, which currently fails with:

```
NameError: global name 'Reporter' is not defined
```

in lib/python/rose/suite_engine_procs/cylc.py at line 409.

@matthewrmshin, please review.
