### PR TITLE
rose edit: fix latent file page

### DIFF
--- a/demo/rose-config-edit/demo_meta/app/11-latent/meta/rose-meta.conf
+++ b/demo/rose-config-edit/demo_meta/app/11-latent/meta/rose-meta.conf
@@ -1,6 +1,9 @@
 [env=B]
 ns=env/B_page
 
+[file:knights_who_say_nl]
+title=Knights who say 'nl!'
+
 [namelist:bar]
 
 [namelist:bar=spam]

--- a/lib/python/rose/config_editor/data.py
+++ b/lib/python/rose/config_editor/data.py
@@ -995,6 +995,14 @@ class ConfigDataManager(object):
                 continue
             if not sect_node.is_ignored() and section.startswith("file:"):
                 file_sections.append(section)
+        for meta_id, sect_node in meta_config.value.items():
+            section, option = self.util.get_section_option_from_id(
+                                                                meta_id)
+            if option is None:
+                if not isinstance(sect_node.value, dict):
+                    continue
+                if not sect_node.is_ignored() and section.startswith("file:"):
+                    file_sections.append(section)
         file_ids = []
         for setting_id, sect_node in meta_config.value.items():
             # The following 'wildcard-esque' id is an exception.


### PR DESCRIPTION
This fixes viewing a latent file page in rose edit.

@matthewrmshin, please review.
