### PR TITLE
rose edit: force status widget update (gtk)

### DIFF
--- a/lib/python/rose/config_editor/status.py
+++ b/lib/python/rose/config_editor/status.py
@@ -103,12 +103,16 @@ class StatusBar(gtk.VBox):
             self.messages.pop(0)
         self._update_message_widget(str(message), kind=kind)
         self._update_console()
+        while gtk.gdk.events_pending():
+            gtk.main_iteration()
 
     def set_num_errors(self, new_num_errors):
         """Update the number of errors."""
         if new_num_errors != self.num_errors:
             self.num_errors = new_num_errors
             self._update_error_widget()
+            while gtk.gdk.events_pending():
+                gtk.main_iteration()
 
     def _generate_error_widget(self):
         # Generate the error display widget.


### PR DESCRIPTION
This should make the status bar in `rose edit` update graphically even if there is later queued computation.

@arjclark, please review.
