### PR TITLE
rose edit: fix create config

### DIFF
--- a/lib/python/rose/config_editor/loader.py
+++ b/lib/python/rose/config_editor/loader.py
@@ -215,15 +215,17 @@ class ConfigDataManager(object):
 
     def load_config(self, config_directory=None,
                     config_name=None, config=None,
-                    reload_tree_on=False, is_discovery=False):
+                    reload_tree_on=False, is_discovery=False,
+                    skip_load_event=False):
         """Load the configuration and meta-data. Load namespaces."""
         is_top_level = False
         if config_directory is None:
             name = "/" + config_name.lstrip("/")
             config = config
             s_config = copy.deepcopy(config)
-            self.signal_load_event(rose.config_editor.LOAD_CONFIG,
-                                   name.lstrip("/"))
+            if not skip_load_event:
+                self.signal_load_event(rose.config_editor.LOAD_CONFIG,
+                                       name.lstrip("/"))
         else:
             config_directory = config_directory.rstrip("/")
             if config_directory != self.top_level_directory:
@@ -241,8 +243,9 @@ class ConfigDataManager(object):
                 # A suite configuration
                 self.load_info_config(config_directory)
                 name = "/" + self.top_level_name + "-conf"
-            self.signal_load_event(rose.config_editor.LOAD_CONFIG,
-                                   name.lstrip("/"))
+            if not skip_load_event:
+                self.signal_load_event(rose.config_editor.LOAD_CONFIG,
+                                       name.lstrip("/"))
             config_path = os.path.join(config_directory, rose.SUB_CONFIG_NAME)
             if not os.path.isfile(config_path):
                 if (os.path.abspath(config_directory) ==
@@ -280,8 +283,9 @@ class ConfigDataManager(object):
         s_var, s_l_var = self.load_vars_from_config(name)
         self.config[name].vars = VarData(var, l_var, s_var, s_l_var)
         
-        self.signal_load_event(rose.config_editor.LOAD_METADATA,
-                               name.lstrip("/"))
+        if not skip_load_event:
+            self.signal_load_event(rose.config_editor.LOAD_METADATA,
+                                   name.lstrip("/"))
         # Process namespaces and ignored statuses.
         self.load_variable_namespaces(name)
         self.load_variable_namespaces(name, from_saved=True)

--- a/lib/python/rose/config_editor/main.py
+++ b/lib/python/rose/config_editor/main.py
@@ -1399,7 +1399,8 @@ class MainController(object):
             rose.gtk.util.run_dialog(rose.gtk.util.DIALOG_TYPE_ERROR,
                                      text, title)
             return False
-        self.data.load_config(os.path.dirname(new_path), reload_tree_on=True)
+        self.data.load_config(os.path.dirname(new_path), reload_tree_on=True,
+                              skip_load_event=True)
         stack_item = rose.config_editor.stack.StackItem(
                           config_name,
                           rose.config_editor.STACK_ACTION_ADDED,

--- a/lib/python/rose/config_editor/menu.py
+++ b/lib/python/rose/config_editor/menu.py
@@ -437,7 +437,7 @@ class Handler(object):
         name, meta = self.mainwindow.launch_new_config_dialog(root)
         if name is None:
             return False
-        config_name = "/" + self.data.top_level_name + "/" + name
+        config_name = "/" + name
         self._add_config(config_name, meta)
 
     def delete_request(self, namespace_list):

--- a/lib/python/rose/config_editor/window.py
+++ b/lib/python/rose/config_editor/window.py
@@ -305,11 +305,11 @@ class MainWindow(object):
         label = rose.config_editor.DIALOG_LABEL_CONFIG_CHOOSE_NAME
         ok_tip_text = rose.config_editor.TIP_CONFIG_CHOOSE_NAME
         err_tip_text = rose.config_editor.TIP_CONFIG_CHOOSE_NAME_ERROR
-        dialog, container, name_entry = rose.gtk.util._get_naming_dialog(
-                                                           label,
-                                                           checker_function,
-                                                           ok_tip_text,
-                                                           err_tip_text)
+        dialog, container, name_entry = rose.gtk.util.get_naming_dialog(
+                                                          label,
+                                                          checker_function,
+                                                          ok_tip_text,
+                                                          err_tip_text)
         dialog.set_title(rose.config_editor.DIALOG_TITLE_CONFIG_CREATE)
         meta_hbox = gtk.HBox()
         meta_label = gtk.Label(


### PR DESCRIPTION
This fixes the 'Create new configuration' right click menu option in <code>rose edit</code>.

@arjclark, please review.
