### PR TITLE
rose edit: skip errors for unknown sections

### DIFF
--- a/lib/python/rose/config_editor/updater.py
+++ b/lib/python/rose/config_editor/updater.py
@@ -686,6 +686,8 @@ class Updater(object):
                 sect_data = config_sections.now.get(section)
                 if sect_data is None:
                     sect_data = config_sections.latent.get(section)
+                if sect_data is None:
+                    continue
                 if bad_report.is_warning:
                     sect_data.warning.setdefault(macro_type, info)
                 else:


### PR DESCRIPTION
This fixes an exception in rose edit where a custom or built-in macro reports an error for an unknown (not in data or metadata) section.

@matthewrmshin, please review.
