### PR TITLE
rose host-select: fix documentation on load

### DIFF
--- a/bin/rose-host-select
+++ b/bin/rose-host-select
@@ -42,7 +42,7 @@
 #     --rank-method=METHOD[:METHOD-ARG]
 #         Specify the method for ranking a list of hosts. The method can be:
 #             "load" (by average load as reported by "uptime" divided by number
-#                     of processors):
+#                     of virtual processors):
 #                 If METHOD-ARG is specified, it must be "1", "5" or "15". The
 #                 default is to use the 15 minute load.
 #             "fs" (by % usage of a file system as reported by df):

--- a/doc/rose-command.html
+++ b/doc/rose-command.html
@@ -793,7 +793,7 @@
         <ul>
           <li>
             <var>load</var> (by average load as reported by <kbd>uptime</kbd>
-            divided by number of processors):
+            divided by number of virtual processors):
 
             <ul>
               <li>If <var>METHOD-ARG</var> is specified, it must be "1", "5" or


### PR DESCRIPTION
It is divided by the number of _virtual_ processors.
