### PR TITLE
#791: fix bad rose edit gtk.Entry behaviour

### DIFF
--- a/lib/python/rose/config_editor/valuewidget/array.py
+++ b/lib/python/rose/config_editor/valuewidget/array.py
@@ -252,7 +252,13 @@ class EntryArrayValueWidget(gtk.HBox):
         entry.set_text(value_item)
         entry.connect('focus-in-event',
                       self._handle_focus_on_entry)
-        entry.connect_after('changed', self.setter)
+        entry.connect("button-release-event",
+                      self._handle_middle_click_paste)
+        entry.connect_after("paste-clipboard", self.setter)
+        entry.connect_after("key-release-event",
+                            lambda e, v: self.setter(e))
+        entry.connect_after("button-release-event",
+                            lambda e, v: self.setter(e))
         entry.connect('focus-out-event',
                       self._handle_focus_off_entry)
         entry.set_width_chars(self.chars_width - 1)
@@ -436,6 +442,11 @@ class EntryArrayValueWidget(gtk.HBox):
         if widget.get_text() != '':
             widget.select_region(widget.get_position(),
                                  widget.get_position())
+        return False
+
+    def _handle_middle_click_paste(self, widget, event):
+        if event.button == 2:
+            self.setter(widget)
         return False
 
 

--- a/lib/python/rose/config_editor/valuewidget/character.py
+++ b/lib/python/rose/config_editor/valuewidget/character.py
@@ -60,7 +60,13 @@ class QuotedTextValueWidget(gtk.HBox):
                              insensitive_colour)
         self.in_error = not self.type_checker(self.value)
         self.set_entry_text()
-        self.entry.connect_after("changed", self.setter)
+        self.entry.connect("button-release-event",
+                           self._handle_middle_click_paste)
+        self.entry.connect_after("paste-clipboard", self.setter)
+        self.entry.connect_after("key-release-event",
+                                 lambda e, v: self.setter(e))
+        self.entry.connect_after("button-release-event",
+                                 lambda e, v: self.setter(e))
         self.entry.show()
         self.pack_start(self.entry, expand=True, fill=True,
                         padding=0)
@@ -127,6 +133,11 @@ class QuotedTextValueWidget(gtk.HBox):
             return False
         self.set_entry_text()
         self.entry.set_position(position)
+
+    def _handle_middle_click_paste(self, widget, event):
+        if event.button == 2:
+            self.setter()
+        return False
 
 
 def text_for_character_widget(text):

--- a/lib/python/rose/config_editor/valuewidget/meta.py
+++ b/lib/python/rose/config_editor/valuewidget/meta.py
@@ -37,7 +37,11 @@ class MetaValueWidget(gtk.HBox):
         self.normal_colour = self.entry.style.text[gtk.STATE_NORMAL]
         self.insens_colour = self.entry.style.text[gtk.STATE_INSENSITIVE]
         self.entry.set_text(self.value)
-        self.entry.connect_after("changed", self._check_diff)
+        self.entry.connect("button-release-event",
+                           self._handle_middle_click_paste)
+        self.entry.connect_after("paste-clipboard", self._check_diff)
+        self.entry.connect_after("key-release-event", self._check_diff)
+        self.entry.connect_after("button-release-event", self._check_diff)
         self.entry.connect("activate", self._setter)
         self.entry.connect("focus-out-event", self._setter)
         self.entry.show()
@@ -81,3 +85,7 @@ class MetaValueWidget(gtk.HBox):
             return False
         self.entry.set_position(focus_index)
 
+    def _handle_middle_click_paste(self, widget, event):
+        if event.button == 2:
+            self._check_diff()
+        return False

--- a/lib/python/rose/config_editor/valuewidget/text.py
+++ b/lib/python/rose/config_editor/valuewidget/text.py
@@ -51,7 +51,13 @@ class RawValueWidget(gtk.HBox):
             self.entry.set_tooltip_text(
                        rose.config_editor.VAR_WIDGET_ENV_INFO)
         self.entry.set_text(self.value)
-        self.entry.connect_after("changed", self.setter)
+        self.entry.connect("button-release-event",
+                           self._handle_middle_click_paste)
+        self.entry.connect_after("paste-clipboard", self.setter)
+        self.entry.connect_after("key-release-event",
+                                 lambda e, v: self.setter(e))
+        self.entry.connect_after("button-release-event",
+                                 lambda e, v: self.setter(e))
         self.entry.show()
         self.pack_start(self.entry, expand=True, fill=True,
                                     padding=0)
@@ -82,6 +88,11 @@ class RawValueWidget(gtk.HBox):
         if focus_index is None:
             return False
         self.entry.set_position(focus_index)
+
+    def _handle_middle_click_paste(self, widget, event):
+        if event.button == 2:
+            self.setter(widget)
+        return False
 
 
 class TextMultilineValueWidget(gtk.HBox):


### PR DESCRIPTION
This reverts the changes from 2a3b96ba which enabled middle click but owing to the subtleties of the signal emission messed up the cursor re-positioning following error setting - so the cursor would appear in the wrong place after typing or inserting invalid text in a valuewidget.

@matthewrmshin, please review.
