### PR TITLE
rose suite-hook --shutdown: run with --kill --now

### DIFF
--- a/lib/python/rose/suite_control.py
+++ b/lib/python/rose/suite_control.py
@@ -88,7 +88,7 @@ class SuiteControl(object):
                   True.
         stderr: A file handle for stderr, if relevant for suite engine.
         stdout: A file handle for stdout, if relevant for suite engine.
-        args: extra arguments for the suite engine's gcontrol command.
+        args: extra arguments for the suite engine's shutdown command.
 
         """
         engine_version = self._get_engine_version(suite_name)

--- a/lib/python/rose/suite_engine_procs/cylc.py
+++ b/lib/python/rose/suite_engine_procs/cylc.py
@@ -671,7 +671,16 @@ class CylcProcessor(SuiteEngineProcessor):
 
     def shutdown(self, suite_name, host=None, engine_version=None, args=None,
                  stderr=None, stdout=None):
-        """Shut down the suite."""
+        """Shut down the suite.
+
+        suite_name -- the name of the suite.
+        host -- a host where the suite is running.
+        engine_version -- if specified, use this version of Cylc.
+        stderr -- A file handle for stderr, if relevant for suite engine.
+        stdout -- A file handle for stdout, if relevant for suite engine.
+        args -- extra arguments for "cylc shutdown".
+
+        """
         command = ["cylc", "shutdown", suite_name, "--force"]
         if host:
             command += ["--host=%s" % host]

--- a/lib/python/rose/suite_hook.py
+++ b/lib/python/rose/suite_hook.py
@@ -97,7 +97,8 @@ class RoseSuiteHook(object):
 
         # Shut down if required
         if should_shutdown:
-            self.suite_engine_proc.shutdown(suite_name)
+            self.suite_engine_proc.shutdown(suite_name,
+                                            args=["--now", "--kill"])
 
     __call__ = run
         

--- a/t/rose-suite-hook/00-shutdown.t
+++ b/t/rose-suite-hook/00-shutdown.t
@@ -35,7 +35,7 @@ run_pass "$TEST_KEY" \
 #-------------------------------------------------------------------------------
 # Wait for the suite to complete, test shutdown on fail
 TEST_KEY=$TEST_KEY_BASE-suite-hook-shutdown
-TIMEOUT=$(($(date +%s) + 300)) # wait 5 minutes
+TIMEOUT=$(($(date +%s) + 60)) # wait 1 minute
 while [[ -e $HOME/.cylc/ports/$NAME ]] && (($(date +%s) < TIMEOUT)); do
     sleep 1
 done

--- a/t/rose-suite-hook/00-shutdown/suite.rc
+++ b/t/rose-suite-hook/00-shutdown/suite.rc
@@ -8,6 +8,7 @@
     [[dependencies]]
         graph = """
 my_task_1
+my_task_2
 """
 
 [runtime]
@@ -22,3 +23,5 @@ my_task_1
            execution timeout  = 1
     [[my_task_1]]
         command scripting = "false"
+    [[my_task_2]]
+        command scripting = "sleep 600"


### PR DESCRIPTION
Now run `cylc shutdown` with `--kill --now`. This stops the suite
immediately. Otherwise, it may still be waiting for defunct jobs that
are in the submitted or running status.

Modify the `rose-suite-hook/00-shutdown.t` test to have a 2nd long running task to see if the hook triggered by the failure of the 1st task would cause the suite to shut down promptly or not.

Also some general tidy up.
