### PR TITLE
metomi/rose#508: fix multiple inheritance example explanation

### DIFF
--- a/doc/rose-rug-advanced-tutorials-multi-inherit.html
+++ b/doc/rose-rug-advanced-tutorials-multi-inherit.html
@@ -268,7 +268,7 @@ extended/overwritten by red_car
       <pre class="prettyprint lang-cylc">
     [[red_car]]
         # From COMPETITOR_VEHICLE:
-        command scripting = "race_the_car"
+        command scripting = "race"
 
         [[[environment]]]
             # From ENGINE ELECTRIC:


### PR DESCRIPTION
Fix the explanation command scripting in the multiple inheritance.

@arjclark, please review.
