### PR TITLE
rose edit: fix capture middle click paste

### DIFF
--- a/lib/python/rose/config_editor/page.py
+++ b/lib/python/rose/config_editor/page.py
@@ -145,8 +145,13 @@ class ConfigPage(gtk.VBox):
         self.scroll_vadj = self.scrolled_main_window.get_vadjustment()
         self.scrolled_main_window.connect(
                      "button-press-event",
-                     lambda b, e: e.button == 3 and 
-                                  self.launch_add_menu(e.button, e.time))
+                     self._handle_click_main_window)
+
+    def _handle_click_main_window(self, widget, event):
+        if event.button != 3:
+            return False
+        self.launch_add_menu(event.button, event.time)
+        return False
 
     def get_label_widget(self, is_detached=False):
         """Return a container of widgets for the notebook tab label."""

--- a/lib/python/rose/config_editor/valuewidget/array.py
+++ b/lib/python/rose/config_editor/valuewidget/array.py
@@ -252,11 +252,7 @@ class EntryArrayValueWidget(gtk.HBox):
         entry.set_text(value_item)
         entry.connect('focus-in-event',
                       self._handle_focus_on_entry)
-        entry.connect_after("paste-clipboard", self.setter)
-        entry.connect_after('key-release-event',
-                            lambda e, v: self.setter(e))
-        entry.connect_after('button-release-event',
-                            lambda e, v: self.setter(e))
+        entry.connect_after('changed', self.setter)
         entry.connect('focus-out-event',
                       self._handle_focus_off_entry)
         entry.set_width_chars(self.chars_width - 1)

--- a/lib/python/rose/config_editor/valuewidget/character.py
+++ b/lib/python/rose/config_editor/valuewidget/character.py
@@ -60,9 +60,7 @@ class QuotedTextValueWidget(gtk.HBox):
                              insensitive_colour)
         self.in_error = not self.type_checker(self.value)
         self.set_entry_text()
-        self.entry.connect_after("key-release-event", self.setter)
-        self.entry.connect_after("button-release-event", self.setter)
-        self.entry.connect_after("paste-clipboard", self.setter)
+        self.entry.connect_after("changed", self.setter)
         self.entry.show()
         self.pack_start(self.entry, expand=True, fill=True,
                         padding=0)

--- a/lib/python/rose/config_editor/valuewidget/meta.py
+++ b/lib/python/rose/config_editor/valuewidget/meta.py
@@ -37,9 +37,7 @@ class MetaValueWidget(gtk.HBox):
         self.normal_colour = self.entry.style.text[gtk.STATE_NORMAL]
         self.insens_colour = self.entry.style.text[gtk.STATE_INSENSITIVE]
         self.entry.set_text(self.value)
-        self.entry.connect_after("paste-clipboard", self._check_diff)
-        self.entry.connect_after("key-release-event", self._check_diff)
-        self.entry.connect_after("button-release-event", self._check_diff)
+        self.entry.connect_after("changed", self._check_diff)
         self.entry.connect("activate", self._setter)
         self.entry.connect("focus-out-event", self._setter)
         self.entry.show()

--- a/lib/python/rose/config_editor/valuewidget/text.py
+++ b/lib/python/rose/config_editor/valuewidget/text.py
@@ -40,7 +40,6 @@ class RawValueWidget(gtk.HBox):
         self.metadata = metadata
         self.set_value = set_value
         self.hook = hook
-
         self.entry = gtk.Entry()
         insensitive_colour = gtk.Style().bg[0]
         self.entry.modify_bg(gtk.STATE_INSENSITIVE,
@@ -52,9 +51,7 @@ class RawValueWidget(gtk.HBox):
             self.entry.set_tooltip_text(
                        rose.config_editor.VAR_WIDGET_ENV_INFO)
         self.entry.set_text(self.value)
-        self.entry.connect_after("paste-clipboard", self.setter)
-        self.entry.connect_after("key-release-event", self.setter)
-        self.entry.connect_after("button-release-event", self.setter)
+        self.entry.connect_after("changed", self.setter)
         self.entry.show()
         self.pack_start(self.entry, expand=True, fill=True,
                                     padding=0)


### PR DESCRIPTION
This fixes a failure to capture a middle click paste event in the `gtk.Entry` widgets in rose edit.

@matthewrmshin, please review.

The change can be tested by opening an app that looks like this:

```
[env]
A=foo
```

selecting some text from a browser, terminal, or text editor, and middle click pasting it into the value widget for <samp>env=A</samp>. In the old code, no modification was noticed.
