### PR TITLE
rose documentation: remove rogue fullstop from cylc slides

### DIFF
--- a/doc/rose-rug-suites.html
+++ b/doc/rose-rug-suites.html
@@ -1155,7 +1155,7 @@ type=boolean
 
       <ul class="incremental">
         <li><kbd>fcm_make</kbd> - built-in application to run <code>fcm
-        make</code>.</li>
+        make</code></li>
 
         <li><kbd>rose_ana</kbd> - an engine to compare program outputs</li>
 


### PR DESCRIPTION
Removes a rogue full-stop from the end of a bullet point.

@benfitzpatrick - please review.
