### PR TITLE
#686: fix rosie go load crash

### DIFF
--- a/lib/python/rosie/ws_client.py
+++ b/lib/python/rosie/ws_client.py
@@ -318,7 +318,11 @@ def get_local_suite_details(prefix=None, id_list=None, skip_status=False):
             q.extend(["or ( idx eq " + id_.idx,
                       "and branch eq " + id_.branch + " )"])
     ws_client = RosieWSClient(prefix=prefix)
-    result_maps, url = ws_client.query(q)
+    if q:
+        result_maps, url = ws_client.query(q)
+    else:
+        result_maps = []
+        url = None
     result_idx_branches = [(r[u"idx"], r[u"branch"]) for r in result_maps]
     q = []
     for id_ in prefix_id_list:


### PR DESCRIPTION
This closes #686. Test by removing all local copies of suites for the initial prefix and running `rosie go` - it should crash unless this fix is applied.

@arjclark, please review.
