### PR TITLE
rose app-upgrade: fix documentation

### DIFF
--- a/doc/rose-command.html
+++ b/doc/rose-command.html
@@ -351,6 +351,10 @@
     <h3>OPTIONS</h3>
 
     <dl>
+      <dt><kbd>--all-versions, -a</kbd></dt>
+      
+      <dd>Use all tagged versions.</dd>
+
       <dt><kbd>--config=DIR; -C DIR</kbd></dt>
 
       <dd>Use configuration in <var>DIR</var> instead of <var>$PWD</var>.</dd>


### PR DESCRIPTION
This fixes a discrepancy between the CLI html documentation and the actual CLI help for `rose app-upgrade`.

@arjclark, please review.
