### PR TITLE
rose config-edit: fix save -> No Metadata

### DIFF
--- a/lib/python/rose/config_editor/main.py
+++ b/lib/python/rose/config_editor/main.py
@@ -1303,7 +1303,7 @@ class MainController(object):
             config_names = [only_config_name]
         for config_name in config_names:
             config = self.data.dump_to_internal_config(config_name)
-            new_saved_config = self.data.dump_to_internal_config(config_name)
+            new_save_config = self.data.dump_to_internal_config(config_name)
             config_data = self.data.config[config_name]
             directory = config_data.directory
             config_vars = config_data.vars
@@ -1331,7 +1331,7 @@ class MainController(object):
             # Un-prettify.
             config = self.data.dump_to_internal_config(config_name)
             # Update the last save data.
-            config_data.saved_config = new_saved_config
+            config_data.save_config = new_save_config
             config_vars.save.clear()
             config_vars.latent_save.clear()
             for section, variables in config_vars.now.items():


### PR DESCRIPTION
Currently, making a change, saving it, and turning off metadata will erroneously report an unsaved change in rose edit.

@arjclark, please review.
