### PR TITLE
Doc: fix typos

### DIFF
--- a/doc/rose-configuration-metadata.html
+++ b/doc/rose-configuration-metadata.html
@@ -1071,7 +1071,7 @@ elephant_mood='peaceful'
 
     <p>and an expression in the configuration metadata:</p>
     <pre class="prettyprint lang-python">
-namelist:zoo=elephant_type != 'annoyed' and num_elephants &gt;= 2
+namelist:zoo=elephant_mood != 'annoyed' and num_elephants &gt;= 2
 </pre>
 
     <p>then the expression would become:</p>

--- a/doc/rose-rug-suites.html
+++ b/doc/rose-rug-suites.html
@@ -337,6 +337,7 @@ default=echo 'Hello World'
 [runtime]
     [[root]]
         command scripting = "rose task-run"
+    [[hello_world]]
 </pre>
 
       <p><samp>[[root]]</samp> contains default settings that all cylc tasks


### PR DESCRIPTION
Fix typo in `rose-configuration-metadata.html`.

Add `[[hello_world]]` section in `rose-rug-suites.html` to ensure that the example passes `cylc validate --strict`.

(Change reported by a user via email.)
