### PR TITLE
remotes tutorial: fix a heading

### DIFF
--- a/doc/rose-rug-advanced-tutorials-remotes.html
+++ b/doc/rose-rug-advanced-tutorials-remotes.html
@@ -132,7 +132,7 @@
     </div>
 
     <div class="slide">
-      <h3 class="alwayshidden">Description</h3>
+      <h3 class="alwayshidden">Example (3)</h3>
 
       <p>In the suite directory create an <samp>app</samp> directory</p>
 


### PR DESCRIPTION
Fixes a misnamed h3 heading in the remotes tutorial
