### PR TITLE
rose edit: fix add latent mixed widget

### DIFF
--- a/lib/python/rose/config_editor/valuewidget/array/mixed.py
+++ b/lib/python/rose/config_editor/valuewidget/array/mixed.py
@@ -143,6 +143,8 @@ class MixedArrayValueWidget(gtk.HBox):
 
     def get_focus_index(self):
         text = ''
+        if not self.value_array:
+            return 0
         for r, widget_list in enumerate(self.rows):
             for i, widget in enumerate(widget_list):
                 val = self.value_array[r * self.num_cols + i]


### PR DESCRIPTION
If a variable uses the mixed widget (valuewidget.array.mixed) and is in a latent state, adding the variable will result in a traceback:

```
File "........../lib/python/rose/config_editor/valuewidget/array/mixed.py", line 148, in get_focus_index
    val = self.value_array[r * self.num_cols + i]
IndexError: list index out of range
```

This is because `self.value_array` is an empty list, and (in this case) it is trying to find the zeroth element. This adds a catch to stop it bothering - as a latent variable, it cannot have focus in any case.

@arjclark, please review.
