### PR TITLE
Use `gzip` command to write `*.gz` files

### DIFF
--- a/lib/python/rose/apps/rose_arch_compressions/rose_arch_gzip.py
+++ b/lib/python/rose/apps/rose_arch_compressions/rose_arch_gzip.py
@@ -20,8 +20,8 @@
 """Compress archive sources in gzip."""
 
 
-import gzip
 import os
+from rose.popen import RosePopenError
 
 
 class RoseArchGzip(object):
@@ -46,14 +46,7 @@ class RoseArchGzip(object):
             work_path_gz = os.path.join(work_dir, name_gz)
             self.app_runner.fs_util.makedirs(
                                 self.app_runner.fs_util.dirname(work_path_gz))
-            gz_f = gzip.open(work_path_gz, "wb")
-            f = open(source.path)
-            f_bsize = os.fstatvfs(f.fileno()).f_bsize
-            while True:
-                bytes = f.read(f_bsize)
-                if not bytes:
-                    break
-                gz_f.write(bytes)
-            f.close()
-            gz_f.close()
+            # N.B. Python's gzip is slow
+            command = "gzip -c '%s' >'%s'" % (source.path, work_path_gz)
+            self.app_runner.popen.run_simple(command, shell=True)
             source.path = work_path_gz

--- a/lib/python/rose/apps/rose_arch_compressions/rose_arch_tar.py
+++ b/lib/python/rose/apps/rose_arch_compressions/rose_arch_tar.py
@@ -29,8 +29,8 @@ class RoseArchTarGzip(object):
     """Compress archive sources in tar."""
 
     SCHEMES = ["pax", "pax.gz", "tar", "tar.gz", "tgz"]
-    SCHEME_EXTS = {"pax.gz": ":gz", "tar.gz": ":gz", "tgz": ":gz"}
     SCHEME_FORMATS = {"pax": tarfile.PAX_FORMAT, "pax.gz": tarfile.PAX_FORMAT}
+    GZIP_EXTS = ["pax.gz", "tar.gz", "tgz"]
 
     def __init__(self, app_runner, *args, **kwargs):
         self.app_runner = app_runner
@@ -47,17 +47,24 @@ class RoseArchTarGzip(object):
             sources[0].path.endswith("." + target.compress_scheme)):
             target.work_source_path = sources[0].path
             return # Assume that it has been done
-        fd, tmp_name = mkstemp(suffix="." + target.compress_scheme, dir=work_dir)
+        fd, tar_name = mkstemp(suffix=".tar", dir=work_dir)
         os.close(fd)
-        target.work_source_path = tmp_name
-        scheme_ext = self.SCHEME_EXTS.get(target.compress_scheme, "")
+        target.work_source_path = tar_name
         scheme_format = self.SCHEME_FORMATS.get(target.compress_scheme,
                                                 tarfile.DEFAULT_FORMAT)
         f_bsize = os.statvfs(work_dir).f_bsize
-        t = tarfile.open(tmp_name, "w" + scheme_ext, bufsize=f_bsize,
-                         format=scheme_format)
+        t = tarfile.open(tar_name, "w", bufsize=f_bsize, format=scheme_format)
         for source in sources:
             f = open(source.path)
             tarinfo = t.gettarinfo(arcname=source.name, fileobj=f)
             t.addfile(tarinfo, f)
         t.close()
+        # N.B. Python's gzip is slow
+        if target.compress_scheme in self.GZIP_EXTS:
+            fd, gz_name = mkstemp(suffix="." + target.compress_scheme,
+                                  dir=work_dir)
+            os.close(fd)
+            target.work_source_path = gz_name
+            command = "gzip -c '%s' >'%s'" % (tar_name, gz_name)
+            self.app_runner.popen.run_simple(command, shell=True)
+            self.app_runner.fs_util.delete(tar_name)

--- a/lib/python/rose/suite_run.py
+++ b/lib/python/rose/suite_run.py
@@ -468,12 +468,14 @@ class SuiteRunner(Runner):
             for log in list(logs):
                 if os.path.isfile(log):
                     continue
-                log_tar_gz = log + ".tar.gz"
+                log_tar = log + ".tar"
                 f_bsize = os.statvfs(log).f_bsize
-                f = tarfile.open(log_tar_gz, "w:gz", bufsize=f_bsize)
+                f = tarfile.open(log_tar, "w", bufsize=f_bsize)
                 f.add(log)
                 f.close()
-                self.handle_event(SuiteLogArchiveEvent(log_tar_gz, log))
+                # N.B. Python's gzip is slow
+                self.popen.run_simple("gzip", log_tar)
+                self.handle_event(SuiteLogArchiveEvent(log_tar + ".gz", log))
                 self.fs_util.delete(log)
 
     def _run_init_dir_work(self, opts, suite_name, name, conf_tree=None,


### PR DESCRIPTION
At the time of this commit, Python's core `gzip` module is about 10X
slower than the `gzip` command.

Close #989.
