### PR TITLE
rose.popen: print `return-code` instead of rc

### DIFF
--- a/lib/python/rose/popen.py
+++ b/lib/python/rose/popen.py
@@ -45,7 +45,7 @@ class RosePopenError(Exception):
         tail = ""
         if self.stderr:
             tail = ", stderr=\n%s" % self.stderr
-        return "%s # rc=%d%s" % (cmd_str, self.rc, tail)
+        return "%s # return-code=%d%s" % (cmd_str, self.rc, tail)
 
 
 class RosePopenEvent(Event):

--- a/t/rose-app-run/02-command.t
+++ b/t/rose-app-run/02-command.t
@@ -51,7 +51,7 @@ setup
 run_fail "$TEST_KEY" rose app-run -C ../config -q -c false
 file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" <<'__CONTENT__'
-[FAIL] false # rc=1
+[FAIL] false # return-code=1
 __CONTENT__
 teardown
 #-------------------------------------------------------------------------------

--- a/t/rose-app-run/03-env.t
+++ b/t/rose-app-run/03-env.t
@@ -112,7 +112,7 @@ setup
 run_fail "$TEST_KEY" rose app-run --config=../config -q -D '[!env]'
 file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" <<'__CONTENT__'
-[FAIL] printenv FOO BAR BAZ # rc=1
+[FAIL] printenv FOO BAR BAZ # return-code=1
 __CONTENT__
 teardown
 #-------------------------------------------------------------------------------
@@ -125,7 +125,7 @@ $FOO
 $BAZ
 __CONTENT__
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" <<'__CONTENT__'
-[FAIL] printenv FOO BAR BAZ # rc=1
+[FAIL] printenv FOO BAR BAZ # return-code=1
 __CONTENT__
 teardown
 #-------------------------------------------------------------------------------

--- a/t/rose-app-run/07-opt.t
+++ b/t/rose-app-run/07-opt.t
@@ -88,7 +88,7 @@ foo
 baz
 __CONTENT__
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" <<'__CONTENT__'
-[FAIL] printenv FOO BAR BAZ # rc=1
+[FAIL] printenv FOO BAR BAZ # return-code=1
 __CONTENT__
 teardown
 #-------------------------------------------------------------------------------
@@ -98,7 +98,7 @@ setup
 run_fail "$TEST_KEY" rose app-run --config=../config --opt-conf-key=$OPT_3 -q
 file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" <<'__CONTENT__'
-[FAIL] printenv FOO BAR BAZ # rc=1
+[FAIL] printenv FOO BAR BAZ # return-code=1
 __CONTENT__
 teardown
 #-------------------------------------------------------------------------------
@@ -112,7 +112,7 @@ foolish fool
 baz
 __CONTENT__
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" <<'__CONTENT__'
-[FAIL] printenv FOO BAR BAZ # rc=1
+[FAIL] printenv FOO BAR BAZ # return-code=1
 __CONTENT__
 teardown
 #-------------------------------------------------------------------------------
@@ -126,7 +126,7 @@ foolish fool
 baz
 __CONTENT__
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" <<'__CONTENT__'
-[FAIL] printenv FOO BAR BAZ # rc=1
+[FAIL] printenv FOO BAR BAZ # return-code=1
 __CONTENT__
 teardown
 #-------------------------------------------------------------------------------
@@ -140,7 +140,7 @@ foolish fool
 baz
 __CONTENT__
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" <<'__CONTENT__'
-[FAIL] printenv FOO BAR BAZ # rc=1
+[FAIL] printenv FOO BAR BAZ # return-code=1
 __CONTENT__
 teardown
 #-------------------------------------------------------------------------------
@@ -172,7 +172,7 @@ foolish fool
 baz
 __CONTENT__
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" <<'__CONTENT__'
-[FAIL] printenv FOO BAR BAZ # rc=1
+[FAIL] printenv FOO BAR BAZ # return-code=1
 __CONTENT__
 rm -r ../config2
 teardown


### PR DESCRIPTION
Supersede metomi/rose#778, but use hyphen instead of space between
`return` and `code`. This should make it easier to parse.

Modify `rose test-battery` for the change.
