### PR TITLE
cylc ping: add timeout

### DIFF
--- a/lib/python/rose/suite_engine_procs/cylc.py
+++ b/lib/python/rose/suite_engine_procs/cylc.py
@@ -357,14 +357,15 @@ class CylcProcessor(SuiteEngineProcessor):
         if callable(self.event_handler):
             return self.event_handler(*args, **kwargs)
 
-    def ping(self, suite_name, hosts=None):
+    def ping(self, suite_name, hosts=None, timeout=10):
         """Return a list of host names where suite_name is running."""
         if not hosts:
             hosts = ["localhost"]
         host_proc_dict = {}
         for host in sorted(hosts):
             proc = self.popen.run_bg(
-                    "cylc", "ping", "--host=" + host, suite_name)
+                    "cylc", "ping", "--host=" + host, suite_name, 
+                    "--pyro-timeout=" + str(timeout))
             host_proc_dict[host] = proc
         ping_ok_hosts = []
         while host_proc_dict:


### PR DESCRIPTION
Adds a timeout to cylc ping to prevent rose sgc and rose suite-run failing in event of a hung port on one of the machines.

This is a hotfix and we should look at removing cylc ping calls in #544
