### PR TITLE
rose mpi-launch: fix unbound variable

### DIFF
--- a/bin/rose-mpi-launch
+++ b/bin/rose-mpi-launch
@@ -217,6 +217,7 @@ fi
 #-------------------------------------------------------------------------------
 # 3. Launch the program.
 #-------------------------------------------------------------------------------
+ROSE_LAUNCHER_BASE=${ROSE_LAUNCHER_BASE:-}
 if [[ -n $ROSE_COMMAND_FILE ]]; then
     if [[ -z $ROSE_LAUNCHER_BASE ]]; then
         err "ROSE_LAUNCHER not defined, command file not supported."


### PR DESCRIPTION
UM reconfiguration jobs in my first UM Rose suite (now working!) were failing with:

```
/oper/admin/um_fcm/rose/rose.git/bin/rose-mpi-launch: line 229: ROSE_LAUNCHER_BASE: unbound variable
[FAIL] um-recon # return-code=1
```

I'm not entirely sure if this is a bug or if just reflects some deficiency in my local rose installation, but initializing the variable if unset fixed it for me...
