### PR TITLE
config-edit: disable right click help launching

### DIFF
--- a/lib/python/rose/config_editor/keywidget.py
+++ b/lib/python/rose/config_editor/keywidget.py
@@ -104,7 +104,7 @@ class KeyWidget(gtk.HBox):
 
     def handle_launch_help(self, widget, event):
         """Handle launching help."""
-        if event.type == gtk.gdk.BUTTON_PRESS and event.button == 1:
+        if event.type == gtk.gdk.BUTTON_PRESS and event.button != 3:
             self.launch_help()
         
     def set_ignored(self):


### PR DESCRIPTION
Fix for #550.

Adds a handler to catch click type and only launch help on left clicking the help link.
