### PR TITLE
Remove references to readlink

### DIFF
--- a/bin/rose
+++ b/bin/rose
@@ -79,7 +79,7 @@ function help_util() {
 }
 
 function print_version() {
-    echo "Rose $ROSE_VERSION ($(readlink -f $ROSE_HOME))"
+    echo "Rose $ROSE_VERSION ($ROSE_HOME)"
 }
 
 #-------------------------------------------------------------------------------

--- a/lib/bash/rose_init
+++ b/lib/bash/rose_init
@@ -34,7 +34,6 @@ function rose_init() {
     set -eu
     ROSE_NS=$(basename $0)
     ROSE_HOME_BIN=$(cd $(dirname $0) && pwd)
-    ROSE_HOME_BIN=$(readlink -f $ROSE_HOME_BIN)
     ROSE_HOME=$(dirname $ROSE_HOME_BIN)
     eval $(grep 'ROSE_VERSION' $ROSE_HOME/doc/rose-version.js)
     local DESC=


### PR DESCRIPTION
The readlink function depends on GNU coreutils, which isn't available on
all systems (e.g. BSDs). Remove references to readlink so that Rose will
run on those systems.

Readlink is currently used in Rose's shell wrappers to remove symbolic
links from paths.
