### PR TITLE
rose suite-hook: update for cylc/cylc#477

### DIFF
--- a/lib/python/rose/suite_engine_procs/cylc.py
+++ b/lib/python/rose/suite_engine_procs/cylc.py
@@ -46,6 +46,9 @@ class CylcProcessor(SuiteEngineProcessor):
 
     EVENTS = {"submission succeeded": "submit",
               "submission failed": "submit-fail",
+              "started": "init",
+              "succeeded": "pass",
+              "failed": "fail",
               "execution started": "init",
               "execution succeeded": "pass",
               "execution failed": "fail",


### PR DESCRIPTION
Support latest event names.

Should be backward compatible.
