### PR TITLE
rose.fs_util: makedirs: handle broken symlink.

### DIFF
--- a/lib/python/rose/fs_util.py
+++ b/lib/python/rose/fs_util.py
@@ -105,10 +105,9 @@ class FileSystemUtil(object):
     def makedirs(self, path):
         """Wrap os.makedirs. Does nothing if directory exists."""
 
-        if os.path.isfile(path):
-            self.delete(path)
         # Attempt to handle race conditions
         while not os.path.isdir(path):
+            self.delete(path)
             try:
                 os.makedirs(path)
             except OSError as e:


### PR DESCRIPTION
If path is points to a broken symbolic link, the function currently hangs.
This should fix it.
