### PR TITLE
Print task return codes with 'return code' rather than 'rc'.

### DIFF
--- a/lib/python/rose/popen.py
+++ b/lib/python/rose/popen.py
@@ -45,7 +45,7 @@ class RosePopenError(Exception):
         tail = ""
         if self.stderr:
             tail = ", stderr=\n%s" % self.stderr
-        return "%s # rc=%d%s" % (cmd_str, self.rc, tail)
+        return "%s # return code=%d%s" % (cmd_str, self.rc, tail)
 
 
 class RosePopenEvent(Event):

--- a/sbin/rosa-svn-post-commit
+++ b/sbin/rosa-svn-post-commit
@@ -108,7 +108,7 @@ def svnlook(*args):
     (out, err) = p.communicate()
     rc = p.wait()
     if rc:
-        sys.exit("[FAIL] %s # rc=%d" % (" ".join(["svnlook"] + list(args)), rc))
+        sys.exit("[FAIL] %s # return code=%d" % (" ".join(["svnlook"] + list(args)), rc))
     return out
 
 

--- a/sbin/rosa-svn-pre-commit
+++ b/sbin/rosa-svn-pre-commit
@@ -73,7 +73,7 @@ def svnlook(*args):
     (out, err) = p.communicate()
     rc = p.wait()
     if rc:
-        sys.exit("[FAIL] %s # rc=%d" % (" ".join(["svnlook"] + list(args)), rc))
+        sys.exit("[FAIL] %s # return code=%d" % (" ".join(["svnlook"] + list(args)), rc))
     return out
 
 


### PR DESCRIPTION
Just a small change hopefully... With one of the errors we get on Hector - a SIGILL is sent but nothing is written to stderr in python. Changing the 'rc' to 'return code' in the output I think makes things more obvious.
