### PR TITLE
rose misc: add syntax highlighting documentation for Kate

### DIFF
--- a/doc/rose-rug-getting-started.html
+++ b/doc/rose-rug-getting-started.html
@@ -115,11 +115,13 @@ geditor=gvim -f
     "http://cylc.github.com/cylc/html/single/cug-html.html#x1-530008.2">Cylc
     User Guide</a> for details.</p>
 
-    <p>There is a gedit plugin and a vim plugin for syntax highlighting of Rose
+    <p>There are gedit, kate, and vim plugins for syntax highlighting of Rose
     configuration files, located at:</p>
 
     <ul>
       <li><samp>$ROSE_HOME/etc/rose-conf.lang</samp></li>
+
+      <li><samp>$ROSE_HOME/etc/rose-conf.xml</samp></li>
 
       <li><samp>$ROSE_HOME/etc/rose-conf.vim</samp></li>
     </ul>


### PR DESCRIPTION
This should have been done in #605 - now fixed.

@matthewrmshin, please review.
