### PR TITLE
#721: fix markup bug for clickable labels

### DIFF
--- a/demo/rose-config-edit/demo_meta/app/02-help/meta/rose-meta.conf
+++ b/demo/rose-config-edit/demo_meta/app/02-help/meta/rose-meta.conf
@@ -7,6 +7,7 @@ url = http://fcm1/projects/rose/wiki/Proposal/MetadataConfiguration#env
 title = Title for my_env2
 description = This is the description
  It can be spread over several lines. Click env=my_env3 to navigate.
+ You could also click on http://www.google.co.uk
  
  Blank lines are ignored :-(
 
@@ -32,6 +33,8 @@ url = http://fcm1/projects/rose/wiki/Proposal/MetadataConfiguration#my_env2
 title = Title for my_env3
 description = This variable has "url" defined but no "help".
  This means that if you left click on the variable it should open a web page.
+help=You can put help links in the text, even at the end
+    =like this: http://www.google.co.uk
 url = http://fcm1/projects/rose/wiki/Proposal/MetadataConfiguration#my_env3
 
 [ns=file]

--- a/lib/python/rose/gtk/util.py
+++ b/lib/python/rose/gtk/util.py
@@ -43,10 +43,10 @@ import rose.resource
 
 DIALOG_BUTTON_CLOSE = "Close"
 DIALOG_LABEL_README = "README"
-REC_DIALOG_HYPERLINK_ID_OR_URL = re.compile(r"""(?P<start_break>\b)
-                                            (?P<url>[\w:-]+=\w+|https?://\S+)
-                                            (?P<end_break>\b)""",
-                                            re.X)
+REC_DIALOG_HYPERLINK_ID_OR_URL = re.compile(
+                     r"""(?P<start_break>\b)
+                         (?P<url>[\w:-]+=\w+|https?://[^\s<]+)
+                         (?P<end_break>\b)""", re.X)
 DIALOG_MARKUP_URL_HTML = (r"""\g<start_break>""" +
                           r"""<a href='\g<url>'>\g<url></a>""" + 
                           r"""\g<end_break>""")


### PR DESCRIPTION
This closes #721.

@matthewrmshin, please review.

Testing instructions:

Open the `demo/rose-config-edit/demo_meta/app/02-help` app, navigate to the `Env section title` page and deselect the menu option `Metadata -> Layout Preferences -> Hide Variable Help`. This code won't give a warning and fail to construct the label, but the head of master will.
