### PR TITLE
rose suite-run: Make pgrep use exact matching rather than substrings.

### DIFF
--- a/lib/python/rose/suite_engine_procs/cylc.py
+++ b/lib/python/rose/suite_engine_procs/cylc.py
@@ -547,7 +547,7 @@ class CylcProcessor(SuiteEngineProcessor):
                     continue
                 cmd = self.popen.get_cmd("ssh", host, "pgrep", "-u",
                                          pwd.getpwuid(os.getuid()).pw_name,
-                                         suite_name, '-f')
+                                         suite_name, '-f', '-x')
                 host_proc_dict[host] = self.popen.run_bg(*cmd)
             while host_proc_dict:
                 for host, proc in host_proc_dict.items():


### PR DESCRIPTION
Make pgrep use exact matching so that suite `test` isn't mistaken for `test-variant` in the returned processes.

Closes #965

@matthewrmshin - please review.
