### PR TITLE
rose mpi-launch: don't call inner by default.

### DIFF
--- a/bin/rose-mpi-launch
+++ b/bin/rose-mpi-launch
@@ -77,10 +77,6 @@
 # ENVIRONMENT VARIABLES
 #     optional ROSE_LAUNCHER
 #         Specify the launcher program.
-#     optional ROSE_LAUNCH_INNER
-#         Only relevant when launching with a command. Specify an inner wrapper
-#         to be run by launcher, can be set to a null string to call the
-#         executable directly. Default is "$0 --inner".
 #     optional ROSE_LAUNCHER_LIST
 #         Override "launcher-list" setting in configuration.
 #     optional ROSE_LAUNCHER_FILEOPTS
@@ -93,10 +89,11 @@
 #         Override "launcher-postopts.LAUNCHER" setting for the selected
 #         LAUNCHER.
 #     optional ROSE_LAUNCHER_ULIMIT_OPTS
-#         Only relevant if $ROSE_LAUNCH_INNER is used. Specify the arguments to
-#         ulimit. Setting this variable to "-a -s unlimited -d unlimited -a"
+#         Only relevant when launching with a command. Tell launcher to run
+#         "rose mpi-launch --inner $@". Specify the arguments to ulimit.
+#         E.g. Setting this variable to "-a -s unlimited -d unlimited -a"
 #         results in "ulimit -a; ulimit -s unlimited; ulimit -d unlimited;
-#         ulimit -a"
+#         ulimit -a".
 #     optional NPROC
 #         Specify the number of processors to run on. Default is 1.
 #
@@ -230,7 +227,8 @@ if [[ -n $ROSE_COMMAND_FILE ]]; then
     eval "exec $ROSE_LAUNCHER $ROSE_LAUNCHER_FILEOPTS $@"
 else
     if [[ -n $ROSE_LAUNCHER_BASE ]]; then
-        if ! printenv ROSE_LAUNCH_INNER 1>/dev/null; then
+        ROSE_LAUNCH_INNER=
+        if [[ -n ${ROSE_LAUNCHER_ULIMIT_OPTS:-} ]]; then
              ROSE_LAUNCH_INNER="${0}$(optv) --inner"
         fi
         # Options

--- a/doc/rose-command.html
+++ b/doc/rose-command.html
@@ -1059,12 +1059,6 @@ launcher-preopts.mpiexec=-n $NPROC
 
       <dd>Specify the launcher program.</dd>
 
-      <dt><kbd>optional ROSE_LAUNCH_INNER</kbd></dt>
-
-      <dd>Only relevant when launching with a command. Specify an inner wrapper
-      to be run by launcher, can be set to a null string to call the executable
-      directly. Default is <kbd>$0 --inner</kbd>.</dd>
-
       <dt><kbd>optional ROSE_LAUNCHER_LIST</kbd></dt>
 
       <dd>Override <var>launcher-list</var> setting in configuration.</dd>
@@ -1086,10 +1080,11 @@ launcher-preopts.mpiexec=-n $NPROC
 
       <dt><kbd>optional ROSE_LAUNCHER_ULIMIT_OPTS</kbd></dt>
 
-      <dd>Only relevant if <var>$ROSE_LAUNCH_INNER</var> is used. Specify the
-      arguments to <kbd>ulimit</kbd>. Setting this variable to <kbd>-a -s
-      unlimited -d unlimited -a</kbd> results in <kbd>ulimit -a; ulimit -s
-      unlimited; ulimit -d unlimited; ulimit -a</kbd></dd>
+      <dd>Only relevant when launching with a command. Tell launcher to run
+      <kbd>rose mpi-launch --inner $@</kbd>. Specify the arguments to
+      <kbd>ulimit</kbd>. Setting this variable to <kbd>-a -s unlimited -d
+      unlimited -a</kbd> results in <kbd>ulimit -a; ulimit -s unlimited; ulimit
+      -d unlimited; ulimit -a</kbd>.</dd>
 
       <dt><kbd>optional NPROC</kbd></dt>
 

--- a/doc/rose-variables.html
+++ b/doc/rose-variables.html
@@ -190,19 +190,6 @@
       <li>rose</li>
     </ul>
 
-    <h2 id="ROSE_LAUNCH_INNER"><var>ROSE_LAUNCH_INNER</var></h2>
-
-    <h3>Description</h3>
-
-    <p>Specifies an inner wrapper to be run by launcher, can be set to "" to
-    call the executable directly. Default is <kbd>$0 --inner</kbd>.</p>
-
-    <h3>Used By</h3>
-
-    <ul>
-      <li><a href="rose-command.html#rose-mpi-launch">rose mpi-launch</a></li>
-    </ul>
-
     <h2 id="ROSE_LAUNCHER"><var>ROSE_LAUNCHER</var></h2>
 
     <h3>Description</h3>
@@ -272,9 +259,10 @@
 
     <h3>Description</h3>
 
-    <p>Specifies the arguments to ulimit. Setting this variable to <kbd>-a -s
+    <p>Tell launcher to run <kbd>rose mpi-launch --inner $@</kbd>. Specify the
+    arguments to <kbd>ulimit</kbd>. E.g. Setting this variable to <kbd>-a -s
     unlimited -d unlimited -a</kbd> results in <kbd>ulimit -a; ulimit -s
-    unlimited; ulimit -d unlimited; ulimit -a</kbd></p>
+    unlimited; ulimit -d unlimited; ulimit -a</kbd>.</p>
 
     <h3>Used By</h3>
 

--- a/t/rose-mpi-launch/00-command.t
+++ b/t/rose-mpi-launch/00-command.t
@@ -21,7 +21,7 @@
 #-------------------------------------------------------------------------------
 . $(dirname $0)/test_header
 #-------------------------------------------------------------------------------
-tests 21
+tests 18
 #-------------------------------------------------------------------------------
 # No argument.
 TEST_KEY=$TEST_KEY_BASE-null
@@ -38,7 +38,7 @@ TEST_KEY=$TEST_KEY_BASE
 run_pass "$TEST_KEY" rose mpi-launch true to your heart
 TRUE=$(which true)
 file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<__OUT__
-[my-launcher] -n 1 $ROSE_HOME/bin/rose-mpi-launch --inner $TRUE to your heart
+[my-launcher] -n 1 $TRUE to your heart
 __OUT__
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
 #-------------------------------------------------------------------------------
@@ -49,17 +49,7 @@ NPROC=$NPROC \
     run_pass "$TEST_KEY" rose mpi-launch true to your heart
 TRUE=$(which true)
 file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<__OUT__
-[my-launcher] -n $NPROC $ROSE_HOME/bin/rose-mpi-launch --inner $TRUE to your heart
-__OUT__
-file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
-#-------------------------------------------------------------------------------
-# Basic, no inner
-TEST_KEY=$TEST_KEY_BASE-no-inner
-ROSE_LAUNCH_INNER= \
-    run_pass "$TEST_KEY" rose mpi-launch true to your heart
-TRUE=$(which true)
-file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<__OUT__
-[my-launcher] -n 1 $TRUE to your heart
+[my-launcher] -n $NPROC $TRUE to your heart
 __OUT__
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
 #-------------------------------------------------------------------------------
@@ -69,7 +59,7 @@ ROSE_TEST_RC=1 \
     run_fail "$TEST_KEY" rose mpi-launch true to your heart
 TRUE=$(which true)
 file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<__OUT__
-[my-launcher] -n 1 $ROSE_HOME/bin/rose-mpi-launch --inner $TRUE to your heart
+[my-launcher] -n 1 $TRUE to your heart
 __OUT__
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
 #-------------------------------------------------------------------------------
@@ -79,7 +69,7 @@ ROSE_LAUNCHER=our-launcher \
     run_pass "$TEST_KEY" rose mpi-launch true to your heart
 TRUE=$(which true)
 file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<__OUT__
-[our-launcher] $ROSE_HOME/bin/rose-mpi-launch --inner $TRUE -n 1 to your heart
+[our-launcher] $TRUE -n 1 to your heart
 __OUT__
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
 #-------------------------------------------------------------------------------
@@ -89,7 +79,7 @@ PATH=$TEST_SOURCE_DIR/bin2:$PATH \
     run_pass "$TEST_KEY" rose mpi-launch true to your heart
 TRUE=$(which true)
 file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<__OUT__
-[test-launcher] $ROSE_HOME/bin/rose-mpi-launch --inner $TRUE to your heart
+[test-launcher] $TRUE to your heart
 __OUT__
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
 #-------------------------------------------------------------------------------

--- a/t/rose-mpi-launch/01-command-inner.t
+++ b/t/rose-mpi-launch/01-command-inner.t
@@ -25,9 +25,10 @@ tests 6
 #-------------------------------------------------------------------------------
 # Basic.
 TEST_KEY=$TEST_KEY_BASE
-run_pass "$TEST_KEY" rose mpi-launch --inner echo hello world
-file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<'__OUT__'
-hello world
+ROSE_LAUNCHER_ULIMIT_OPTS='-a' \
+    run_pass "$TEST_KEY" rose mpi-launch echo hello world
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<__OUT__
+[my-launcher] -n 1 $ROSE_HOME/bin/rose-mpi-launch --inner $(which echo) hello world
 __OUT__
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
The inner wrapper may cause problems at some sites. It should not be
called as a default. The program will now make an `--inner` call only if
`ROSE_LAUNCH_ULIMIT_OPTS` is defined.

Resolve #796.
