### PR TITLE
rose edit: fix ignored status calculation

### DIFF
--- a/lib/python/rose/config_editor/data_helper.py
+++ b/lib/python/rose/config_editor/data_helper.py
@@ -412,6 +412,8 @@ class ConfigDataHelper(object):
             object_statuses = variable_statuses
         status_counts = object_statuses.items()
         status_counts.sort(lambda x, y: cmp(x[1], y[1]))
+        if not status_counts:
+            return rose.config.ConfigNode.STATE_NORMAL
         status = status_counts[0][0]
         if status == rose.variable.IGNORED_BY_USER:
             return rose.config.ConfigNode.STATE_USER_IGNORED


### PR DESCRIPTION
This fixes the edge case for ignored status calculation where a variable-defined namespace is pointed to but doesn't contain anything.

@matthewrmshin, please review.
