### PR TITLE
#858: document opt conf ordering

### DIFF
--- a/bin/rose-app-run
+++ b/bin/rose-app-run
@@ -59,6 +59,7 @@
 #         Do not overwrite existing files.
 #     --opt-conf-key=KEY, -O KEY
 #         Each of these switches on an optional configuration identified by KEY.
+#         The configurations are applied first-to-last.
 #     --quiet, -q
 #         Decrement verbosity.
 #     --verbose; -v
@@ -67,7 +68,7 @@
 # ENVIRONMENT VARIABLES
 #     optional ROSE_APP_OPT_CONF_KEYS
 #         Each KEY in this space delimited list switches on an optional
-#         configuration.
+#         configuration. The configurations are applied first-to-last.
 #     optional ROSE_FILE_INSTALL_ROOT
 #         If specified, change to the specified directory to install files.
 #-------------------------------------------------------------------------------

--- a/bin/rose-suite-run
+++ b/bin/rose-suite-run
@@ -83,6 +83,7 @@
 #         Do not validate (suite engine configuration) in strict mode.
 #     --opt-conf-key=KEY, -O KEY
 #         Each of these switches on an optional configuration identified by KEY.
+#         The configurations are applied first-to-last.
 #     --quiet, -q
 #         Decrement verbosity.
 #     --reload
@@ -102,7 +103,7 @@
 #         The name of the host where the "rose suite-run" command was invoked.
 #     optional ROSE_SUITE_OPT_CONF_KEYS
 #         Each KEY in this space delimited list switches on an optional
-#         configuration.
+#         configuration. The configurations are applied first-to-last.
 #
 # JINJA2 VARIABLES
 #     "rose suite-run" provides the following Jinja2 variables to the suite.

--- a/doc/rose-command.html
+++ b/doc/rose-command.html
@@ -90,8 +90,8 @@
 
       <dt><a href="#rose-host-select">rose host-select</a></dt>
 
-      <dd>Select a host from a set of groups or names by load, by free
-	memory or by random.</dd>
+      <dd>Select a host from a set of groups or names by load, by free memory
+      or by random.</dd>
 
       <dt><a href="#rose-macro">rose macro</a></dt>
 
@@ -297,7 +297,7 @@
       <dt><kbd>--opt-conf-key=KEY, -O KEY</kbd></dt>
 
       <dd>Each of these switches on an optional configuration identified by
-      <var>KEY</var>.</dd>
+      <var>KEY</var>. The configurations are applied first-to-last.</dd>
 
       <dt><kbd>--quiet, -q</kbd></dt>
 
@@ -314,7 +314,7 @@
       <dt><kbd>optional ROSE_APP_OPT_CONF_KEYS</kbd></dt>
 
       <dd>Each KEY in this space delimited list switches on an optional
-      configuration.</dd>
+      configuration. The configurations are applied first-to-last.</dd>
 
       <dt><kbd>optional ROSE_FILE_INSTALL_ROOT</kbd></dt>
 
@@ -564,8 +564,8 @@
     <h3>DESCRIPTION</h3>
 
     <p>Launch the GTK+ GUI to edit a suite or application configuration.</p>
-    
-    <p>If a suite contains more than 10 applications then they will only be 
+
+    <p>If a suite contains more than 10 applications then they will only be
     loaded after startup, on demand.</p>
 
     <h3>OPTIONS</h3>
@@ -589,11 +589,11 @@
       </dd>
 
       <dt><kbd>--load-all-apps</kbd></dt>
-      
+
       <dd>Force loading of all applications on startup.</dd>
 
       <dt><kbd>--load-no-apps</kbd></dt>
-      
+
       <dd>Load applications in the suite on demand.</dd>
 
       <dt><kbd>--meta-path=PATH; -M PATH</kbd></dt>
@@ -604,7 +604,7 @@
       <dt><kbd>--new</kbd></dt>
 
       <dd>Launch, ignoring any configuration.</dd>
-      
+
       <dt><kbd>--no-metadata</kbd></dt>
 
       <dd>Launch with metadata switched off.</dd>
@@ -769,7 +769,7 @@
             </ul>
           </li>
 
-	  <li>
+          <li>
             <var>mem</var> (by largest amount of free memory):
 
             <ul>
@@ -783,15 +783,15 @@
 
       <dt><kbd>--threshold=[METHOD[:METHOD-ARG]:]VALUE</kbd></dt>
 
-      <dd>Each of these option specifies a numeric value of a threshold of which
-      the hosts must either not exceed or must be greater than depending on the
-      specified method. Accepts the same <var>METHOD</var> and
+      <dd>Each of these option specifies a numeric value of a threshold of
+      which the hosts must either not exceed or must be greater than depending
+      on the specified method. Accepts the same <var>METHOD</var> and
       <var>METHOD-ARG</var> (and the same defaults) as the
       <kbd>--rank-method=METHOD[:METHOD-ARG]</kbd> option. (Obviously, the
-      <var>random</var> method does not make sense in this case.) 
-      <var>load</var> and <var>fs</var> must not exceed threshold while 
-      <var>mem</var> must be greater than threshold. A host not meeting 
-      a threshold condition will be excluded from the ranking list.</dd>
+      <var>random</var> method does not make sense in this case.)
+      <var>load</var> and <var>fs</var> must not exceed threshold while
+      <var>mem</var> must be greater than threshold. A host not meeting a
+      threshold condition will be excluded from the ranking list.</dd>
 
       <dt><kbd>--verbose, -v</kbd></dt>
 
@@ -1000,14 +1000,14 @@
       the MPI launcher command.</li>
     </ol>
 
-    <p>In all cases, the remaining arguments will be added to the command line of
-    the launcher program.</p>
+    <p>In all cases, the remaining arguments will be added to the command line
+    of the launcher program.</p>
 
     <h3>OPTIONS</h3>
 
     <dl>
       <dt><kbd>--command-file=FILE</kbd>, <kbd>-f FILE</kbd></dt>
-      
+
       <dd>Specify a command file for the MPI launcher.</dd>
 
       <dt><kbd>--debug</kbd></dt>
@@ -1034,8 +1034,8 @@
     <dl>
       <dt><kbd>launcher-list=LIST</kbd></dt>
 
-      <dd>Specify a list of launcher commands. E.g.:
-
+      <dd>
+        Specify a list of launcher commands. E.g.:
         <pre class="prettyprint lang-rose_conf">
 launcher-list=poe mpiexec
 </pre>
@@ -1043,25 +1043,26 @@ launcher-list=poe mpiexec
 
       <dt><kbd>launcher-fileopts.LAUNCHER=OPTION-TEMPLATE</kbd></dt>
 
-      <dd>Specify the options to a <var>LAUNCHER</var> for launching with a
-      command file.  The template string should contain
-      <var>$ROSE_COMMAND_FILE</var> (or <var>${ROSE_COMMAND_FILE}</var>), which
-      will be expanded to the path to the command file. E.g.:
-
+      <dd>
+        Specify the options to a <var>LAUNCHER</var> for launching with a
+        command file. The template string should contain
+        <var>$ROSE_COMMAND_FILE</var> (or <var>${ROSE_COMMAND_FILE}</var>),
+        which will be expanded to the path to the command file. E.g.:
         <pre class="prettyprint lang-rose_conf">
 launcher-fileopts.mpiexec=-f $ROSE_COMMAND_FILE
 launcher-fileopts.poe=-cmdfile $ROSE_COMMAND_FILE
 </pre>
       </dd>
 
-      <dt><kbd>launcher-preopts.LAUNCHER=OPTIONS</kbd><br/>
+      <dt><kbd>launcher-preopts.LAUNCHER=OPTIONS</kbd><br />
       <kbd>launcher-postopts.LAUNCHER=OPTIONS</kbd></dt>
 
-      <dd>Specify the options to a <var>LAUNCHER</var> for launching with a
-      command.  <var>preopts</var> are options placed after the launcher command
-      but before <var>COMMAND</var>. <var>postopts</var> are options placed
-      after <var>COMMAND</var> but before the remaining arguments. E.g.:
-
+      <dd>
+        Specify the options to a <var>LAUNCHER</var> for launching with a
+        command. <var>preopts</var> are options placed after the launcher
+        command but before <var>COMMAND</var>. <var>postopts</var> are options
+        placed after <var>COMMAND</var> but before the remaining arguments.
+        E.g.:
         <pre class="prettyprint lang-rose_conf">
 launcher-preopts.mpiexec=-n $NPROC
 </pre>
@@ -1402,6 +1403,7 @@ launcher-preopts.mpiexec=-n $NPROC
 
       <li><kbd>rose suite-log --archive CYCLE ...</kbd></li>
     </ol>
+
     <p><kbd>rose suite-log</kbd></p>
 
     <h3>SYNOPSIS</h3>
@@ -1454,11 +1456,10 @@ launcher-preopts.mpiexec=-n $NPROC
 
       <dd>Specify a timeout. Normally, a lock is put in place to prevent other
       instances of <a href="#rose-suite-hook">rose suite-hook</a> or <kbd>rose
-      suite-log --update</kbd> from updating the suite log at the same time. The
-      command hangs as it attempts to grab the lock. This option specify a
+      suite-log --update</kbd> from updating the suite log at the same time.
+      The command hangs as it attempts to grab the lock. This option specify a
       timeout (in number of seconds) for the attempt.
       (default=<kbd>300.0</kbd>)</dd>
-
 
       <dt><kbd>--update</kbd>, <kbd>-u</kbd></dt>
 
@@ -1604,7 +1605,7 @@ launcher-preopts.mpiexec=-n $NPROC
       <dt><kbd>--opt-conf-key=KEY, -O KEY</kbd></dt>
 
       <dd>Each of these switches on an optional configuration identified by
-      <var>KEY</var>.</dd>
+      <var>KEY</var>. The configurations are applied first-to-last.</dd>
 
       <dt><kbd>--quiet, -q</kbd></dt>
 
@@ -1647,7 +1648,7 @@ launcher-preopts.mpiexec=-n $NPROC
       <dt><kbd>optional ROSE_SUITE_OPT_CONF_KEYS</kbd></dt>
 
       <dd>Each KEY in this space delimited list switches on an optional
-      configuration.</dd>
+      configuration. The configurations are applied first-to-last.</dd>
     </dl>
 
     <h3>JINJA2</h3>
@@ -1876,8 +1877,8 @@ launcher-preopts.mpiexec=-n $NPROC
       environment variable called <var>NAME</var> (or <var>PATH</var> if
       <var>NAME</var> is not specified). If a relative path is given, it is
       relative to <var>$ROSE_SUITE_DIR</var>. An empty value resets the default
-      and any previous <kbd>--path=PATTERN</kbd> settings.
-      (Default for <var>PATH</var> is <kbd>share/fcm[_-]make*/*/bin</kbd> and
+      and any previous <kbd>--path=PATTERN</kbd> settings. (Default for
+      <var>PATH</var> is <kbd>share/fcm[_-]make*/*/bin</kbd> and
       <kbd>work/fcm[_-]make*/*/bin</kbd>)</dd>
 
       <dt><kbd>--prefix-delim=DELIMITER</kbd></dt>
@@ -1999,7 +2000,8 @@ environment scripting = "eval $(rose task-env)"
     <p>Run the Rose test battery.</p>
 
     <p>Change to <var>$ROSE_HOME/t</var> and run the <code>prove</code>
-    command. If no argument is specified, run <code>prove -j 9 -r -s</code>.</p>
+    command. If no argument is specified, run <code>prove -j 9 -r
+    -s</code>.</p>
 
     <h3>SEE ALSO</h3>
 
@@ -2477,7 +2479,7 @@ abc01 from daisy
 
       <dt><kbd>--user=~USERNAME; -u ~USERNAME</kbd></dt>
 
-      <dd>Specify another user whose roses directory you want to list e.g. 
+      <dd>Specify another user whose roses directory you want to list e.g.
       <code>--user=~bob</code></dd>
 
       <dt><kbd>--verbose; -v</kbd></dt>

--- a/doc/rose-configuration.html
+++ b/doc/rose-configuration.html
@@ -231,6 +231,17 @@ key-4=value 4
     utilities may also read optional configuration keys from environment
     variables and/or command line options.</p>
 
+    <p>Where multiple <var>$KEY</var> settings are given, the optional
+    configurations are applied in that order - for example, a setting:</p>
+    <pre class="prettyprint lang-rose_conf">
+opts=ketchup mayonnaise
+</pre>
+
+    <p>implies loading the optional configuration
+    <var>rose-app-ketchup.conf</var> and then the optional configuration
+    <var>rose-app-mayonnaise.conf</var>, which may override the previous
+    one.</p>
+
     <h2 id="site">Site and User Configuration</h2>
 
     <p>Aspects of some Rose utilities can be configured per installation via
@@ -314,16 +325,18 @@ accel-find-next=F3
     <dl>
       <dt><code>[env]</code></dt>
 
-      <dd>Specify the environment variables to export to the suite daemon. The
-      usual <var>$NAME</var> or <var>${NAME}</var> syntax can be used in values
-      to reference environment variables that are already defined before the
-      suite runner is invoked. However, it is unsafe to reference other
-      environment variables defined in this section. If the value of an
-      environment variable setting begins with a tilde <kbd>~</kbd>, all of the
-      characters preceding the 1st slash <kbd>/</kbd> are considered a
-      <em>tilde-prefix</em>. Where possible, a tilde-prefix is replaced with the
-      home directory associated with the specified login name at run time. There
-      are 2 special environment variables which can be specified in this section:
+      <dd>
+        Specify the environment variables to export to the suite daemon. The
+        usual <var>$NAME</var> or <var>${NAME}</var> syntax can be used in
+        values to reference environment variables that are already defined
+        before the suite runner is invoked. However, it is unsafe to reference
+        other environment variables defined in this section. If the value of an
+        environment variable setting begins with a tilde <kbd>~</kbd>, all of
+        the characters preceding the 1st slash <kbd>/</kbd> are considered a
+        <em>tilde-prefix</em>. Where possible, a tilde-prefix is replaced with
+        the home directory associated with the specified login name at run
+        time. There are 2 special environment variables which can be specified
+        in this section:
 
         <ul>
           <li><var>ROSE_VERSION</var>: If specified, the version of Rose that
@@ -526,17 +539,18 @@ accel-find-next=F3
       <dt><code>[env]</code></dt>
 
       <dd>Specify input environment variables to the command, in KEY=VALUE
-      pairs. The usual <var>$NAME</var> or <var>${NAME}</var> syntax can be used
-      in values to reference environment variables that are already defined when
-      the application runner is invoked. However, it is unsafe to reference
-      other environment variables defined in this section. Note:
+      pairs. The usual <var>$NAME</var> or <var>${NAME}</var> syntax can be
+      used in values to reference environment variables that are already
+      defined when the application runner is invoked. However, it is unsafe to
+      reference other environment variables defined in this section. Note:
       <var>UNDEF</var> is a special variable that is always undefined at run
       time. Reference to it will cause a failure at run time. It can be used to
       indicate that a value must be overridden at run time. If the value of an
       environment variable setting begins with a tilde <kbd>~</kbd>, all of the
       characters preceding the 1st slash <kbd>/</kbd> are considered a
-      <em>tilde-prefix</em>. Where possible, a tilde-prefix is replaced with the
-      home directory associated with the specified login name at run time.</dd>
+      <em>tilde-prefix</em>. Where possible, a tilde-prefix is replaced with
+      the home directory associated with the specified login name at run
+      time.</dd>
 
       <dt><code>[etc]</code></dt>
 

--- a/doc/rose-rug-advanced-tutorials-opt-conf.html
+++ b/doc/rose-rug-advanced-tutorials-opt-conf.html
@@ -224,7 +224,8 @@ TOPPING=fudge
       <samp>rose-app-chocofudge.conf</samp> file at runtime.</p>
 
       <p>We can add as many <samp>--opt-conf-key</samp> options to <samp>rose
-      task-run</samp> as we like - not just the one.</p>
+      task-run</samp> as we like - not just the one. This would apply each
+      optional configuration in first-to-last order.</p>
 
       <p>Try running the suite - it should apply the optional configuration
       correctly.</p>
@@ -263,10 +264,10 @@ TOPPING=fudge
 opts=chocofudge
 </pre>
     </div>
-    
+
     <div class="slide">
       <h3 class="alwayshidden">Default Optional Configurations (2)</h3>
-     
+
       <p>We now don't need to specify it at all for <code>rose task-run</code>
       - get rid of the environment variable in the <samp>suite.rc</samp> file,
       so that the <samp>order_icecream</samp> task runtime configuration looks

--- a/doc/rose-variables.html
+++ b/doc/rose-variables.html
@@ -20,15 +20,14 @@
 <body>
   <div class="header-footer" id="body-header">
     <address>
-      &copy; British Crown Copyright 2012-3
-      <a href="http://www.metoffice.gov.uk">Met Office</a>.
-      See <a href="rose-terms-of-use.html">Terms of Use</a>.<br />
+      &copy; British Crown Copyright 2012-3 <a href=
+      "http://www.metoffice.gov.uk">Met Office</a>. See <a href=
+      "rose-terms-of-use.html">Terms of Use</a>.<br />
       This document is released under the <a href=
       "http://www.nationalarchives.gov.uk/doc/open-government-licence/" rel=
       "license">Open Government Licence</a>.<br />
       <span id="rose-version"></span>
-    </address>
-    <img id="rose-icon" src="rose-icon.png" alt="Rose" />
+    </address><img id="rose-icon" src="rose-icon.png" alt="Rose" />
 
     <p><a href=".">Rose Documentation</a></p>
   </div>
@@ -55,7 +54,8 @@
     <h3>Description</h3>
 
     <p>Each KEY in this space delimited list switches on an optional
-    configuration in an application.</p>
+    configuration in an application. The configurations are applied in
+    first-to-last order.</p>
 
     <h3>Used By</h3>
 
@@ -78,7 +78,8 @@
     <h3>Used By</h3>
 
     <ul>
-      <li><a href="rose-command.html#rose-test-battery">rose test-battery</a></li>
+      <li><a href="rose-command.html#rose-test-battery">rose
+      test-battery</a></li>
     </ul>
 
     <h2 id="ROSE_DATA"><var>ROSE_DATA</var></h2>
@@ -214,7 +215,6 @@
     <ul>
       <li><a href="rose-command.html#rose-mpi-launch">rose mpi-launch</a></li>
     </ul>
-
 
     <h2 id="ROSE_LAUNCHER_LIST"><var>ROSE_LAUNCHER_LIST</var></h2>
 
@@ -353,7 +353,8 @@
     <h3>Description</h3>
 
     <p>Each KEY in this space delimited list switches on an optional
-    configuration when installing a suite.</p>
+    configuration when installing a suite. The configurations are applied in
+    first-to-last order.</p>
 
     <h3>Used By</h3>
 


### PR DESCRIPTION
This closes #858. It adds documentation about the order of precedence when using multiple optional configurations.

@matthewrmshin, please review.
