### PR TITLE
tutorials: command-keys: Fix a typo.

### DIFF
--- a/doc/rose-rug-advanced-tutorials-command-key.html
+++ b/doc/rose-rug-advanced-tutorials-command-key.html
@@ -186,7 +186,7 @@ timed_bread=sleep 15; echo 'fresh bread when you want it'
       the <samp>[[breadmaker]]</samp> task to look like this:</p>
       <pre class="prettyprint lang-cylc">
     [[breadmaker]]
-        command scripting="rose task-run --command-key='dough'"
+        command scripting="rose task-run --command-key='make_dough'"
 </pre>
     </div>
 


### PR DESCRIPTION
Missing word added in to fix command-keys tutorial.
