### PR TITLE
Minor rose-stem and rose-ana fixes

### DIFF
--- a/lib/python/rose/apps/rose_ana.py
+++ b/lib/python/rose/apps/rose_ana.py
@@ -286,10 +286,8 @@ class Analyse(object):
             newtask.extract = self.config.get_value([task, "extract"])
             result = re.search(r":", newtask.extract)
             if result:
-                newtask.subextract = re.sub(r".*:\s*", r"",
-                                    newtask.extract)
-                newtask.extract = re.sub(r"\s*:.*", r"",
-                                    newtask.extract)
+                newtask.subextract = ":".join(newtask.extract.split(":")[1:])
+                newtask.extract = newtask.extract.split(":")[0]
             newtask.comparison = self.config.get_value([task, "comparison"])
             newtask.tolerance = self.config.get_value([task, "tolerance"])
             newtask.warnonfail = (

--- a/lib/python/rose/stem.py
+++ b/lib/python/rose/stem.py
@@ -175,11 +175,11 @@ class StemRunner(object):
         rc, output, stderr = self.popen.run('fcm', 'loc-layout', item)
         if rc != 0:
             raise ProjectNotFoundException(item, stderr)
-        result = re.search(r'url:\s*(svn://.*)', output)
+        result = re.search(r'url:\s*(file|svn)(://.*)', output)
         
         # Generate a unique name for this project based on fcm kp
         if result:
-            urlstring = result.group(1)
+            urlstring = result.group(1) + result.group(2)
             rc, kpoutput, stderr = self.popen.run('fcm', 'kp', urlstring)
             kpresult = re.search(r'location{primary}\[(.*)\]\s*=', kpoutput)
             if kpresult:


### PR DESCRIPTION
This fixes two issues which have come up whilst writing the testing documentation:
- rose-stem should allow file:// locations as well as svn://, which is useful when users create their own temporary repositories for the forthcoming rose-stem tutorial.
- rose-ana was parsing the extract method incorrectly - the regular expression was being greedy, causing problems when multiple colons were present in the config file. Fixed by replacing the regular expressions completely with something more robust.

I've tested these by running my tutorial jobs, which work ok, and also by running a task from the UM's rose-stem suite which was modified to pick up these code changes.
