### PR TITLE
rose macro: fix fail-if array variables that look like single float values

### DIFF
--- a/lib/python/rose/macros/rule.py
+++ b/lib/python/rose/macros/rule.py
@@ -190,7 +190,7 @@ class RuleEvaluator(rose.macro.MacroBase):
                 if var_id == "this":
                     var_id = setting_id
                 setting_value = self._get_value_from_id(var_id, config)
-                array_value = rose.variable.array_split(setting_value)
+                array_value = rose.variable.array_split(str(setting_value))
                 new_string = start + "("
                 for elem_num in range(1, len(array_value) + 1):
                     new_string += self.ARRAY_EXPR.format(var_id, elem_num,
@@ -204,7 +204,7 @@ class RuleEvaluator(rose.macro.MacroBase):
             if var_id == "this":
                 var_id = setting_id
             setting_value = self._get_value_from_id(var_id, config)
-            array_value = rose.variable.array_split(setting_value)
+            array_value = rose.variable.array_split(str(setting_value))
             new_string = start + str(len(array_value)) + end
             rule = self.REC_LEN_FUNC.sub(new_string, rule, count=1)
         for search_result in self.REC_SCI_NUM.findall(rule):

--- a/t/rose-macro/09-rule-check.t
+++ b/t/rose-macro/09-rule-check.t
@@ -44,10 +44,13 @@ test_array_pass = '0A', '0A', '0A', '0A'
 test_array_fail = '0A', '2A', '0A', '0A'
 test_array_any_pass = 2, 5, 6, 7
 test_array_any_fail = 2, 0, 6, 7
+test_array_1_any_pass = 2
 test_array_all_pass = 0, 0, 0, 1, 0
 test_array_all_fail = 0, 0, 0, 0, 0
+test_array_1_all_pass = 1
 test_array_len_pass = 0, 1, 2, 3, 4
 test_array_len_fail = 0, 1, 2
+test_array_1_len_pass = 0
 
 [complex:scalar_test]
 test_var_multi_odd_positive_pass = -2
@@ -150,12 +153,22 @@ length = :
 description = Fail if any elements are zero
 fail-if = any(this == 0)
 
+[simple:array_test=test_array_1_any_pass]
+length = :
+description = Fail if any elements are zero
+fail-if = any(this == 0)
+
 [simple:array_test=test_array_all_pass]
 length = :
 description = Fail if all elements are zero
 fail-if = all(this == 0)
 
 [simple:array_test=test_array_all_fail]
+length = :
+description = Fail if all elements are zero
+fail-if = all(this == 0)
+
+[simple:array_test=test_array_1_all_pass]
 length = :
 description = Fail if all elements are zero
 fail-if = all(this == 0)
@@ -169,6 +182,11 @@ fail-if = len(this) != 5
 length = :
 description = Fail if array is wrong length
 fail-if = len(this) != 5
+
+[simple:array_test=test_array_1_len_pass]
+length = :
+description = Fail if array is wrong length
+fail-if = len(this) != 1
 
 [complex:scalar_test=test_var_multi_odd_positive_pass]
 type = real


### PR DESCRIPTION
The `fail-if` checking currently breaks for variables referenced using array expressions if their value looks like a single `float` value. This fixes the problem (float types shouldn't be passed to the array splitter). The changes to the test suite break in the old code, and are fine in the proposed code.

@arjclark, please review.
