### PR TITLE
rose documentation: clarify tutorial

### DIFF
--- a/doc/rose-rug-advanced-tutorials-upgrade-dev.html
+++ b/doc/rose-rug-advanced-tutorials-upgrade-dev.html
@@ -93,7 +93,7 @@
       "http://upload.wikimedia.org/wikipedia/commons/b/b9/Proa1.jpg" width=
       "30%" alt="Micronesia proa (sailing multihull)" />
 
-      <p>Create a new directory called <samp>make_boat_app</samp> somewhere -
+      <p>Create a new directory called <samp>make-boat-app</samp> somewhere -
       e.g. in your homespace - containing a <samp>rose-app.conf</samp> file
       with the following content:</p>
       <pre class="prettyprint lang-rose_conf">
@@ -113,6 +113,13 @@ paddling_twigs=1
       already exist), made up of a category (<samp>make-boat</samp>) at a
       particular version (<samp>0.1</samp>). The meta flag is used by Rose to
       locate a configuration metadata directory.</p>
+
+      <p>Make sure you're using <samp>make-boat</samp> and not
+      <samp>make_boat</samp> - the hyphen makes all the difference!</p>
+    </div>
+
+    <div class="slide">
+      <h3 class="alwayshidden">Example App Version Explanation</h3>
 
       <p>It's important to note that the version in the meta flag doesn't have
       to be numeric - it could be <samp>vn0.1</samp> or <samp>alpha</samp> or


### PR DESCRIPTION
Revived change from #553 - clarify the hyphen usage in the upgrade development tutorial.

@matthewrmshin, please review.
