### PR TITLE
rose bush: cast ws args to str before shlex

### DIFF
--- a/lib/python/rose/bush.py
+++ b/lib/python/rose/bush.py
@@ -134,9 +134,9 @@ class Root(object):
         }
         # TODO: add paths to other suite files
         if cycles:
-            cycles = shlex.split(cycles)
+            cycles = shlex.split(str(cycles))
         if tasks:
-            tasks = shlex.split(tasks)
+            tasks = shlex.split(str(tasks))
         data.update(self._get_suite_logs_info(user, suite))
         data["states"].update(
                 self.suite_engine_proc.get_suite_state_summary(user, suite))


### PR DESCRIPTION
It appears that in newer version of cherrypy, query arguments are
encoded in Unicode. Unfortunately, using `shlex.split` on a Unicode
string gives garbage. Casting the arguments into a `str` solves the
problem.

This addresses part of #918.
