### PR TITLE
suite-hook locking: introduce retry mechanism to suite-log-view

### DIFF
--- a/lib/python/rose/suite_log_view.py
+++ b/lib/python/rose/suite_log_view.py
@@ -104,7 +104,8 @@ class SuiteLogViewGenerator(object):
                 break
             except OSError:
                 attempts += 1
-                sleep(1)
+                if attempts < self.MAX_ATTEMPTS:
+                    sleep(1)
         if attempts == self.MAX_ATTEMPTS:
             self.handle_event(LockEvent(lock))
             return


### PR DESCRIPTION
This introduces a retry mechanism to suite-log-view so when multiple `rose suite-hook` instances are invoked at the same (or very close to) time you don't get errors as per metomi/rose#535.
