### PR TITLE
cylc.py: Remove requirement for '@' in task hosts.

### DIFF
--- a/lib/python/rose/suite_engine_procs/cylc.py
+++ b/lib/python/rose/suite_engine_procs/cylc.py
@@ -311,7 +311,7 @@ class CylcProcessor(SuiteEngineProcessor):
         stmt += "(event==? OR event==? OR event==?)"
         stmt_args += ["submission succeeded", "succeeded", "failed"]
         for row in self._select(suite_name, stmt, stmt_args):
-            if row and "@" in row[0]:
+            if row and row[0]:
                 auth = self._parse_user_host(auth=row[0])
                 if auth:
                     auths.append(auth)


### PR DESCRIPTION
Fixes a bug that will appear when the cylc user@remote_host issue is fixed.

@matthewrmshin - please review.
