### PR TITLE
rose sgc: handle gcontrol fail to launch for non-registered suites

### DIFF
--- a/lib/python/rose/suite_control.py
+++ b/lib/python/rose/suite_control.py
@@ -142,13 +142,6 @@ class SuiteNotFoundError(Exception):
     def __str__(self):
         return ("%s - no suite found for this path." % self.args[0])
 
-class SuiteNotRegisteredError(Exception):
-
-    """An exception raised when a suite is not registered."""
-    def __str__(self):
-        return ("%s: not a registered suite."
-                 % self.args[0])
-
 
 def get_suite_name(event_handler=None):
     """Find the top level of a suite directory structure"""

--- a/lib/python/rose/suite_engine_procs/cylc.py
+++ b/lib/python/rose/suite_engine_procs/cylc.py
@@ -29,7 +29,6 @@ from rose.fs_util import FileSystemEvent
 from rose.popen import RosePopenError
 from rose.reporter import Event, Reporter
 from rose.resource import ResourceLocator
-from rose.suite_control import SuiteNotRegisteredError
 from rose.suite_engine_proc import \
         StillRunningError, SuiteEngineProcessor, SuiteScanResult, TaskProps
 import socket
@@ -1057,3 +1056,11 @@ class DAO(object):
         if commit:
             self.commit()
         return self.cursor
+
+
+class SuiteNotRegisteredError(Exception):
+
+    """An exception raised when a suite is not registered."""
+    def __str__(self):
+        return ("%s: not a registered suite."
+                 % self.args[0])


### PR DESCRIPTION
Closes #939

Raise an exception if trying to run sgc on a non-registered suite - gcylc currently does this but fails silently.

@matthewrmshin - please review.
