### PR TITLE
Tweak to suite-info section of suite configuration documentation

### DIFF
--- a/doc/rose-configuration.html
+++ b/doc/rose-configuration.html
@@ -374,8 +374,8 @@ accel-find-next=F3
       <dt><code>owner</code></dt>
 
       <dd>Specify the user ID of the owner of the suite. The owner has full
-      commit access to the suite. Only the owner can delete the suite or pass
-      the suite's ownership to someone else.</dd>
+      commit access to the suite. Only the owner can delete the suite, pass
+      the suite's ownership to someone else or change the access-list.</dd>
 
       <dt><code>project</code></dt>
 
@@ -390,7 +390,8 @@ accel-find-next=F3
       <dd>Specify a list of users with commit access to trunk of the suite. A
       <kbd>*</kbd> in the list means that anyone can commit to the trunk of the
       suite. Setting this blank or omitting the setting means that nobody apart
-      from the owner can commit to the trunk.</dd>
+      from the owner can commit to the trunk. Only the suite owner can change 
+      the access list.</dd>
 
       <dt><code>description</code></dt>
 


### PR DESCRIPTION
Slight enhancement requested by @dpmatthews to make it clear that only the `owner` is able to make changes to the `access-list` for a suite.
