### PR TITLE
rose suite-log: fix --archive '*'

### DIFF
--- a/bin/rose-suite-log
+++ b/bin/rose-suite-log
@@ -25,6 +25,7 @@
 #     2. rose suite-log --update [ITEM ...]
 #        rose suite-log --update '*' # all task jobs
 #     3. rose suite-log --archive CYCLE ...
+#        rose suite-log --archive '*' # all cycles
 #
 # DESCRIPTION
 #     View or update suite log.

--- a/doc/rose-command.html
+++ b/doc/rose-command.html
@@ -1401,7 +1401,8 @@ launcher-preopts.mpiexec=-n $NPROC
       <li><kbd>rose suite-log --update [ITEM ...]</kbd><br />
       <kbd>rose suite-log --update '*' # all task jobs</kbd></li>
 
-      <li><kbd>rose suite-log --archive CYCLE ...</kbd></li>
+      <li><kbd>rose suite-log --archive CYCLE ...</kbd><br />
+      <kbd>rose suite-log --archive '*' # all cycles</kbd></li>
     </ol>
 
     <p><kbd>rose suite-log</kbd></p>

--- a/lib/python/rose/suite_engine_procs/cylc.py
+++ b/lib/python/rose/suite_engine_procs/cylc.py
@@ -454,7 +454,8 @@ class CylcProcessor(SuiteEngineProcessor):
         """
         cycles = []
         if "*" in items:
-            rows = self._select("SELECT DISTINCT cycle in task_events")
+            rows = self._select(suite_name,
+                                "SELECT DISTINCT cycle from task_events")
             for row in rows:
                 cycles.append(row[0])
         else:

--- a/t/rose-suite-log/06-archive-star
+++ b/t/rose-suite-log/06-archive-star
@@ -1,0 +1,1 @@
+01-update-cycle

--- a/t/rose-suite-log/06-archive-star.t
+++ b/t/rose-suite-log/06-archive-star.t
@@ -1,0 +1,110 @@
+#!/bin/bash
+#-------------------------------------------------------------------------------
+# (C) British Crown Copyright 2012-3 Met Office.
+#
+# This file is part of Rose, a framework for scientific suites.
+#
+# Rose is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Rose is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Rose. If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test "rose suite-log --archive *", without site/user configurations.
+#-------------------------------------------------------------------------------
+. $(dirname $0)/test_header
+
+#-------------------------------------------------------------------------------
+tests 15
+#-------------------------------------------------------------------------------
+if [[ $TEST_KEY_BASE == *-remote* ]]; then
+    JOB_HOST=$(rose config 't' 'job-host')
+    if [[ -z $JOB_HOST ]]; then
+        skip 29 '[t]job-host not defined'
+        exit 0
+    fi
+    JOB_HOST=$(rose host-select $JOB_HOST)
+fi
+#-------------------------------------------------------------------------------
+# Run the suite.
+export ROSE_CONF_PATH=
+TEST_KEY=$TEST_KEY_BASE
+SUITE_RUN_DIR=$(mktemp -d --tmpdir=$HOME/cylc-run 'rose-test-battery.XXXXXX')
+NAME=$(basename $SUITE_RUN_DIR)
+if [[ -n ${JOB_HOST:-} ]]; then
+    run_pass "$TEST_KEY" \
+        rose suite-run -C $TEST_SOURCE_DIR/$TEST_KEY_BASE --name=$NAME \
+        --no-gcontrol --host=localhost \
+        -D "[jinja2:suite.rc]HOST=\"$JOB_HOST\""
+else
+    run_pass "$TEST_KEY" \
+        rose suite-run -C $TEST_SOURCE_DIR/$TEST_KEY_BASE --name=$NAME \
+        --no-gcontrol --host=localhost
+fi
+#-------------------------------------------------------------------------------
+# Wait for the suite to complete, test shutdown on fail
+TEST_KEY="$TEST_KEY_BASE-complete"
+TIMEOUT=$(($(date +%s) + 300)) # wait 5 minutes
+while [[ -e $HOME/.cylc/ports/$NAME ]] && (($(date +%s) < TIMEOUT)); do
+    sleep 1
+done
+if [[ -e $HOME/.cylc/ports/$NAME ]]; then
+    fail "$TEST_KEY"
+    exit 1
+else
+    pass "$TEST_KEY"
+fi
+#-------------------------------------------------------------------------------
+# Test --archive.
+TEST_KEY="$TEST_KEY_BASE-star"
+for CYCLE in 2013010112 2013010200; do
+    TEST_KEY="$TEST_KEY_BASE-$CYCLE"
+    run_pass "$TEST_KEY-before" python - \
+        "$HOME/cylc-run/$NAME/log/rose-suite-log-$CYCLE.json" \
+        'my_task_2' <<'__PYTHON__'
+import json, sys
+file_name, task_name = sys.argv[1:]
+d = json.load(open(file_name))
+sys.exit(task_name in d["tasks"])
+__PYTHON__
+    run_pass "$TEST_KEY-main-before" python - \
+        "$HOME/cylc-run/$NAME/log/rose-suite-log.json" $CYCLE <<'__PYTHON__'
+import json, sys
+file_name, cycle = sys.argv[1:]
+d = json.load(open(file_name))
+sys.exit(cycle not in d["cycle_times_current"]
+            or cycle in d["cycle_times_archived"])
+__PYTHON__
+    run_pass "$TEST_KEY-list-job-logs-before" ls $SUITE_RUN_DIR/log/job/*$CYCLE*
+    if [[ -n ${JOB_HOST:-} ]]; then
+        run_pass "$TEST_KEY-job-log.out-before-jobhost" \
+            ssh -oBatchMode=yes $JOB_HOST \
+            test -f cylc-run/$NAME/log/job/my_task_2.$CYCLE.1.out
+        run_fail "$TEST_KEY-job-log.out-before-localhost" \
+            test -f $SUITE_RUN_DIR/log/job/my_task_2.$CYCLE.1.out
+    else
+        pass "$TEST_KEY-job-log.out-before-jobhost"
+        pass "$TEST_KEY-job-log.out-before-localhost"
+    fi
+done
+N_JOB_LOGS=$(wc -l "$TEST_KEY-list-job-logs-before.out" | cut -d' ' -f1)
+run_pass "$TEST_KEY-command" rose suite-log -n $NAME --archive "*" --debug
+run_fail "$TEST_KEY-list-job-logs-after" ls $SUITE_RUN_DIR/log/job/*
+if [[ -n ${JOB_HOST:-} ]]; then
+    ((N_JOB_LOGS += 3)) # script, out and err files
+    run_fail "$TEST_KEY-job-log.out-after-jobhost" \
+        ssh -oBatchMode=yes $JOB_HOST \
+        ls cylc-run/$NAME/log/job/my_task_2.*.1.out
+else
+    pass "$TEST_KEY-job-log.out-after-jobhost"
+fi
+#-------------------------------------------------------------------------------
+rose suite-clean -q -y $NAME
+exit 0


### PR DESCRIPTION
This fixes a bug with `rose suite-log --archive '*'` and adds a test for it (derived from the existing 01-update-cycle.t file in the same directory).

@matthewrmshin, please review.
