### PR TITLE
#332: improve rose edit macro reporting

### DIFF
--- a/lib/python/rose/config_editor/__init__.py
+++ b/lib/python/rose/config_editor/__init__.py
@@ -200,6 +200,10 @@ EVENT_MACRO_TRANSFORM_OK = "{1}: {0}: no changes"
 EVENT_MACRO_VALIDATE = "{1}: {0}: {2} errors"
 EVENT_MACRO_VALIDATE_ALL = "Custom Validators: {0}: {1} errors"
 EVENT_MACRO_VALIDATE_ALL_OK = "Custom Validators: {0}: all OK"
+EVENT_MACRO_VALIDATE_CHECK_ALL = (
+           "Custom Validators, FailureRuleChecker: {0} total problems found")
+EVENT_MACRO_VALIDATE_CHECK_ALL_OK = (
+           "Custom Validators, FailureRuleChecker: No problems found")
 EVENT_MACRO_VALIDATE_OK = "{1}: {0} is OK"
 EVENT_MACRO_VALIDATE_NO_PROBLEMS = "Custom Validators: No problems found"
 EVENT_MACRO_VALIDATE_PROBLEMS_FOUND = "Custom Validators: {0} problems found"

--- a/lib/python/rose/config_editor/main.py
+++ b/lib/python/rose/config_editor/main.py
@@ -447,7 +447,7 @@ class MainController(object):
                                      rose.config_editor.SHOW_MODE_NO_TITLE,
                                      m.get_active())),
                      ('/TopMenuBar/Metadata/All V',
-                      lambda m: self.main_handle.run_custom_macro(
+                      lambda m: self.main_handle.handle_run_custom_macro(
                                      method_name=rose.macro.VALIDATE_METHOD)),
                      ('/TopMenuBar/Metadata/Autofix',
                       lambda m: self.main_handle.transform_default()),
@@ -740,19 +740,19 @@ class MainController(object):
         launch_edit = lambda: self.nav_handle.edit_request(
                                                    namespace_name)
         page = rose.config_editor.page.ConfigPage(
-                                  page_metadata,
-                                  data,
-                                  latent_data,
-                                  sect_ops,
-                                  var_ops,
-                                  section_data_objects,
-                                  self.data.helper.get_format_sections,
-                                  directory,
-                                  sub_data=sub_data,
-                                  sub_ops=sub_ops,
-                                  launch_info_func=launch_info,
-                                  launch_edit_func=launch_edit,
-                                  launch_macro_func=self.main_handle.run_custom_macro)
+                page_metadata,
+                data,
+                latent_data,
+                sect_ops,
+                var_ops,
+                section_data_objects,
+                self.data.helper.get_format_sections,
+                directory,
+                sub_data=sub_data,
+                sub_ops=sub_ops,
+                launch_info_func=launch_info,
+                launch_edit_func=launch_edit,
+                launch_macro_func=self.main_handle.handle_run_custom_macro)
         #FIXME: These three should go.
         page.trigger_tab_detach = lambda b: self._handle_detach_request(page)
         var_ops.trigger_ignored_update = lambda v: page.update_ignored()


### PR DESCRIPTION
This improves the reporting for running custom macros or the fail-if checking in `rose edit`. The config names are now correctly sorted, preview apps are ignored, and the number of errors reported is now the total number of errors rather than the number of configurations.

The demo/rose-config-edit/demo_meta suite is useful for testing this - in particular, the check fail-if/warn-if, all validator macros, and the toolbar combo validate button are useful.

@arjclark, please review.
