### PR TITLE
rose app-run: report correctly ref to ! namelist

### DIFF
--- a/lib/python/rose/loc_handlers/namelist.py
+++ b/lib/python/rose/loc_handlers/namelist.py
@@ -57,8 +57,6 @@ class NamelistLocHandler(object):
         """Write namelist to loc.cache."""
         if not loc.loc_type:
             self.parse(loc, config)
-        f = open(loc.cache, "wb")
-
         if loc.name.endswith("(:)"):
             name = loc.name[0:-2]
             sections = [k for k in config.value.keys() if k.startswith(name)]
@@ -68,10 +66,11 @@ class NamelistLocHandler(object):
             raise ValueError(loc.name)
         if loc.name.endswith("(:)"):
             sections.sort(rose.config.sort_settings)
+        f = open(loc.cache, "wb")
         for section in sections:
             section_node = config.get([section], no_ignore=True)
-            if section_node.state:
-                continue
+            if section_node is None:
+                raise ValueError(loc.name)
             group = RE_NAMELIST_GROUP.match(section).group(1)
             nlg = "&" + group + "\n"
             for key, node in sorted(section_node.value.items()):

--- a/t/rose-app-run/06-namelist.t
+++ b/t/rose-app-run/06-namelist.t
@@ -92,7 +92,7 @@ red_onion = 3
 carrot = 1
 __CONFIG__
 #-------------------------------------------------------------------------------
-tests 18
+tests 21
 #-------------------------------------------------------------------------------
 # Normal mode with namelist files.
 TEST_KEY=$TEST_KEY_BASE
@@ -203,6 +203,18 @@ TEST_KEY=$TEST_KEY_BASE-non-existent
 test_setup
 run_fail "$TEST_KEY" rose app-run --config=../config -q \
     '--define=[file:shopping-list-3.nl]source=namelist:shopping_list'
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" <<'__CONTENT__'
+[FAIL] file:shopping-list-3.nl=source=namelist:shopping_list: bad setting
+__CONTENT__
+test_teardown
+#-------------------------------------------------------------------------------
+# Normal mode with file referencing an ignored namelist section.
+TEST_KEY=$TEST_KEY_BASE-ignored
+test_setup
+run_fail "$TEST_KEY" rose app-run --config=../config -q \
+    '--define=[file:shopping-list-3.nl]source=namelist:shopping_list' \
+    '--define=[!namelist:shopping_list]'
 file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" <<'__CONTENT__'
 [FAIL] file:shopping-list-3.nl=source=namelist:shopping_list: bad setting


### PR DESCRIPTION
Instead of failing with a None exception.

Fix #906.
