### PR TITLE
rose edit: fix optional configuration names with hyphens

### DIFF
--- a/lib/python/rose/__init__.py
+++ b/lib/python/rose/__init__.py
@@ -38,8 +38,9 @@ INFO_CONFIG_NAME = "rose-suite.info"
 TOP_CONFIG_NAME = "rose-suite.conf"
 META_DEFAULT_VN_DIR = "HEAD"
 
+# Optional configurations - not applicable to rose.conf optional configs.
 GLOB_OPT_CONFIG_FILE = "rose-*-*.conf"
-RE_OPT_CONFIG_FILE = "rose-.*-(.+).conf$"
+RE_OPT_CONFIG_FILE = "rose-.*?-(.+).conf$"
 
 
 # Configuration specification names

--- a/lib/python/rose/config_editor/data.py
+++ b/lib/python/rose/config_editor/data.py
@@ -391,7 +391,12 @@ class ConfigDataManager(object):
         opt_glob = os.path.join(opt_dir, rose.GLOB_OPT_CONFIG_FILE)
         for path in glob.glob(opt_glob):
             if os.access(path, os.F_OK | os.R_OK):
-                name = re.search(rose.RE_OPT_CONFIG_FILE, path).group(1)
+                filename = os.path.basename(path)
+                # filename is a null string if path is to a directory.
+                result = re.match(rose.RE_OPT_CONFIG_FILE, filename)
+                if not result:
+                    continue                    
+                name = result.group(1)
                 try:
                     opt_config = rose.config.load(path)
                 except Exception as e:


### PR DESCRIPTION
This fixes optional configurations that contain hyphens in the names - current behaviour is to truncate the name after a hyphen.

The demo/rose-config-edit/demo_meta/app/09-opt app can be used to test this.

@arjclark, please review (after this next release).
