### PR TITLE
doc: use terms like `logs`, `STDOUT`, `STDERR`

### DIFF
--- a/doc/rose-rug-suites.html
+++ b/doc/rose-rug-suites.html
@@ -1030,18 +1030,18 @@ type=boolean
       <p><samp>log/</samp>, <samp>log.*/</samp> sub-directories:</p>
 
       <ul class="incremental">
-        <li>Used to suite logs, including <var>STDOUT</var> and
-        <var>STDERR</var> outputs.</li>
-
-        <li>Rose stores an <samp>index.html</samp> page (the suite log viewer)
-        under this directory.</li>
+        <li>The <samp>suite</samp> subdirectory contains the suite logs,
+        including <var>STDOUT</var> and <var>STDERR</var> outputs.</li>
 
         <li>The <samp>job/</samp> subdirectory contains the job scripts for
         submitting the tasks, their <var>STDOUT</var> and
         <var>STDERR</var> outputs.</li>
 
-        <li>The <samp>rose-suite.version</samp> file, which records any version
-        control information about the suite, including any local
+        <li>Rose adds the library files for the suite log viewer under this
+        directory.</li>
+
+        <li>Rose adds the <samp>rose-suite.version</samp> file, which records
+        any version control information about the suite, including any local
         modifications.</li>
       </ul>
     </div>


### PR DESCRIPTION
The general term `output` may be confusing, because it can mean other
items generated by a program. Where possible, use specific terminology
for log files.
