### PR TITLE
rose suite-shutdown: fix order of args to cylc shutdown

### DIFF
--- a/lib/python/rose/suite_engine_procs/cylc.py
+++ b/lib/python/rose/suite_engine_procs/cylc.py
@@ -536,12 +536,11 @@ class CylcProcessor(SuiteEngineProcessor):
     def shutdown(self, suite_name, host=None, engine_version=None, args=None,
                  stderr=None, stdout=None):
         """Shut down the suite."""
-        command = ["cylc", "shutdown", "--force"]
+        command = ["cylc", "shutdown", suite_name, "--force"]
         if host:
             command += ["--host=%s" % host]
         if args:
             command += args
-        command += [suite_name]
         environ = dict(os.environ)
         if engine_version:
             environ.update({self.get_version_env_name(): engine_version})


### PR DESCRIPTION
Currently `rose suite-shutdown -- TAG` gets passed to cylc as `cylc shutdown TAG SUITENAME` which fails since TAG is not a suite, meaning you cannot shut down a suite at a specific cycle time/tag/task.

This reorders the passing of args to `cylc shutdown` so it is now `cylc shutdown SUITENAME TAG`.
