### PR TITLE
rosie go, lookup, ls: do not display invalid-named working copies

### DIFF
--- a/lib/python/rosie/ws_client.py
+++ b/lib/python/rosie/ws_client.py
@@ -282,7 +282,8 @@ def get_local_suites(prefix=None, skip_status=False):
         except SuiteIdError as e:
             continue
         if prefix is None or id_.prefix == prefix:
-            local_copies.append(id_)
+            if str(id_) == path:
+                local_copies.append(id_)
     return local_copies
 
 


### PR DESCRIPTION
Closes #738
