### PR TITLE
rose metadata: fix title and length inheritance

### DIFF
--- a/demo/rose-config-edit/demo_meta/app/01-types/meta/rose-meta.conf
+++ b/demo/rose-config-edit/demo_meta/app/01-types/meta/rose-meta.conf
@@ -147,9 +147,11 @@ length = :
 
 [namelist:nl2]
 duplicate = true
+title = Namelist 2
 
 [namelist:nl2=my_num]
 description = Number, no modifier description, must be 5
+title = My Number
 values = 5
 
 [namelist:nl2{mod1}=my_num]

--- a/demo/rose-config-edit/demo_meta/app/10-duplicate/meta/rose-meta.conf
+++ b/demo/rose-config-edit/demo_meta/app/10-duplicate/meta/rose-meta.conf
@@ -1,0 +1,32 @@
+[namelist:drink]
+title=Drink Choice
+
+[namelist:drink=fizzy]
+title=Fizzy?
+type=logical
+
+[namelist:drink=straws]
+length=:
+title=Straw Colours
+values=red,green,blue,pink,orange
+
+[namelist:icecream]
+description=Mmmm... icecream configuration...
+duplicate=true
+title=Icecream Namelist
+
+[namelist:icecream=sprinkles]
+title=Sprinkles?
+type=logical
+
+[namelist:icecream=toppings]
+length=:
+title=Toppings
+
+[namelist:icecream{strawberry}=toppings]
+description=Toppings for strawberry icecream
+
+[namelist:icecream{strawberry}]
+duplicate=true
+help=Icecream of the strawberry variety.
+title=Strawberry Icecream

--- a/demo/rose-config-edit/demo_meta/app/10-duplicate/rose-app.conf
+++ b/demo/rose-config-edit/demo_meta/app/10-duplicate/rose-app.conf
@@ -1,0 +1,16 @@
+[namelist:drink]
+fizzy=.true.
+straws(1)=red
+straws(2)=blue
+
+[namelist:icecream{chocolate}]
+sprinkles=.false.
+
+[namelist:icecream{strawberry}(1)]
+sprinkles=.false.
+toppings(1)=cream
+toppings(2)=fudge
+
+[namelist:icecream{strawberry}(2)]
+sprinkles=.true.
+toppings=cream,fudge


### PR DESCRIPTION
Currently, the metadata inheritance function (in `macro.py`) does not distinguish between metadata for sections with modifiers (e.g. `namelist:foo{bar}`) and metadata for <i>variables</i> in sections with modifiers (e.g. `namelist:foo{bar}=baz`).

The code should now correctly inherit titles for these variables, and (as a side issue) improve the display of sections with modifiers. If you set a title on a section in the metadata:

```
[namelist:foo]
title=Foo Namelist
```

a section `namelist:foo{bar}` will now appear in `rose edit` as:

Foo Namelist {bar}

i.e. it includes the title.

As a side issue, variables that are themselves elements of an array (e.g. `env=SPAM(1)`) will no longer inherit the array `length` attribute - this should have been done before. They also inherit the title with the index at the end.

The changes can be seen in the config editor by comparing the new app in the current `rose edit` with the new version.

@matthewrmshin, please review.
