### PR TITLE
rose suite-log-view: use --name=SUITE-NAME

### DIFF
--- a/bin/rose-suite-log-view
+++ b/bin/rose-suite-log-view
@@ -21,17 +21,17 @@
 #     rose suite-log-view
 #
 # SYNOPSIS
-#     rose suite-log-view [OPTIONS] [SUITE [TASK ...]]
+#     rose suite-log-view [OPTIONS] [TASK ...]
 #
 # DESCRIPTION
-#     Generate and browse the log view of SUITE.
+#     Generate and browse the log view of a suite.
 #
 #     If one or more TASK is specified, re-sync their logs if they are
 #     submitted remotely.
 #
 #     Analyse the suite log to generate a JSON file for feeding into an HTML
-#     based viewer. SUITE should be a valid suite name. If not defined, use
-#     `basename $PWD`.
+#     based viewer. If --name=SUITE-NAME is not specified, the basename of $PWD
+#     is assumed to be the suite name.
 #
 #     If the DISPLAY environment variable is defined. Launch the web browser to
 #     display the log view unless --no-web-browse is specified.
@@ -42,6 +42,8 @@
 #     --log-archive-threshold=CYCLE-TIME
 #         Switch on job log archiving by specifying a cycle time threshold. All
 #         job logs at this cycle time or older will be archived. Implies --full.
+#     --name=SUITE-NAME
+#         Specify the suite name.
 #     --no-web-browse
 #         Do not open a web browser to display the log view.
 #-------------------------------------------------------------------------------

--- a/doc/rose-command.html
+++ b/doc/rose-command.html
@@ -1259,15 +1259,15 @@
 
     <h3>SYNOPSIS</h3>
 
-    <p><kbd>rose suite-log-view [OPTIONS] [SUITE]</kbd></p>
+    <p><kbd>rose suite-log-view [OPTIONS] [TASK ...]</kbd></p>
 
     <h3>DESCRIPTION</h3>
 
-    <p>Generate and browse the log view of <var>SUITE</var>.</p>
+    <p>Generate and browse the log view of a suite.</p>
 
     <p>Analyse the suite log to generate a JSON file for feeding into an HTML
-    based viewer. <var>SUITE</var> should be a valid suite name. If not
-    defined, use <var>basename $PWD</var>.</p>
+    based viewer. If <kbd>--name=SUITE-NAME</kbd> is not specified, the 
+    basename of <var>$PWD</var> is assumed to be the suite name.</p>
 
     <p>If the <var>DISPLAY</var> environment variable is defined. Launch the
     web browser to display the log view unless <kbd>--no-web-browse</kbd> is
@@ -1286,6 +1286,10 @@
       <dd>Switch on job log archiving by specifying a cycle time threshold. All
       job logs at this cycle time or older will be archived. Implies
       <kbd>--full</kbd>.</dd>
+
+      <dt><kbd>--name=SUITE-NAME</kbd></dt>
+      
+      <dd>Specify the suite name.</dd>
 
       <dt><kbd>--no-web-browse</kbd></dt>
 

--- a/lib/python/rose/suite_log_view.py
+++ b/lib/python/rose/suite_log_view.py
@@ -252,7 +252,7 @@ class SuiteLogViewGenerator(object):
 def main():
     opt_parser = RoseOptionParser()
     opt_parser.add_my_options("full_mode", "log_archive_threshold",
-                              "web_browser_mode")
+                              "name", "web_browser_mode")
     opts, args = opt_parser.parse_args()
     report = Reporter(opts.verbosity - opts.quietness)
 
@@ -268,8 +268,8 @@ def main():
 
 def suite_log_view(opts, args, report=None):
     gen = SuiteLogViewGenerator(event_handler=report)
-    if args:
-        suite_name = args.pop(0)
+    if opts.name:
+        suite_name = opts.name
     else:
         suite_name = os.path.basename(os.getcwd())
         try:
@@ -278,7 +278,7 @@ def suite_log_view(opts, args, report=None):
             report(e)
             sys.exit(1)
     if not opts.full_mode and args:
-        gen.update_job_log(suite_name, tasks=args)
+        gen.update_job_log(suite_name, task_ids=args)
     gen(suite_name, opts.full_mode, opts.log_archive_threshold)
     if opts.web_browser_mode:
         return gen.view_suite_log_url(suite_name)


### PR DESCRIPTION
Change for #577.

`rose suite-log-view` now uses `--name=SUITE-NAME` to specify an alternate suite name, in line with the other command line utilities, rather than passing it as an argument.

Also fixes a misnamed key for specifying tasks to update which was broken.
