### PR TITLE
rose_arch: more informative command format message

### DIFF
--- a/lib/python/rose/apps/rose_arch.py
+++ b/lib/python/rose/apps/rose_arch.py
@@ -35,11 +35,12 @@ import sqlite3
 import sys
 from tempfile import mkdtemp
 
+
 class RoseArchCommandFormatError(KeyError):
 
     """An error raised when trying to construct a command format."""
 
-    ERROR_FORMAT = "command-format=%s: %s: %s"
+    ERROR_FORMAT = "%s: bad command-format: %s: error: %s: %s"
 
     def __str__(self):
         return self.ERROR_FORMAT % self.args
@@ -261,7 +262,12 @@ class RoseArchApp(BuiltinApp):
                     target.status = target.ST_BAD
                     app_runner.handle_event(
                         RoseArchCommandFormatError(
-                                target.command_format, type(e).__name__, e))
+                            target.name,
+                            target.command_format,
+                            type(e).__name__,
+                            e
+                        )
+                    )
                 else:
                     rc, out, err = app_runner.popen.run(command, shell=True)
                     if rc:

--- a/t/rose-task-run/04-app-arch.t
+++ b/t/rose-task-run/04-app-arch.t
@@ -82,7 +82,7 @@ CYCLE=2013010112
 TEST_KEY="$TEST_KEY_BASE-bad-archive-1"
 FILE_PREFIX="$SUITE_RUN_DIR/log/job/archive_bad_"
 file_cmp "$TEST_KEY.err" "${FILE_PREFIX}1.$CYCLE.1.err" <<'__ERR__'
-[FAIL] command-format=foo put %(target)s %(source)s: KeyError: 'source'
+[FAIL] foo://2013010112/hello/worlds/planet-n.tar.gz: bad command-format: foo put %(target)s %(source)s: error: KeyError: 'source'
 __ERR__
 TEST_KEY="$TEST_KEY_BASE-bad-archive-2"
 file_cmp "$TEST_KEY.err" "${FILE_PREFIX}2.$CYCLE.1.err" <<'__ERR__'


### PR DESCRIPTION
It's relatively common to mis-specify the `command-format` in `rose_arch` - this makes the error description a bit more obvious.

@matthewrmshin, please review
