### PR TITLE
rose documentation: add summary slide to end of rug:suite files and rosie

### DIFF
--- a/doc/rose-rug-files.html
+++ b/doc/rose-rug-files.html
@@ -518,7 +518,7 @@ rosie lookup -Q owner eq bob and title contains test
         <li>Running a suite - see also <a href="rose-quick-ref.html">
         Quick Reference</a></li>
         <li>Suite version control</li>
-        <li>rosie go and command line equivalents</li>
+        <li><code>rosie go</code> and command line equivalents</li>
       </ul>
     </div>
 


### PR DESCRIPTION
As discussed, this adds a summary/conclusion slide to the rug: suite files and rosie presentation as it otherwise ends abruptly.

@matthewrmshin - please review.
