### PR TITLE
rose suite-run complain if a suite is already running on a remote host even if port file not present

### DIFF
--- a/lib/python/rose/suite_engine_procs/cylc.py
+++ b/lib/python/rose/suite_engine_procs/cylc.py
@@ -448,8 +448,9 @@ class CylcProcessor(SuiteEngineProcessor):
             for host in sorted(hosts):
                 if host == "localhost":
                     continue
-                cmd = self.popen.get_cmd("ssh", host, "pgrep", "-u", 
-                                         os.environ['USER'], suite_name, '-f')
+                cmd = self.popen.get_cmd("ssh", host, "pgrep", "-u",
+                                         pwd.getpwuid(os.getuid()).pw_name,
+                                         suite_name, '-f')
                 host_proc_dict[host] = self.popen.run_bg(*cmd)
             while host_proc_dict:
                 for host, proc in host_proc_dict.items():


### PR DESCRIPTION
This adds a scan of remote hosts for processes running for a suite upon invoking rose suite-run.

Previously suite-run only worked with ports files. This now complains when suites have a process on a remote machine using pgrep to find processes for that suite name under that user's account.

Closes #903
