### PR TITLE
Fix suite log view exit handling

### DIFF
--- a/lib/python/rose/suite_engine_procs/cylc.py
+++ b/lib/python/rose/suite_engine_procs/cylc.py
@@ -135,7 +135,7 @@ class CylcProcessor(SuiteEngineProcessor):
             status = None
             if event in ["pass", "fail"]:
                 status = event
-                event = "exit"
+                submit["events"]["exit"] = event_time
                 submit["status"] = status
                 if key == "signaled":
                     submit["signal"] = message.rsplit(None, 1)[-1]


### PR DESCRIPTION
This fixes an error in 34701d6. Currently, the suite log viewer will not be able to retrieve the exit time.

@matthewrmshin, please review.
