### PR TITLE
rose test-battery: fix skip suite-log tests

### DIFF
--- a/t/rose-suite-log/00-update-task.t
+++ b/t/rose-suite-log/00-update-task.t
@@ -27,7 +27,7 @@ tests 8
 if [[ $TEST_KEY_BASE == *-remote* ]]; then
     JOB_HOST=$(rose config 't' 'job-host')
     if [[ -z $JOB_HOST ]]; then
-        skip 9 '[t]job-host not defined'
+        skip 8 '[t]job-host not defined'
         exit 0
     fi
     JOB_HOST=$(rose host-select $JOB_HOST)


### PR DESCRIPTION
This fixes the test-battery skip for `t/rose-suite-log/03-update-task-remote.t` without any job remote hosts.

@matthewrmshin, please review.
