### PR TITLE
rose suite-clean: fix lingering DB connection

### DIFF
--- a/lib/python/rose/fs_util.py
+++ b/lib/python/rose/fs_util.py
@@ -76,10 +76,14 @@ class FileSystemUtil(object):
         """Delete a file or a directory."""
 
         if os.path.islink(path) or os.path.isfile(path):
-            ret = os.unlink(path)
+            os.unlink(path)
             self.handle_event(FileSystemEvent(FileSystemEvent.DELETE, path))
         elif os.path.isdir(path):
-            ret = shutil.rmtree(path, ignore_errors=True)
+            # Ignore errors, so that broken symlinks are ignored
+            shutil.rmtree(path, ignore_errors=True)
+            # Try again w/o ignore_errors, if required
+            if os.path.isdir(path):
+                shutil.rmtree(path)
             event = FileSystemEvent(FileSystemEvent.DELETE, path + "/")
             self.handle_event(event)
 

--- a/t/rose-rug-brief-tour/00-normal.t
+++ b/t/rose-rug-brief-tour/00-normal.t
@@ -40,7 +40,6 @@ run_pass "$TEST_KEY" rose suite-run --name=$NAME --no-gcontrol -S SLEEP=\":\"
 # Wait for the suite to complete
 TEST_KEY=$TEST_KEY_BASE-suite-run-wait
 TIMEOUT=$(($(date +%s) + 300)) # wait 5 minutes
-OK=false
 while [[ -e $HOME/.cylc/ports/$NAME ]] && (($(date +%s) < TIMEOUT)); do
     sleep 1
 done
@@ -48,7 +47,6 @@ if [[ -e $HOME/.cylc/ports/$NAME ]]; then
     fail "$TEST_KEY"
     exit 1
 else
-    OK=true
     pass "$TEST_KEY"
 fi
 #-------------------------------------------------------------------------------
@@ -82,7 +80,5 @@ sys.exit(d["cycle_time"] != cycle or len(d["tasks"]) != len(tasks) or
 __PYTHON__
 done
 #-------------------------------------------------------------------------------
-if $OK; then
-    rm -r $SUITE_RUN_DIR
-fi
+rose suite-clean -q -y $NAME
 exit 0

--- a/t/rose-suite-clean/01-running.t
+++ b/t/rose-suite-clean/01-running.t
@@ -22,7 +22,7 @@
 . $(dirname $0)/test_header
 
 #-------------------------------------------------------------------------------
-tests 3
+tests 5
 #-------------------------------------------------------------------------------
 export ROSE_CONF_PATH=
 TEST_KEY=$TEST_KEY_BASE
@@ -39,7 +39,9 @@ run_fail "$TEST_KEY" rose suite-clean -y $NAME
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" <<__ERR__
 [FAIL] $NAME: cannot clean, still running on localhost
 __ERR__
-ls -ld $HOME/cylc-run/$NAME 1>/dev/null
+if [[ ! -d $HOME/cylc-run/$NAME ]]; then
+    exit 1
+fi
 #-------------------------------------------------------------------------------
 touch $SUITE_RUN_DIR/flag # let the suite stop
 # Wait for the suite to complete
@@ -52,6 +54,9 @@ if [[ -e $HOME/.cylc/ports/$NAME ]]; then
 fi
 TEST_KEY=$TEST_KEY_BASE-stopped
 run_pass "$TEST_KEY" rose suite-clean -y $NAME
-! ls -ld $HOME/cylc-run/$NAME 2>/dev/null
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<__OUT__
+[INFO] delete: $SUITE_RUN_DIR/
+__OUT__
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
 #-------------------------------------------------------------------------------
 exit 0

--- a/t/rose-suite-hook/00-shutdown.t
+++ b/t/rose-suite-hook/00-shutdown.t
@@ -23,7 +23,7 @@
 export ROSE_CONF_PATH=
 
 #-------------------------------------------------------------------------------
-tests 3
+tests 2
 #-------------------------------------------------------------------------------
 # Run the suite.
 TEST_KEY=$TEST_KEY_BASE
@@ -36,7 +36,6 @@ run_pass "$TEST_KEY" \
 # Wait for the suite to complete, test shutdown on fail
 TEST_KEY=$TEST_KEY_BASE-suite-hook-shutdown
 TIMEOUT=$(($(date +%s) + 300)) # wait 5 minutes
-OK=false
 while [[ -e $HOME/.cylc/ports/$NAME ]] && (($(date +%s) < TIMEOUT)); do
     sleep 1
 done
@@ -44,10 +43,8 @@ if [[ -e $HOME/.cylc/ports/$NAME ]]; then
     fail "$TEST_KEY"
     exit 1
 else
-    OK=true
     pass "$TEST_KEY"
 fi
 #-------------------------------------------------------------------------------
-run_pass "$TEST_KEY_BASE-clean" rose suite-clean -y $NAME
-rmdir $SUITE_RUN_DIR 2>/dev/null || true
+rose suite-clean -q -y $NAME
 exit 0

--- a/t/rose-suite-hook/01-job-host.t
+++ b/t/rose-suite-hook/01-job-host.t
@@ -24,11 +24,11 @@
 . $(dirname $0)/test_header
 
 #-------------------------------------------------------------------------------
-tests 6
+tests 5
 KEY=${TEST_KEY_BASE#0?-}
 HOST=$(rose config 't' $KEY)
 if [[ -z $HOST ]]; then
-    skip 6 "[t]$KEY not defined"
+    skip 5 "[t]$KEY not defined"
     exit 0
 fi
 HOST=$(rose host-select $HOST)
@@ -46,7 +46,6 @@ run_pass "$TEST_KEY" \
 # Wait for the suite to complete
 TEST_KEY=$TEST_KEY_BASE-suite-run-ok
 TIMEOUT=$(($(date +%s) + 300)) # wait 5 minutes
-OK=false
 while [[ -e $HOME/.cylc/ports/$NAME ]] && (($(date +%s) < TIMEOUT)); do
     sleep 1
 done
@@ -54,7 +53,6 @@ if [[ -e $HOME/.cylc/ports/$NAME ]]; then
     fail "$TEST_KEY"
     exit 1
 else
-    OK=true
     pass "$TEST_KEY"
 fi
 #-------------------------------------------------------------------------------
@@ -69,6 +67,5 @@ __CONTENT__
 cd $OLDPWD
 
 #-------------------------------------------------------------------------------
-run_pass "$TEST_KEY_BASE-clean" rose suite-clean -y $NAME
-rmdir $SUITE_RUN_DIR 2>/dev/null || true
+rose suite-clean -q -y $NAME
 exit 0

--- a/t/rose-suite-log/00-update-task.t
+++ b/t/rose-suite-log/00-update-task.t
@@ -22,12 +22,12 @@
 . $(dirname $0)/test_header
 
 #-------------------------------------------------------------------------------
-tests 10
+tests 9
 #-------------------------------------------------------------------------------
 if [[ $TEST_KEY_BASE == *-remote* ]]; then
     JOB_HOST=$(rose config 't' 'job-host')
     if [[ -z $JOB_HOST ]]; then
-        skip 10 '[t]job-host not defined'
+        skip 9 '[t]job-host not defined'
         exit 0
     fi
     JOB_HOST=$(rose host-select $JOB_HOST)
@@ -52,7 +52,6 @@ fi
 # Wait for the suite to complete, test shutdown on fail
 TEST_KEY="$TEST_KEY_BASE-complete"
 TIMEOUT=$(($(date +%s) + 300)) # wait 5 minutes
-OK=false
 while [[ -e $HOME/.cylc/ports/$NAME ]] && (($(date +%s) < TIMEOUT)); do
     sleep 1
 done
@@ -60,7 +59,6 @@ if [[ -e $HOME/.cylc/ports/$NAME ]]; then
     fail "$TEST_KEY"
     exit 1
 else
-    OK=true
     pass "$TEST_KEY"
 fi
 #-------------------------------------------------------------------------------
@@ -93,6 +91,5 @@ sys.exit(task_name not in d["tasks"])
 __PYTHON__
 file_test "$TEST_KEY-log.out" $SUITE_RUN_DIR/log/job/my_task_2.1.1.out
 #-------------------------------------------------------------------------------
-run_pass "$TEST_KEY_BASE-clean" rose suite-clean -y --debug $NAME
-rmdir $SUITE_RUN_DIR 2>/dev/null || true
+rose suite-clean -q -y $NAME
 exit 0

--- a/t/rose-suite-log/01-update-cycle.t
+++ b/t/rose-suite-log/01-update-cycle.t
@@ -23,12 +23,12 @@
 . $(dirname $0)/test_header
 
 #-------------------------------------------------------------------------------
-tests 30
+tests 29
 #-------------------------------------------------------------------------------
 if [[ $TEST_KEY_BASE == *-remote* ]]; then
     JOB_HOST=$(rose config 't' 'job-host')
     if [[ -z $JOB_HOST ]]; then
-        skip 30 '[t]job-host not defined'
+        skip 29 '[t]job-host not defined'
         exit 0
     fi
     JOB_HOST=$(rose host-select $JOB_HOST)
@@ -53,7 +53,6 @@ fi
 # Wait for the suite to complete, test shutdown on fail
 TEST_KEY="$TEST_KEY_BASE-complete"
 TIMEOUT=$(($(date +%s) + 300)) # wait 5 minutes
-OK=false
 while [[ -e $HOME/.cylc/ports/$NAME ]] && (($(date +%s) < TIMEOUT)); do
     sleep 1
 done
@@ -61,7 +60,6 @@ if [[ -e $HOME/.cylc/ports/$NAME ]]; then
     fail "$TEST_KEY"
     exit 1
 else
-    OK=true
     pass "$TEST_KEY"
 fi
 #-------------------------------------------------------------------------------
@@ -165,6 +163,5 @@ __PYTHON__
         $SUITE_RUN_DIR/log/job/my_task_2.$CYCLE.1.out
 done
 #-------------------------------------------------------------------------------
-run_pass "$TEST_KEY_BASE-clean" rose suite-clean -y $NAME
-rmdir $SUITE_RUN_DIR 2>/dev/null || true
+rose suite-clean -q -y $NAME
 exit 0

--- a/t/rose-suite-log/02-update-force.t
+++ b/t/rose-suite-log/02-update-force.t
@@ -22,12 +22,12 @@
 . $(dirname $0)/test_header
 
 #-------------------------------------------------------------------------------
-tests 22
+tests 21
 #-------------------------------------------------------------------------------
 if [[ $TEST_KEY_BASE == *-remote* ]]; then
     JOB_HOST=$(rose config 't' 'job-host')
     if [[ -z $JOB_HOST ]]; then
-        skip 22 '[t]job-host not defined'
+        skip 21 '[t]job-host not defined'
         exit 0
     fi
     JOB_HOST=$(rose host-select $JOB_HOST)
@@ -52,7 +52,6 @@ fi
 # Wait for the suite to complete, test shutdown on fail
 TEST_KEY="$TEST_KEY_BASE-complete"
 TIMEOUT=$(($(date +%s) + 300)) # wait 5 minutes
-OK=false
 while [[ -e $HOME/.cylc/ports/$NAME ]] && (($(date +%s) < TIMEOUT)); do
     sleep 1
 done
@@ -60,7 +59,6 @@ if [[ -e $HOME/.cylc/ports/$NAME ]]; then
     fail "$TEST_KEY"
     exit 1
 else
-    OK=true
     pass "$TEST_KEY"
 fi
 #-------------------------------------------------------------------------------
@@ -104,6 +102,5 @@ d = json.load(open(file_name))
 sys.exit(len(d["cycle_times_current"]) != 3)
 __PYTHON__
 #-------------------------------------------------------------------------------
-run_pass "$TEST_KEY_BASE-clean" rose suite-clean -y $NAME
-rmdir $SUITE_RUN_DIR 2>/dev/null || true
+rose suite-clean -q -y $NAME
 exit 0

--- a/t/rose-suite-run/00-run-basic.t
+++ b/t/rose-suite-run/00-run-basic.t
@@ -22,7 +22,7 @@
 . $(dirname $0)/test_header
 
 #-------------------------------------------------------------------------------
-N_TESTS=12
+N_TESTS=11
 tests $N_TESTS
 #-------------------------------------------------------------------------------
 # Run the suite.
@@ -60,7 +60,6 @@ run_pass "$TEST_KEY" rose suite-run --reload \
 TEST_KEY=$TEST_KEY_BASE-suite-run-wait
 touch $SUITE_RUN_DIR/flag # allow the task to die
 TIMEOUT=$(($(date +%s) + 300)) # wait 5 minutes
-OK=false
 while [[ -e $HOME/.cylc/ports/$NAME ]] && (($(date +%s) < TIMEOUT)); do
     sleep 1
 done
@@ -68,11 +67,8 @@ if [[ -e $HOME/.cylc/ports/$NAME ]]; then
     fail "$TEST_KEY"
     exit 1
 else
-    OK=true
     pass "$TEST_KEY"
 fi
 #-------------------------------------------------------------------------------
-TEST_KEY=$TEST_KEY_BASE-clean
-run_pass "$TEST_KEY" rose suite-clean -y $NAME
-rmdir $SUITE_RUN_DIR 2>/dev/null || true
+rose suite-clean -q -y $NAME
 exit 0

--- a/t/rose-suite-run/02-install.t
+++ b/t/rose-suite-run/02-install.t
@@ -22,7 +22,7 @@
 . $(dirname $0)/test_header
 
 #-------------------------------------------------------------------------------
-N_TESTS=7
+N_TESTS=6
 tests $N_TESTS
 #-------------------------------------------------------------------------------
 JOB_HOST=$(rose config --default= 't' 'job-host')
@@ -85,7 +85,5 @@ else
     skip 2 "$TEST_KEY_BASE-items: [t]job-host not defined"
 fi
 #-------------------------------------------------------------------------------
-TEST_KEY=$TEST_KEY_BASE-clean
-run_pass "$TEST_KEY" rose suite-clean -y $NAME
-rmdir $SUITE_RUN_DIR 2>/dev/null || true
+rose suite-clean -q -y $NAME
 exit 0

--- a/t/rose-suite-run/05-log.t
+++ b/t/rose-suite-run/05-log.t
@@ -22,7 +22,7 @@
 . $(dirname $0)/test_header
 
 #-------------------------------------------------------------------------------
-tests 32
+tests 31
 export ROSE_CONF_PATH=
 #-------------------------------------------------------------------------------
 mkdir -p $HOME/cylc-run
@@ -54,7 +54,6 @@ for I in $(seq 0 $N_RUNS); do
     # Wait for the suite to complete
     TEST_KEY=$TEST_KEY_BASE-$I-wait
     TIMEOUT=$(($(date +%s) + 60)) # wait 1 minute
-    OK=false
     while [[ -e $HOME/.cylc/ports/$NAME ]] && (($(date +%s) < TIMEOUT)); do
         sleep 1
     done
@@ -62,7 +61,6 @@ for I in $(seq 0 $N_RUNS); do
         fail "$TEST_KEY"
         exit 1
     else
-        OK=true
         pass "$TEST_KEY"
     fi
     TEST_KEY=$TEST_KEY_BASE-$I-log
@@ -85,7 +83,6 @@ run_pass "$TEST_KEY" $ROSE_SUITE_RUN --log-keep=0
 # Wait for the suite to complete
 TEST_KEY=$TEST_KEY_BASE-log-keep-0-wait
 TIMEOUT=$(($(date +%s) + 60)) # wait 1 minute
-OK=false
 while [[ -e $HOME/.cylc/ports/$NAME ]] && (($(date +%s) < TIMEOUT)); do
     sleep 1
 done
@@ -93,7 +90,6 @@ if [[ -e $HOME/.cylc/ports/$NAME ]]; then
     fail "$TEST_KEY"
     exit 1
 else
-    OK=true
     pass "$TEST_KEY"
 fi
 
@@ -108,7 +104,5 @@ $SUITE_RUN_DIR/log.keep
 __OUT__
 
 #-------------------------------------------------------------------------------
-TEST_KEY=$TEST_KEY_BASE-clean
-run_pass "$TEST_KEY" rose suite-clean -y $NAME
-rmdir $SUITE_RUN_DIR 2>/dev/null || true
+rose suite-clean -q -y $NAME
 exit 0

--- a/t/rose-suite-run/06-opt-conf.t
+++ b/t/rose-suite-run/06-opt-conf.t
@@ -22,7 +22,7 @@
 . $(dirname $0)/test_header
 
 #-------------------------------------------------------------------------------
-tests 12
+tests 9
 export ROSE_CONF_PATH=
 #-------------------------------------------------------------------------------
 cat </dev/null >tests
@@ -72,10 +72,8 @@ done <tests
 #-------------------------------------------------------------------------------
 # Tidy up
 while read OPT_KEY SUITE_RUN_DIR; do
-    TEST_KEY=$TEST_KEY_BASE-clean-$OPT_KEY
     NAME=$(basename $SUITE_RUN_DIR)
-    run_pass "$TEST_KEY" rose suite-clean -y $NAME
-    rmdir $SUITE_RUN_DIR 2>/dev/null || true
+    rose suite-clean -q -y $NAME
 done <tests
 #-------------------------------------------------------------------------------
 exit 0

--- a/t/rose-suite-run/07-port-file.t
+++ b/t/rose-suite-run/07-port-file.t
@@ -37,4 +37,6 @@ file_cmp "$TEST_KEY.err" "$TEST_KEY.err" <<__ERR__
 [FAIL] $NAME: is already running (detected ~/.cylc/ports/$NAME)
 __ERR__
 #-------------------------------------------------------------------------------
+rm $HOME/.cylc/ports/$NAME
+rose suite-clean -q -y $NAME
 exit 0

--- a/t/rose-task-run/00-run-basic.t
+++ b/t/rose-task-run/00-run-basic.t
@@ -36,7 +36,6 @@ run_pass "$TEST_KEY" \
 # Wait for the suite to complete
 TEST_KEY=$TEST_KEY_BASE-suite-run-wait
 TIMEOUT=$(($(date +%s) + 300)) # wait 5 minutes
-OK=false
 while [[ -e $HOME/.cylc/ports/$NAME ]] && (($(date +%s) < TIMEOUT)); do
     sleep 1
 done
@@ -44,7 +43,6 @@ if [[ -e $HOME/.cylc/ports/$NAME ]]; then
     fail "$TEST_KEY"
     exit 1
 else
-    OK=true
     pass "$TEST_KEY"
 fi
 #-------------------------------------------------------------------------------
@@ -92,7 +90,5 @@ for CYCLE in 2013010100 2013010112 2013010200; do
     PREV_CYCLE=$CYCLE
 done
 #-------------------------------------------------------------------------------
-if $OK; then
-    rm -r $SUITE_RUN_DIR
-fi
+rose suite-clean -q -y $NAME
 exit 0

--- a/t/rose-task-run/02-run-path-empty.t
+++ b/t/rose-task-run/02-run-path-empty.t
@@ -36,7 +36,6 @@ run_pass "$TEST_KEY" \
 # Wait for the suite to complete
 TEST_KEY=$TEST_KEY_BASE-suite-run-wait
 TIMEOUT=$(($(date +%s) + 300)) # wait 5 minutes
-OK=false
 while [[ -e $HOME/.cylc/ports/$NAME ]] && (($(date +%s) < TIMEOUT)); do
     sleep 1
 done
@@ -44,7 +43,6 @@ if [[ -e $HOME/.cylc/ports/$NAME ]]; then
     fail "$TEST_KEY"
     exit 1
 else
-    OK=true
     pass "$TEST_KEY"
 fi
 #-------------------------------------------------------------------------------
@@ -58,7 +56,5 @@ for CYCLE in 2013010100 2013010112 2013010200; do
     PREV_CYCLE=$CYCLE
 done
 #-------------------------------------------------------------------------------
-if $OK; then
-    rm -r $SUITE_RUN_DIR
-fi
+rose suite-clean -q -y $NAME
 exit 0


### PR DESCRIPTION
It looks like `rose suite-clean $NAME` was leaving behind an empty
directory `$HOME/cylc-run/$NAME`. It turns out to be caused by a
lingering connection to the suite DB opened by the command itself, so it
was unable to remove the seemingly empty directory, because the suite DB
is renamed as a `.nfs*` file, which only gets removed when the command
is done. This change fixes the problem.

It also tidies up some of the tests that use the `rose suite-clean` command. (And I was guilty in putting in unnecessary workarounds in the tests rather than actually fixing the problem as described by this pull request.)
