### PR TITLE
rosie go: fix null copy crash reporting

### DIFF
--- a/lib/python/rosie/browser/__init__.py
+++ b/lib/python/rosie/browser/__init__.py
@@ -188,9 +188,9 @@ LABEL_ERROR_DISCOVERY = "Ignore errors in suite info?"
 LABEL_HISTORY_TREEVIEW = "Search History"
 TITLE_NEW_SUITE_WIZARD = "Edit new suite information"
 TITLE_ERROR_DISCOVERY = "Errors found"
-TITLE_SUITE_COPY_ERROR = "Suite copy problem"
 TITLE_HISTORY_IO_ERROR = "History read/write error"
 TITLE_HISTORY_NAVIGATION_ERROR = "History navigation error"
+TITLE_ERROR = "Error"
 TITLE_INVALID_QUERY = "Error"
 
 # Miscellaneous

--- a/lib/python/rosie/browser/main.py
+++ b/lib/python/rosie/browser/main.py
@@ -240,14 +240,10 @@ class MainWindow(gtk.Window):
         try:
             new_id = self.suite_director.vc_client.create(config, from_id,
                                          self.search_manager.ws_client.prefix)
-        except rosie.vc.SuiteCopyNullError as e:
-            new_id = e.new_id
-            rose.gtk.util.run_dialog(rose.gtk.util.DIALOG_TYPE_INFO,
-                                     str(e),
-                                     title=rosie.browser.TITLE_SUITE_COPY_ERROR)
         except Exception as e:
             rose.gtk.util.run_dialog(rose.gtk.util.DIALOG_TYPE_ERROR,
-                                     type(e).__name__ + ": " + str(e))
+                                     type(e).__name__ + ": " + str(e),
+                                     title=rosie.browser.TITLE_ERROR)
             return None
 
         # Poll for new entry in db.


### PR DESCRIPTION
This is a clunky fix for the "copy a suite with no contents" problem, which previously crashed out in a non-nice way. @matthewrmshin, please review.
