### PR TITLE
rose app-run: file installation fixes.

### DIFF
--- a/doc/rose-configuration.html
+++ b/doc/rose-configuration.html
@@ -1314,10 +1314,6 @@ help=Used in conjunction with namelist:Var_DiagnosticsNL=n_linear_adj_test to
 
       <dd>Target is an empty file.</dd>
 
-      <dt><code>mode=mkdir,source=</code></dt>
-
-      <dd>Target is an empty directory.</dd>
-
       <dt><code>mode=auto,source=SOURCE</code></dt>
 
       <dd>Target is a copy of <var>SOURCE</var>.</dd>
@@ -1327,6 +1323,10 @@ help=Used in conjunction with namelist:Var_DiagnosticsNL=n_linear_adj_test to
       <dd>Target is created by concatenating the contents of
       <var>SOURCE-LIST</var>. The sources should either be all files or all
       directories.</dd>
+
+      <dt><code>mode=mkdir</code></dt>
+
+      <dd>Target is a directory.</dd>
 
       <dt><code>mode=symlink,source=SOURCE</code></dt>
 

--- a/lib/python/rose/checksum.py
+++ b/lib/python/rose/checksum.py
@@ -44,8 +44,7 @@ def get_checksum(name):
 
     path_and_checksum_list = []
     if os.path.isfile(name):
-        m = md5()
-        m.update(open(name).read())
+        m = _load(name)
         path_and_checksum_list.append(("", m.hexdigest()))
     else: # if os.path.isdir(path):
         path_and_checksum_list = []
@@ -53,8 +52,20 @@ def get_checksum(name):
             path = dirpath[len(name) + 1:]
             path_and_checksum_list.append((path, None))
             for filename in filenames:
-                m = md5()
-                m.update(open(os.path.join(dirpath, filename)).read())
+                m = _load(os.path.join(dirpath, filename))
                 filepath = os.path.join(path, filename)
                 path_and_checksum_list.append((filepath, m.hexdigest()))
     return path_and_checksum_list
+
+def _load(source):
+    """Load content of source into an md5 object, and return it."""
+    m = md5()
+    s = open(source)
+    f_bsize = os.statvfs(source).f_bsize
+    while True:
+        bytes = s.read(f_bsize)
+        if not bytes:
+            break
+        m.update(bytes)
+    s.close()
+    return m


### PR DESCRIPTION
1. Ensure executable sources results in an executable target.
2. Attempt to read large files (for copy and checksum) no longer results in memory error.
   This is achieved by reading the file in blocks.
3. Don't bother to checksum directory contents if `mode=mkdir`.
