### PR TITLE
optional configurations tutorial: split slide

### DIFF
--- a/doc/rose-rug-advanced-tutorials-opt-conf.html
+++ b/doc/rose-rug-advanced-tutorials-opt-conf.html
@@ -257,7 +257,11 @@ TOPPING=fudge
       <pre class="prettyprint lang-rose_conf">
 opts=chocofudge
 </pre>
-
+    </div>
+    
+    <div class="slide">
+      <h3 class="alwayshidden">Default Optional Configurations (2)</h3>
+     
       <p>We now don't need to specify it at all for <code>rose task-run</code>
       - get rid of the environment variable in the <samp>suite.rc</samp> file,
       so that the <samp>order_icecream</samp> task runtime configuration looks


### PR DESCRIPTION
This splits a slide in two so content doesn't drop off the bottom.
