### PR TITLE
#801: fix modal no-metadata dialog

### DIFF
--- a/lib/python/rose/config_editor/util.py
+++ b/lib/python/rose/config_editor/util.py
@@ -203,7 +203,8 @@ def launch_error_dialog(exception=None, text=""):
     if exception is not None:
         text += type(exception).__name__ + ": " + str(exception)
     rose.gtk.dialog.run_dialog(rose.gtk.dialog.DIALOG_TYPE_ERROR,
-                               text, rose.config_editor.DIALOG_TITLE_ERROR)
+                               text, rose.config_editor.DIALOG_TITLE_ERROR,
+                               modal=False)
 
 
 def text_for_character_widget(text):


### PR DESCRIPTION
This closes #801. The relevant function is only used in this particular context.

@matthewrmshin, please review.
