### PR TITLE
rose edit: fix right click expansion of subsequent rows

### DIFF
--- a/lib/python/rose/config_editor/panel.py
+++ b/lib/python/rose/config_editor/panel.py
@@ -628,7 +628,8 @@ class HyperLinkTreePanel(gtk.ScrolledWindow):
             if not all(child_dups):
                 self.tree.expand_row(path, open_all=False)
                 stack.append(treemodel.iter_children(iter_))
-            stack.append(treemodel.iter_next(iter_))
+            if path != start_path:
+                stack.append(treemodel.iter_next(iter_))
 
     def collapse_reset(self):
         """Return the tree view to the basic startup state."""


### PR DESCRIPTION
Currently, a right click expand-all on a top-level page in the config editor page panel will expand subsequent top-level page hierarchies as well - this is not meant to happen.

@matthewrmshin, please review.
