### PR TITLE
rose documentation: Fix a missing "-c" in clock-triggered tutorial.

### DIFF
--- a/doc/rose-rug-advanced-tutorials-clock-triggered.html
+++ b/doc/rose-rug-advanced-tutorials-clock-triggered.html
@@ -139,7 +139,7 @@
             failed handler = "rose suite-hook --mail"
     [[bell]]
         environment scripting = "eval $(rose task-env)"
-        command scripting = "yes 'bong' | head -n $(rose date --format=%H)"
+        command scripting = "yes 'bong' | head -n $(rose date -c --format=%H)"
 </pre>
     </div>
 


### PR DESCRIPTION
Puts a missing `-c` in for the clock-triggered tutorial suite.
