### PR TITLE
Print absolute path of users data rather than relative path

### DIFF
--- a/lib/python/rose/apps/rose_ana.py
+++ b/lib/python/rose/apps/rose_ana.py
@@ -260,7 +260,7 @@ class Analyse(object):
             setattr(task, configvar, getattr(task, filevar))
             filenames = glob.glob(env_var_process(getattr(task, filevar)))
             if len(filenames) > 0:
-                setattr(task, filevar, filenames[0])
+                setattr(task, filevar, os.path.abspath(filenames[0]))
         return task
 
     def load_tasks(self):


### PR DESCRIPTION
I've just done a quick test and this prints "/path/to/user/cylc-run/suite/work/task/output.dat" rather than "../task/output.dat", which I think is what is needed. 

@benfitzpatrick, please can you take a look when you get a minute?
