### PR TITLE
rose demo: fix validate macro and add argument

### DIFF
--- a/demo/rose-config-edit/demo_meta/app/05-validate/meta/lib/python/macros/fib.py
+++ b/demo/rose-config-edit/demo_meta/app/05-validate/meta/lib/python/macros/fib.py
@@ -14,10 +14,13 @@ class FibonacciChecker(rose.macro.MacroBase):
 
     BAD_SEQUENCE = "not the Fibonacci sequence"
 
-    def validate(self, config, meta_config):
+    def validate(self, config, meta_config, starts_at_zero=False):
         """Validate an array containing integer elements."""
         self.reports = []
-        seq = [1, 1]
+        if starts_at_zero:
+            seq = [0, 1]
+        else:
+            seq = [1, 1]
         problem_list = []
         section = "env"
         option = "INVALID_SEQUENCE"
@@ -29,7 +32,8 @@ class FibonacciChecker(rose.macro.MacroBase):
         if all([w.isdigit() for w in elems]) and len(elems) > 1:
             int_elems = [int(w) for w in elems]
             if len(int_elems) >= 2 and int_elems[:2] != seq:
-                self._flag_problem(section, option, value)
+                self.add_report(section, option, value,
+                                self.BAD_SEQUENCE)
             else:
                 for i, element in enumerate(int_elems):
                     if i < 2:


### PR DESCRIPTION
This fixes a bug in the `demo/rose-config-edit/demo_meta` demo suite's validation macro, and adds a keyword argument.

@arjclark, please review.
