### PR TITLE
rose date -c: trap undef ROSE_TASK_CYCLE_TIME.

### DIFF
--- a/t/rose-date/00-basic.t
+++ b/t/rose-date/00-basic.t
@@ -21,7 +21,7 @@
 #-------------------------------------------------------------------------------
 . $(dirname $0)/test_header
 #-------------------------------------------------------------------------------
-tests 17
+tests 20
 #-------------------------------------------------------------------------------
 # Ensure it can parse its own output.
 TEST_KEY=$TEST_KEY_BASE
@@ -67,5 +67,14 @@ file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<'__OUT__'
 2012122500
 __OUT__
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+#-------------------------------------------------------------------------------
+# Test -c option, ROSE_TASK_CYCLE_TIME not defined.
+TEST_KEY=$TEST_KEY_BASE-c-undef
+unset ROSE_TASK_CYCLE_TIME
+run_fail "$TEST_KEY" rose date -c
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" <<'__ERR__'
+[FAIL] [UNDEFINED ENVIRONMENT VARIABLE] ROSE_TASK_CYCLE_TIME
+__ERR__
 #-------------------------------------------------------------------------------
 exit 0


### PR DESCRIPTION
Fix #637.
