### PR TITLE
rose_arch: fix directory source

### DIFF
--- a/lib/python/rose/apps/rose_arch.py
+++ b/lib/python/rose/apps/rose_arch.py
@@ -149,7 +149,7 @@ class RoseArchApp(BuiltinApp):
                             target.sources[checksum] = RoseArchSource(
                                             checksum,
                                             os.path.join(name, p),
-                                            os,path.join(path, p))
+                                            os.path.join(path, p))
                         else: # path is a file
                             target.sources[checksum] = RoseArchSource(
                                             checksum, name, path)

--- a/lib/python/rose/checksum.py
+++ b/lib/python/rose/checksum.py
@@ -42,6 +42,7 @@ def get_checksum(name):
     if not os.path.exists(name):
         raise OSError(errno.ENOENT, os.strerror(errno.ENOENT), name)
 
+    name = os.path.normpath(name)
     path_and_checksum_list = []
     if os.path.isfile(name):
         m = _load(name)

--- a/t/rose-task-run/04-app-arch-db-2013010100-1.out
+++ b/t/rose-task-run/04-app-arch-db-2013010100-1.out
@@ -1,5 +1,6 @@
 foo://2013010100/hello/worlds/dark-matter.txt||FOO_RC=$((2 - 1)) foo put %(target)s %(sources)s|1
 foo://2013010100/hello/worlds/earth.txt||foo put %(target)s %(sources)s|0
+foo://2013010100/hello/worlds/organisms.tar.gz|tar.gz|foo put %(target)s %(sources)s|0
 foo://2013010100/hello/worlds/planet-n.tar.gz|tar.gz|foo put %(target)s %(sources)s|0
 foo://2013010100/hello/worlds/spaceships/|gz|foo put %(target)s %(sources)s|0
 foo://2013010100/hello/worlds/stars/||foo put %(target)s %(sources)s|0
@@ -7,6 +8,15 @@ foo://2013010100/hello/worlds/try.nl||foo put %(target)s %(sources)s|0
 foo://2013010100/hello/worlds/unknown/stuff.pax|pax|foo put %(target)s %(sources)s|0
 foo://2013010100/hello/worlds/dark-matter.txt|hello/dark-matter.txt|d849987cf8a372771652794bc80ee175
 foo://2013010100/hello/worlds/earth.txt|hello/earth.txt|25205c990e801b32e192f72c362d97eb
+foo://2013010100/hello/worlds/organisms.tar.gz|hello/organisms/animals/crocodile.txt|2984b5f5271a31321c97c707ff2e3e6a
+foo://2013010100/hello/worlds/organisms.tar.gz|hello/organisms/animals/elephant.txt|66a7288e1580a8f43c232ebf36920eda
+foo://2013010100/hello/worlds/organisms.tar.gz|hello/organisms/animals/goose.txt|56e752501c971965d760fa3bc9783261
+foo://2013010100/hello/worlds/organisms.tar.gz|hello/organisms/animals/tiger.txt|06e80b85968b13fb155daa467125e1d8
+foo://2013010100/hello/worlds/organisms.tar.gz|hello/organisms/plants/daisy.txt|652c579e83e6d7b91d1797090b3b2be0
+foo://2013010100/hello/worlds/organisms.tar.gz|hello/organisms/plants/holly.txt|0fdc76740360ab1dcaba48b49b9ccd4f
+foo://2013010100/hello/worlds/organisms.tar.gz|hello/organisms/plants/iris.txt|86d3ee2cd18e0a28b34b87e7253e02d0
+foo://2013010100/hello/worlds/organisms.tar.gz|hello/organisms/plants/jasmine.txt|685996a5a728a5663a0d27df72bbc904
+foo://2013010100/hello/worlds/organisms.tar.gz|hello/organisms/plants/lily.txt|1bd7d4e053b683f036b05f4db7d613df
 foo://2013010100/hello/worlds/planet-n.tar.gz|hello/planet-1.txt|dcc4d274f56549096f070645fb505f24
 foo://2013010100/hello/worlds/planet-n.tar.gz|hello/planet-2.txt|1d3203f1d6a37048fb0ed791c890b1dc
 foo://2013010100/hello/worlds/planet-n.tar.gz|hello/planet-3.txt|22b91e433f0ea36b118c5990bdd34c00

--- a/t/rose-task-run/04-app-arch-db-2013010100-2.out
+++ b/t/rose-task-run/04-app-arch-db-2013010100-2.out
@@ -1,5 +1,6 @@
 foo://2013010100/hello/worlds/dark-matter.txt||FOO_RC=$((2 - 2)) foo put %(target)s %(sources)s|0
 foo://2013010100/hello/worlds/earth.txt||foo put %(target)s %(sources)s|0
+foo://2013010100/hello/worlds/organisms.tar.gz|tar.gz|foo put %(target)s %(sources)s|0
 foo://2013010100/hello/worlds/planet-n.tar.gz|tar.gz|foo put %(target)s %(sources)s|0
 foo://2013010100/hello/worlds/spaceships/|gz|foo put %(target)s %(sources)s|0
 foo://2013010100/hello/worlds/stars/||foo put %(target)s %(sources)s|0
@@ -7,6 +8,15 @@ foo://2013010100/hello/worlds/try.nl||foo put %(target)s %(sources)s|0
 foo://2013010100/hello/worlds/unknown/stuff.pax|pax|foo put %(target)s %(sources)s|0
 foo://2013010100/hello/worlds/dark-matter.txt|hello/dark-matter.txt|d849987cf8a372771652794bc80ee175
 foo://2013010100/hello/worlds/earth.txt|hello/earth.txt|25205c990e801b32e192f72c362d97eb
+foo://2013010100/hello/worlds/organisms.tar.gz|hello/organisms/animals/crocodile.txt|2984b5f5271a31321c97c707ff2e3e6a
+foo://2013010100/hello/worlds/organisms.tar.gz|hello/organisms/animals/elephant.txt|66a7288e1580a8f43c232ebf36920eda
+foo://2013010100/hello/worlds/organisms.tar.gz|hello/organisms/animals/goose.txt|56e752501c971965d760fa3bc9783261
+foo://2013010100/hello/worlds/organisms.tar.gz|hello/organisms/animals/tiger.txt|06e80b85968b13fb155daa467125e1d8
+foo://2013010100/hello/worlds/organisms.tar.gz|hello/organisms/plants/daisy.txt|652c579e83e6d7b91d1797090b3b2be0
+foo://2013010100/hello/worlds/organisms.tar.gz|hello/organisms/plants/holly.txt|0fdc76740360ab1dcaba48b49b9ccd4f
+foo://2013010100/hello/worlds/organisms.tar.gz|hello/organisms/plants/iris.txt|86d3ee2cd18e0a28b34b87e7253e02d0
+foo://2013010100/hello/worlds/organisms.tar.gz|hello/organisms/plants/jasmine.txt|685996a5a728a5663a0d27df72bbc904
+foo://2013010100/hello/worlds/organisms.tar.gz|hello/organisms/plants/lily.txt|1bd7d4e053b683f036b05f4db7d613df
 foo://2013010100/hello/worlds/planet-n.tar.gz|hello/planet-1.txt|dcc4d274f56549096f070645fb505f24
 foo://2013010100/hello/worlds/planet-n.tar.gz|hello/planet-2.txt|1d3203f1d6a37048fb0ed791c890b1dc
 foo://2013010100/hello/worlds/planet-n.tar.gz|hello/planet-3.txt|22b91e433f0ea36b118c5990bdd34c00

--- a/t/rose-task-run/04-app-arch-db-2013010112-1.out
+++ b/t/rose-task-run/04-app-arch-db-2013010112-1.out
@@ -1,5 +1,6 @@
 foo://2013010112/hello/worlds/dark-matter.txt||FOO_RC=$((2 - 1)) foo put %(target)s %(sources)s|1
 foo://2013010112/hello/worlds/earth.txt||foo put %(target)s %(sources)s|0
+foo://2013010112/hello/worlds/organisms.tar.gz|tar.gz|foo put %(target)s %(sources)s|0
 foo://2013010112/hello/worlds/planet-n.tar.gz|tar.gz|foo put %(target)s %(sources)s|0
 foo://2013010112/hello/worlds/spaceships/|gz|foo put %(target)s %(sources)s|0
 foo://2013010112/hello/worlds/stars/||foo put %(target)s %(sources)s|0
@@ -7,6 +8,15 @@ foo://2013010112/hello/worlds/try.nl||foo put %(target)s %(sources)s|0
 foo://2013010112/hello/worlds/unknown/stuff.pax|pax|foo put %(target)s %(sources)s|0
 foo://2013010112/hello/worlds/dark-matter.txt|hello/dark-matter.txt|0752d8326a675d55ed2568648b347faf
 foo://2013010112/hello/worlds/earth.txt|hello/earth.txt|58a85149e24a2f26af37bbe10d0b4fef
+foo://2013010112/hello/worlds/organisms.tar.gz|hello/organisms/animals/crocodile.txt|c8ab09ebc9f0ea252c85e3226cd4bf1b
+foo://2013010112/hello/worlds/organisms.tar.gz|hello/organisms/animals/elephant.txt|8dd338fe56dd28f396e1c75c94734c19
+foo://2013010112/hello/worlds/organisms.tar.gz|hello/organisms/animals/goose.txt|1b4ef04cce16c5a3aac9d20b7c7cf6bc
+foo://2013010112/hello/worlds/organisms.tar.gz|hello/organisms/animals/tiger.txt|c64902873ce4cbd289100fc77f350e45
+foo://2013010112/hello/worlds/organisms.tar.gz|hello/organisms/plants/daisy.txt|d2a7130a4617e9bdc61ade2499c04dc8
+foo://2013010112/hello/worlds/organisms.tar.gz|hello/organisms/plants/holly.txt|6358475eebfe1de54449038df25e8d6e
+foo://2013010112/hello/worlds/organisms.tar.gz|hello/organisms/plants/iris.txt|d9cfc1c56d538de096ba7f47006f1f2e
+foo://2013010112/hello/worlds/organisms.tar.gz|hello/organisms/plants/jasmine.txt|1883637b57666289c23aa5bcd851d557
+foo://2013010112/hello/worlds/organisms.tar.gz|hello/organisms/plants/lily.txt|2cdee1ca94d96635ad2459cfbb853366
 foo://2013010112/hello/worlds/planet-n.tar.gz|hello/planet-1.txt|5337bae81c39b27410728d532a8d7875
 foo://2013010112/hello/worlds/planet-n.tar.gz|hello/planet-2.txt|74047aa8ff6e403a7b32057915add93a
 foo://2013010112/hello/worlds/planet-n.tar.gz|hello/planet-3.txt|7ea97fecc3fcebc4afa00da19a17b9c1

--- a/t/rose-task-run/04-app-arch-db-2013010112-2.out
+++ b/t/rose-task-run/04-app-arch-db-2013010112-2.out
@@ -1,5 +1,6 @@
 foo://2013010112/hello/worlds/dark-matter.txt||FOO_RC=$((2 - 2)) foo put %(target)s %(sources)s|0
 foo://2013010112/hello/worlds/earth.txt||foo put %(target)s %(sources)s|0
+foo://2013010112/hello/worlds/organisms.tar.gz|tar.gz|foo put %(target)s %(sources)s|0
 foo://2013010112/hello/worlds/planet-n.tar.gz|tar.gz|foo put %(target)s %(sources)s|0
 foo://2013010112/hello/worlds/spaceships/|gz|foo put %(target)s %(sources)s|0
 foo://2013010112/hello/worlds/stars/||foo put %(target)s %(sources)s|0
@@ -7,6 +8,15 @@ foo://2013010112/hello/worlds/try.nl||foo put %(target)s %(sources)s|0
 foo://2013010112/hello/worlds/unknown/stuff.pax|pax|foo put %(target)s %(sources)s|0
 foo://2013010112/hello/worlds/dark-matter.txt|hello/dark-matter.txt|0752d8326a675d55ed2568648b347faf
 foo://2013010112/hello/worlds/earth.txt|hello/earth.txt|58a85149e24a2f26af37bbe10d0b4fef
+foo://2013010112/hello/worlds/organisms.tar.gz|hello/organisms/animals/crocodile.txt|c8ab09ebc9f0ea252c85e3226cd4bf1b
+foo://2013010112/hello/worlds/organisms.tar.gz|hello/organisms/animals/elephant.txt|8dd338fe56dd28f396e1c75c94734c19
+foo://2013010112/hello/worlds/organisms.tar.gz|hello/organisms/animals/goose.txt|1b4ef04cce16c5a3aac9d20b7c7cf6bc
+foo://2013010112/hello/worlds/organisms.tar.gz|hello/organisms/animals/tiger.txt|c64902873ce4cbd289100fc77f350e45
+foo://2013010112/hello/worlds/organisms.tar.gz|hello/organisms/plants/daisy.txt|d2a7130a4617e9bdc61ade2499c04dc8
+foo://2013010112/hello/worlds/organisms.tar.gz|hello/organisms/plants/holly.txt|6358475eebfe1de54449038df25e8d6e
+foo://2013010112/hello/worlds/organisms.tar.gz|hello/organisms/plants/iris.txt|d9cfc1c56d538de096ba7f47006f1f2e
+foo://2013010112/hello/worlds/organisms.tar.gz|hello/organisms/plants/jasmine.txt|1883637b57666289c23aa5bcd851d557
+foo://2013010112/hello/worlds/organisms.tar.gz|hello/organisms/plants/lily.txt|2cdee1ca94d96635ad2459cfbb853366
 foo://2013010112/hello/worlds/planet-n.tar.gz|hello/planet-1.txt|5337bae81c39b27410728d532a8d7875
 foo://2013010112/hello/worlds/planet-n.tar.gz|hello/planet-2.txt|74047aa8ff6e403a7b32057915add93a
 foo://2013010112/hello/worlds/planet-n.tar.gz|hello/planet-3.txt|7ea97fecc3fcebc4afa00da19a17b9c1

--- a/t/rose-task-run/04-app-arch-db-2013010200-1.out
+++ b/t/rose-task-run/04-app-arch-db-2013010200-1.out
@@ -1,5 +1,6 @@
 foo://2013010200/hello/worlds/dark-matter.txt||FOO_RC=$((2 - 1)) foo put %(target)s %(sources)s|1
 foo://2013010200/hello/worlds/earth.txt||foo put %(target)s %(sources)s|0
+foo://2013010200/hello/worlds/organisms.tar.gz|tar.gz|foo put %(target)s %(sources)s|0
 foo://2013010200/hello/worlds/planet-n.tar.gz|tar.gz|foo put %(target)s %(sources)s|0
 foo://2013010200/hello/worlds/spaceships/|gz|foo put %(target)s %(sources)s|0
 foo://2013010200/hello/worlds/stars/||foo put %(target)s %(sources)s|0
@@ -7,6 +8,15 @@ foo://2013010200/hello/worlds/try.nl||foo put %(target)s %(sources)s|0
 foo://2013010200/hello/worlds/unknown/stuff.pax|pax|foo put %(target)s %(sources)s|0
 foo://2013010200/hello/worlds/dark-matter.txt|hello/dark-matter.txt|f95326c55075aa12d3a3aaf5958dbe67
 foo://2013010200/hello/worlds/earth.txt|hello/earth.txt|dde4e4b505256a1fe9f30fe80b892d24
+foo://2013010200/hello/worlds/organisms.tar.gz|hello/organisms/animals/crocodile.txt|9bfd75677f1d17b743d9d0d7c9b829d3
+foo://2013010200/hello/worlds/organisms.tar.gz|hello/organisms/animals/elephant.txt|00f9c60bc048ae85ded02eda20ff2a13
+foo://2013010200/hello/worlds/organisms.tar.gz|hello/organisms/animals/goose.txt|5b1dcbc37c4cd2a2cc17d963434b27ae
+foo://2013010200/hello/worlds/organisms.tar.gz|hello/organisms/animals/tiger.txt|2354b097ab9d01694c9682862d7eb52c
+foo://2013010200/hello/worlds/organisms.tar.gz|hello/organisms/plants/daisy.txt|cd8dd4f0a17bac9c34c6efbb6c6effd4
+foo://2013010200/hello/worlds/organisms.tar.gz|hello/organisms/plants/holly.txt|1493ae47a78b2635763a27cd990f17ba
+foo://2013010200/hello/worlds/organisms.tar.gz|hello/organisms/plants/iris.txt|6017dedd8b56768e0727ad0ab97c65e3
+foo://2013010200/hello/worlds/organisms.tar.gz|hello/organisms/plants/jasmine.txt|6cf624f7247999827b10ca64332880e8
+foo://2013010200/hello/worlds/organisms.tar.gz|hello/organisms/plants/lily.txt|ed649bdb0d00b739d0188fc181c4bf62
 foo://2013010200/hello/worlds/planet-n.tar.gz|hello/planet-1.txt|7872cf18ded524b0cd03d366eeb4d4f7
 foo://2013010200/hello/worlds/planet-n.tar.gz|hello/planet-2.txt|081e8a0a6ec6e363b3a260f71d4c191d
 foo://2013010200/hello/worlds/planet-n.tar.gz|hello/planet-3.txt|8b346e7aa5b52b4f8b0ad587a744f775

--- a/t/rose-task-run/04-app-arch-db-2013010200-2.out
+++ b/t/rose-task-run/04-app-arch-db-2013010200-2.out
@@ -1,5 +1,6 @@
 foo://2013010200/hello/worlds/dark-matter.txt||FOO_RC=$((2 - 2)) foo put %(target)s %(sources)s|0
 foo://2013010200/hello/worlds/earth.txt||foo put %(target)s %(sources)s|0
+foo://2013010200/hello/worlds/organisms.tar.gz|tar.gz|foo put %(target)s %(sources)s|0
 foo://2013010200/hello/worlds/planet-n.tar.gz|tar.gz|foo put %(target)s %(sources)s|0
 foo://2013010200/hello/worlds/spaceships/|gz|foo put %(target)s %(sources)s|0
 foo://2013010200/hello/worlds/stars/||foo put %(target)s %(sources)s|0
@@ -7,6 +8,15 @@ foo://2013010200/hello/worlds/try.nl||foo put %(target)s %(sources)s|0
 foo://2013010200/hello/worlds/unknown/stuff.pax|pax|foo put %(target)s %(sources)s|0
 foo://2013010200/hello/worlds/dark-matter.txt|hello/dark-matter.txt|f95326c55075aa12d3a3aaf5958dbe67
 foo://2013010200/hello/worlds/earth.txt|hello/earth.txt|dde4e4b505256a1fe9f30fe80b892d24
+foo://2013010200/hello/worlds/organisms.tar.gz|hello/organisms/animals/crocodile.txt|9bfd75677f1d17b743d9d0d7c9b829d3
+foo://2013010200/hello/worlds/organisms.tar.gz|hello/organisms/animals/elephant.txt|00f9c60bc048ae85ded02eda20ff2a13
+foo://2013010200/hello/worlds/organisms.tar.gz|hello/organisms/animals/goose.txt|5b1dcbc37c4cd2a2cc17d963434b27ae
+foo://2013010200/hello/worlds/organisms.tar.gz|hello/organisms/animals/tiger.txt|2354b097ab9d01694c9682862d7eb52c
+foo://2013010200/hello/worlds/organisms.tar.gz|hello/organisms/plants/daisy.txt|cd8dd4f0a17bac9c34c6efbb6c6effd4
+foo://2013010200/hello/worlds/organisms.tar.gz|hello/organisms/plants/holly.txt|1493ae47a78b2635763a27cd990f17ba
+foo://2013010200/hello/worlds/organisms.tar.gz|hello/organisms/plants/iris.txt|6017dedd8b56768e0727ad0ab97c65e3
+foo://2013010200/hello/worlds/organisms.tar.gz|hello/organisms/plants/jasmine.txt|6cf624f7247999827b10ca64332880e8
+foo://2013010200/hello/worlds/organisms.tar.gz|hello/organisms/plants/lily.txt|ed649bdb0d00b739d0188fc181c4bf62
 foo://2013010200/hello/worlds/planet-n.tar.gz|hello/planet-1.txt|7872cf18ded524b0cd03d366eeb4d4f7
 foo://2013010200/hello/worlds/planet-n.tar.gz|hello/planet-2.txt|081e8a0a6ec6e363b3a260f71d4c191d
 foo://2013010200/hello/worlds/planet-n.tar.gz|hello/planet-3.txt|8b346e7aa5b52b4f8b0ad587a744f775

--- a/t/rose-task-run/04-app-arch-find-foo.out
+++ b/t/rose-task-run/04-app-arch-find-foo.out
@@ -1,5 +1,6 @@
 foo/2013010100/hello/worlds/dark-matter.txt
 foo/2013010100/hello/worlds/earth.txt
+foo/2013010100/hello/worlds/organisms.tar.gz
 foo/2013010100/hello/worlds/planet-n.tar.gz
 foo/2013010100/hello/worlds/spaceships/spaceship-1.txt.gz
 foo/2013010100/hello/worlds/spaceships/spaceship-2.txt.gz
@@ -15,6 +16,7 @@ foo/2013010100/hello/worlds/unknown/stuff.pax
 foo/2013010112/hello/worlds/dark-matter.txt
 foo/2013010112/hello/worlds/earth.txt
 foo/2013010112/hello/worlds/mars.txt.gz
+foo/2013010112/hello/worlds/organisms.tar.gz
 foo/2013010112/hello/worlds/planet-n.tar.gz
 foo/2013010112/hello/worlds/spaceships/spaceship-1.txt.gz
 foo/2013010112/hello/worlds/spaceships/spaceship-2.txt.gz
@@ -29,6 +31,7 @@ foo/2013010112/hello/worlds/try.nl
 foo/2013010112/hello/worlds/unknown/stuff.pax
 foo/2013010200/hello/worlds/dark-matter.txt
 foo/2013010200/hello/worlds/earth.txt
+foo/2013010200/hello/worlds/organisms.tar.gz
 foo/2013010200/hello/worlds/planet-n.tar.gz
 foo/2013010200/hello/worlds/spaceships/spaceship-1.txt.gz
 foo/2013010200/hello/worlds/spaceships/spaceship-2.txt.gz

--- a/t/rose-task-run/04-app-arch/app/archive/rose-app.conf
+++ b/t/rose-task-run/04-app-arch/app/archive/rose-app.conf
@@ -39,3 +39,6 @@ source=stuffing-*.txt
 [arch:dark-matter.txt]
 command-format=FOO_RC=$((2 - $CYLC_TASK_TRY_NUMBER)) foo put %(target)s %(sources)s
 source=hello/dark-matter.txt
+
+[arch:organisms.tar.gz]
+source=hello/organisms/

--- a/t/rose-task-run/04-app-arch/app/install/bin/my-install
+++ b/t/rose-task-run/04-app-arch/app/install/bin/my-install
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -eu
 PREFIX=
 if [[ ${ROSE_TASK_CYCLE_TIME:-} ]]; then
     PREFIX="[$ROSE_TASK_CYCLE_TIME] "
@@ -20,4 +21,11 @@ for I in $(seq 1 9); do
 done
 for I in $(seq 1 9); do
     echo "${PREFIX}Hello Stuff $I" >$ROSE_DATAC/stuffing-$I.txt
+done
+mkdir -p $ROSE_DATAC/hello/organisms/{plants,animals}
+for NAME in lily jasmine holly iris daisy; do
+    echo "${PREFIX}Hello $NAME" >$ROSE_DATAC/hello/organisms/plants/$NAME.txt
+done
+for NAME in elephant tiger goose crocodile; do
+    echo "${PREFIX}Hello $NAME" >$ROSE_DATAC/hello/organisms/animals/$NAME.txt
 done


### PR DESCRIPTION
This fixes:
- `rose.apps.rose_arch`: an incorrect syntax which caused `source=DIR` to fail.
- `rose.checksum`: trailing slash in `name` argument gave incorrect result.
