### PR TITLE
rose documentation: fix typo

### DIFF
--- a/doc/rose-variables.html
+++ b/doc/rose-variables.html
@@ -453,7 +453,7 @@
 
     <h3>Description</h3>
 
-    <p>(Deprecated) Use the <var>opts</var> setting in the application
+    <p>(Deprecated) Use the <var>args</var> setting in the application
     configuration instead.</p>
 
     <p>Additional options and arguments for <kbd>fcm make</kbd> or <kbd>rose


### PR DESCRIPTION
This fixes an incorrect setting suggestion in the documentation.

@matthewrmshin, please review.
