### PR TITLE
rose documentation: fix reference in upgrade tutorial

### DIFF
--- a/doc/rose-rug-advanced-tutorials-upgrade-dev.html
+++ b/doc/rose-rug-advanced-tutorials-upgrade-dev.html
@@ -433,7 +433,7 @@ class MyFirstUpgradeMacro(rose.upgrade.MacroUpgrade):
       want, and (behind the scenes) adds some things to the
       <samp>self.reports</samp> list mentioned in the <samp>return config,
       self.reports</samp> line. Note that when we add options like
-      <var>small_trees</var>, we need values to add them with - what they are
+      <var>misc_branches</var>, we need values to add them with - what they are
       will often be a matter of judgement.</p>
 
       <p>However, even if they appear to be numeric inputs, values should


### PR DESCRIPTION
This fixes a reference in the upgrade tutorial to a variable whose name has since been changed (`small_trees`).

@arjclark, please review.
