### PR TITLE
rose bush: do not apply prettify to normal files

### DIFF
--- a/lib/html/rose-bush/view.html
+++ b/lib/html/rose-bush/view.html
@@ -91,13 +91,11 @@ rel="stylesheet" media="screen" />
 {% if file_content -%}
 <script type="text/javascript" src="{{script}}/etc/google-code-prettify/prettify.js">
 </script>
-{% endif -%}
-{% if file_content -%}
 <script type="text/javascript" src="{{script}}/etc/prettify-{{file_content}}.js">
 </script>
-{% endif -%}
 <script type="text/javascript">
 $(prettyPrint);
 </script>
+{% endif -%}
 </body>
 </html>


### PR DESCRIPTION
This removes the prettification of normal files viewed in Rose Bush, as it was taking too long.

@matthewrmshin, please review.
