### PR TITLE
rose edit - fix info dialog for non-trivially-nested data

### DIFF
--- a/lib/python/rose/config_editor/util.py
+++ b/lib/python/rose/config_editor/util.py
@@ -189,32 +189,11 @@ def launch_node_info_dialog(node, changes, search_function):
         indent0 = len(prefix)
         text += prefix
         lenval = maxlen - indent0
-        text += _format_data(att_val, global_indent=indent0, width=lenval)
+        text += _pretty_format_data(att_val, global_indent=indent0,
+                                    width=lenval)
         text += "\n"
     rose.gtk.dialog.run_hyperlink_dialog(gtk.STOCK_DIALOG_INFO, text, title,
                                          search_function)
-
-def _format_data(data, global_indent=0, indent=4, width=60):
-    sub_name = rose.config_editor.DIALOG_NODE_INFO_SUB_ATTRIBUTE
-    safe_str = rose.gtk.util.safe_str
-    delim = rose.config_editor.DIALOG_NODE_INFO_DELIMITER
-    if isinstance(data, dict) and data:
-        text = ""
-        for key, val in data.items():
-            text += "\n" + " " * global_indent
-            sub_prefix = sub_name.format(safe_str(key)) + delim
-            sub_ind0 = global_indent + len(sub_prefix)
-            sub_lenval = width - len(sub_prefix)
-            str_val = _format_data(val,
-                                   global_indent=(global_indent + indent))
-            text += sub_prefix + str_val
-        return text
-    if isinstance(data, list) and data:
-        text = ",".join([_format_data(v) for v in data])
-        return wrap_string(text, width, global_indent)
-    if data != {} and data != []:
-        return wrap_string(str(data), width, global_indent)
-    return ""
 
 
 def launch_error_dialog(exception=None, text=""):
@@ -267,4 +246,27 @@ def wrap_string(text, maxlen=72, indent0=0, maxlines=4, sep=","):
     if len(lines) > maxlines:
         lines = lines[:4] + ["..."]
     return "\n".join(lines)
-    
+
+
+def _pretty_format_data(data, global_indent=0, indent=4, width=60):
+    sub_name = rose.config_editor.DIALOG_NODE_INFO_SUB_ATTRIBUTE
+    safe_str = rose.gtk.util.safe_str
+    delim = rose.config_editor.DIALOG_NODE_INFO_DELIMITER
+    if isinstance(data, dict) and data:
+        text = ""
+        for key, val in data.items():
+            text += "\n" + " " * global_indent
+            sub_prefix = sub_name.format(safe_str(key)) + delim
+            sub_ind0 = global_indent + len(sub_prefix)
+            sub_lenval = width - len(sub_prefix)
+            indent_next = global_indent + indent
+            str_val = _pretty_format_data(val,
+                                          global_indent=indent_next)
+            text += sub_prefix + str_val
+        return text
+    if isinstance(data, list) and data:
+        text = ",".join([_pretty_format_data(v) for v in data])
+        return wrap_string(text, width, global_indent)
+    if data != {} and data != []:
+        return wrap_string(str(data), width, global_indent)
+    return ""


### PR DESCRIPTION
The info dialog for a variable or section in `rose edit` currently fails when trying to represent a variable with optional configuration information. This is because it can currently only handle trivially-nested data.

This change (primarily e616c7f) separates out the custom prettyprinting so that an arbitrary depth of nesting can be represented nicely.

A good example can be seen by looking at the `demo/rose-config-edit/demo_meta/app/09-opt` app in `rose edit`.

@matthewrmshin, please review.
