### PR TITLE
#844: rose edit: fix jumping page bug

### DIFF
--- a/lib/python/rose/config_editor/main.py
+++ b/lib/python/rose/config_editor/main.py
@@ -635,9 +635,9 @@ class MainController(object):
         else:
             n = self.notebook.get_current_page()
             self.notebook.insert_page(page, page.labelwidget, n)
+            self.notebook.set_current_page(n)
             if n != -1:
                 self.notebook.remove_page(n + 1)
-            self.notebook.set_current_page(n)
         self.notebook.set_tab_label_packing(page)
 
     def make_page(self, namespace_name):

--- a/lib/python/rose/config_editor/nav_panel.py
+++ b/lib/python/rose/config_editor/nav_panel.py
@@ -96,7 +96,7 @@ class PageNavigationPanel(gtk.ScrolledWindow):
         self.name_iter_map = {}
         self.add(self.tree)
         self.load_tree(None, namespace_tree)
-        self.tree.connect('button_press_event',
+        self.tree.connect('button-press-event',
                           self.handle_activation)
         self._last_tree_activation_path = None
         self.tree.connect('row_activated',
@@ -356,13 +356,16 @@ class PageNavigationPanel(gtk.ScrolledWindow):
             path = self.filter_model.convert_child_path_to_path(path)
         except TypeError:
             path = None
-        if path is not None:
+        if path is None:
+            dest_path = (0,)
+        else:
             i = 1
             while self.tree.row_expanded(path[:i]) and i <= len(path):
                 i += 1
-            self.tree.set_cursor(path[:i])
-        if path is None:
-            self.tree.set_cursor((0,))
+            dest_path = path[:i]
+        cursor_path, cursor_column = self.tree.get_cursor()
+        if cursor_path != dest_path:
+            self.tree.set_cursor(dest_path)
 
     def get_path_from_names(self, row_names, unfiltered=False):
         """Return a row path corresponding to the list of branch names."""


### PR DESCRIPTION
This fixes a problem where the page tree will jump to an incorrect row after page launch. This can only really be seen for a large configuration with many tabs open. Launching many tabs, then selecting one of the middle tabs and then left-click launching pages should produce jitter with the old code.

The left-click launching destroys the current page and makes a new one in the tab. This was registered as two separate page changes, necessitating two page tree jumps, which caused the problem - it should just be one.

This closes #844.

@arjclark, please review.
