### PR TITLE
tarfile.open: use os.statvfs.f_bsize as bufsize

### DIFF
--- a/lib/python/rose/apps/rose_arch_compressions/rose_arch_tar.py
+++ b/lib/python/rose/apps/rose_arch_compressions/rose_arch_tar.py
@@ -53,7 +53,9 @@ class RoseArchTarGzip(object):
         scheme_ext = self.SCHEME_EXTS.get(target.compress_scheme, "")
         scheme_format = self.SCHEME_FORMATS.get(target.compress_scheme,
                                                 tarfile.DEFAULT_FORMAT)
-        t = tarfile.open(tmp_name, "w" + scheme_ext, format=scheme_format)
+        f_bsize = os.statvfs(work_dir).f_bsize
+        t = tarfile.open(tmp_name, "w" + scheme_ext, bufsize=f_bsize,
+                         format=scheme_format)
         for source in sources:
             f = open(source.path)
             tarinfo = t.gettarinfo(arcname=source.name, fileobj=f)

--- a/lib/python/rose/suite_engine_procs/cylc.py
+++ b/lib/python/rose/suite_engine_procs/cylc.py
@@ -603,7 +603,8 @@ class CylcProcessor(SuiteEngineProcessor):
                 names = glob(os.path.join("job", glob_))
                 if not names:
                     continue
-                tar = tarfile.open(archive_file_name, "w:gz")
+                f_bsize = os.statvfs(".").f_bsize
+                tar = tarfile.open(archive_file_name, "w:gz", bufsize=f_bsize)
                 for name in names:
                     tar.add(name)
                 tar.close()

--- a/lib/python/rose/suite_run.py
+++ b/lib/python/rose/suite_run.py
@@ -469,7 +469,8 @@ class SuiteRunner(Runner):
                 if os.path.isfile(log):
                     continue
                 log_tar_gz = log + ".tar.gz"
-                f = tarfile.open(log_tar_gz, "w:gz")
+                f_bsize = os.statvfs(log).f_bsize
+                f = tarfile.open(log_tar_gz, "w:gz", bufsize=f_bsize)
                 f.add(log)
                 f.close()
                 self.handle_event(SuiteLogArchiveEvent(log_tar_gz, log))


### PR DESCRIPTION
The default buffer size is not good. This change would adjust the buffer size (for write) according to the block size of the file system. (In theory, this should improve the efficiency of the write.)
