### PR TITLE
rose app-run: fix poll delays default

### DIFF
--- a/lib/python/rose/app_run.py
+++ b/lib/python/rose/app_run.py
@@ -212,7 +212,8 @@ class AppRunner(Runner):
             # m: minutes
             # h: hours
             # N*: repeat the value N times
-            poll_delays_value = config.get_value(["poll", "delays"]).strip()
+            poll_delays_value = config.get_value(
+                ["poll", "delays"], default="").strip()
             units = {"h": 3600, "m": 60, "s": 1}
             if poll_delays_value:
                 for item in poll_delays_value.split(","):

--- a/t/rose-app-run/08-poll.t
+++ b/t/rose-app-run/08-poll.t
@@ -30,7 +30,7 @@ any-files=file3 file4
 test=test -e file5
 __CONFIG__
 #-------------------------------------------------------------------------------
-tests 12
+tests 15
 #-------------------------------------------------------------------------------
 # Timeout test 1.
 TEST_KEY=$TEST_KEY_BASE-timeout-1
@@ -65,6 +65,20 @@ touch file1 file2 file4
 (sleep 2; touch file5) &
 run_pass "$TEST_KEY" rose app-run --config=../config -q \
     -D '[poll]delays=5*1' \
+    -D '[poll]file-test=test -e {} && grep -q hello {}'
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+wait
+test_teardown
+#-------------------------------------------------------------------------------
+# OK test 3 (no delay).
+TEST_KEY=$TEST_KEY_BASE-ok-3
+test_setup
+touch file1 file2 file4
+(sleep 2; echo "hello" | tee file1 >file2) &
+(sleep 2; echo "hello" >file4) &
+(sleep 2; touch file5) &
+run_pass "$TEST_KEY" rose app-run --config=../config -q \
     -D '[poll]file-test=test -e {} && grep -q hello {}'
 file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null


### PR DESCRIPTION
This fixes the case where `delays` is not specified in `[poll]` for `rose app-run` - the documentation (and the code) suggests that it should not fail, but assume a `delays=0` default value.

@matthewrmshin, please review.
