### PR TITLE
fix for --cycle with a cycle time specified.

### DIFF
--- a/lib/python/rose/suite_engine_proc.py
+++ b/lib/python/rose/suite_engine_proc.py
@@ -337,8 +337,10 @@ class SuiteEngineProcessor(object):
         
         if kwargs["cycle"] is not None:
         
+            #If no unit is specified for the cycle and the length is at least 
+            #10 it is assumed to be in YYYYmmddHH format (length 10)
             if (not CycleOffset.REC_TEXT.match(kwargs["cycle"]).group("unit") 
-                and len(kwargs["cycle"]) == 10):
+                and len(kwargs["cycle"]) >= 10):
                 t.task_cycle_time = kwargs["cycle"]
             else:
                 if t.task_cycle_time:


### PR DESCRIPTION
Fix for:

"
    [ ... ]
       # Force task to always run at 0z:
       environment scripting = "eval $(rose task-env --cycle=$(rose date --print-format="%Y%m%d00" ${CYLC_TASK_CYCLE_TIME}))"

However, this fails with the following error:

  JOB SCRIPT STARTING
  [FAIL] days=-2013030700; must have magnitude <= 999999999
"
