### PR TITLE
rosie go: advanced search default operator

### DIFF
--- a/lib/python/rosie/browser/__init__.py
+++ b/lib/python/rosie/browser/__init__.py
@@ -216,6 +216,7 @@ TITLE_INVALID_QUERY = "Error"
 
 # Miscellaneous
 COPYRIGHT = "(C) British Crown Copyright 2012-3 Met Office."
+DEFAULT_FILTER_EXPR = "eq"
 DEFAULT_QUERY = "list_my_suites"
 DELIM_KEYVAL = ": "
 HELP_FILE = "rose-rug-rosie-go.html"

--- a/lib/python/rosie/browser/util.py
+++ b/lib/python/rosie/browser/util.py
@@ -586,8 +586,11 @@ class AdvancedSearchWidget(gtk.VBox):
         column_combo.show()
         column_combo.set_tooltip_text(rosie.browser.TIP_FILTER_COLUMN)
         expr_combo = gtk.combo_box_new_text()
-        for expr in self.filter_exprs:
+        for ind in range(len(self.filter_exprs)):
+            expr = self.filter_exprs[ind]
             expr_combo.append_text(expr)
+            if expr == rosie.browser.DEFAULT_FILTER_EXPR:
+                expr_combo.set_active(ind)
         expr_combo.show()
         expr_combo.set_tooltip_text(rosie.browser.TIP_FILTER_ACTION)
         string_entry = gtk.Entry()


### PR DESCRIPTION
Closes #109.

Set a [configurable] default value for advanced search operator to "eq".

@benfitzpatrick - please review.
