### PR TITLE
rose bush: add host name to brand

### DIFF
--- a/lib/html/rose-bush/index.html
+++ b/lib/html/rose-bush/index.html
@@ -1,8 +1,10 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<title>Rose Bush - Browse User Suite-logs on HTTP</title>
+<title>Rose Bush @ {{host}} - Browse User Suite-logs on HTTP</title>
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+<link rel="icon" href="{{script}}/favicon.ico" />
+<link rel="shortcut icon" href="{{script}}/favicon.ico" />
 <link type="text/css" href="{{script}}/etc/bootstrap/css/bootstrap.min.css"
 rel="stylesheet" media="screen" />
 <link type="text/css" href="{{script}}/rose-bush.css" rel="stylesheet" media="screen" />
@@ -10,7 +12,7 @@ rel="stylesheet" media="screen" />
 <body>
 <div class="container-fluid">
 <div class="hero-unit">
-<h1>Rose Bush</h1>
+<h1>Rose Bush <small>@ {{host}}</small></h1>
 <p>Browse User Suite-logs on HTTP</p>
 </div>
 <div class="row-fluid">

--- a/lib/html/rose-bush/list.html
+++ b/lib/html/rose-bush/list.html
@@ -1,8 +1,10 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<title>{{suite}} ~{{user}}: Rose Bush</title>
+<title>{{suite}} ~{{user}}: Rose Bush @ {{host}}</title>
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+<link rel="icon" href="{{script}}/favicon.ico" />
+<link rel="shortcut icon" href="{{script}}/favicon.ico" />
 <link type="text/css" href="{{script}}/etc/bootstrap/css/bootstrap.min.css"
 rel="stylesheet" media="screen" />
 <link type="text/css" href="{{script}}/rose-bush.css" rel="stylesheet" media="screen" />
@@ -10,8 +12,7 @@ rel="stylesheet" media="screen" />
 <body>
 <div class="navbar navbar-static-top">
 <div class="navbar-inner">
-<a class="brand" href="{{script}}/">
-<img src="/favicon.ico" alt="Rose Bush" title="Rose Bush" /></a>
+<a class="brand" href="{{script}}/">Rose Bush @ {{host}}</a>
 <ul class="nav">
 <li><a href="{{script}}/summary/{{user}}">{{user}}</a></li>
 <li class="active"><a><strong>{{suite}}</strong></a></li>

--- a/lib/html/rose-bush/summary.html
+++ b/lib/html/rose-bush/summary.html
@@ -3,6 +3,8 @@
 <head>
 <title>{{user}}: Rose Bush</title>
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+<link rel="icon" href="{{script}}/favicon.ico" />
+<link rel="shortcut icon" href="{{script}}/favicon.ico" />
 <link type="text/css" href="{{script}}/etc/bootstrap/css/bootstrap.min.css"
 rel="stylesheet" media="screen" />
 <link type="text/css" href="{{script}}/rose-bush.css" rel="stylesheet" media="screen" />
@@ -10,8 +12,7 @@ rel="stylesheet" media="screen" />
 <body>
 <div class="navbar navbar-static-top">
 <div class="navbar-inner">
-<a class="brand" href="{{script}}/">
-<img src="/favicon.ico" alt="Rose Bush" title="Rose Bush" /></a>
+<a class="brand" href="{{script}}/">Rose Bush @ {{host}}</a>
 <ul class="nav">
 <li class="active"><a><strong>{{user}}</strong></a></li>
 </ul>

--- a/lib/html/rose-bush/view.html
+++ b/lib/html/rose-bush/view.html
@@ -1,8 +1,10 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<title>{{path}} {{suite}}~{{user}}: Rose Bush</title>
+<title>{{path}} {{suite}}~{{user}}: Rose Bush @{{host}}</title>
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+<link rel="icon" href="{{script}}/favicon.ico" />
+<link rel="shortcut icon" href="{{script}}/favicon.ico" />
 <link type="text/css" href="{{script}}/etc/bootstrap/css/bootstrap.min.css"
 rel="stylesheet" media="screen" />
 <link type="text/css" href="{{script}}/rose-bush.css" rel="stylesheet" media="screen" />
@@ -10,9 +12,7 @@ rel="stylesheet" media="screen" />
 <body>
 <div class="navbar navbar-static-top">
 <div class="navbar-inner">
-<a class="brand" href="{{script}}/">
-<img src="/favicon.ico" alt="Rose Bush" title="Rose Bush" /></a>
-</a>
+<a class="brand" href="{{script}}/">Rose Bush @ {{host}}</a>
 <ul class="nav">
 <li><a href="{{script}}/summary/{{user}}">{{user}}</a></li>
 <li><a href="{{script}}/list/{{user}}/{{suite}}">{{suite}}</a></li>


### PR DESCRIPTION
We are no doubt going to have to run Rose Bush on different hosts. This change will allow user to quickly tell which Rose Bush they are looking at.

Also add favicon to all HTML pages.
