### PR TITLE
rose suite-run: fix suite log view error

### DIFF
--- a/lib/python/rose/run.py
+++ b/lib/python/rose/run.py
@@ -850,12 +850,15 @@ class SuiteRunner(Runner):
             self.suite_engine_proc.run(
                     suite_name, host, environ, opts.run_mode, args)
             open("rose-suite-run.host", "w").write(host + "\n")
-            self.suite_log_view_gen(suite_name)
 
         # Launch the monitoring tool
         # Note: maybe use os.ttyname(sys.stdout.fileno())?
         if os.getenv("DISPLAY") and host and opts.gcontrol_mode:
             self.suite_engine_proc.gcontrol(suite_name, host)
+
+        # Create the suite log view
+        self.suite_log_view_gen(suite_name)
+
         return ret
 
     def _run_conf(

--- a/lib/python/rose/suite_engine_procs/cylc.py
+++ b/lib/python/rose/suite_engine_procs/cylc.py
@@ -97,6 +97,14 @@ class CylcProcessor(SuiteEngineProcessor):
             # ... more task IDs
         }
         """
+        for i in range(3): # 3 retries
+            try:
+                return self._get_suite_events(suite_name)
+            except sqlite3.OperationalError:
+                sleep(1.0)
+        return {}
+
+    def _get_suite_events(self, suite_name):
         data = {}
 
         # Read task events from suite runtime database


### PR DESCRIPTION
Launch suite-gcontrol before creating suite log view.

Try querying the cylc suite run time DB up to 3 times (with sleep 1 in
between). Catch database operational error, so it does not fail if the
database is busy.
