### PR TITLE
#1034: fix rose edit orphaned warning for optional content sections

### DIFF
--- a/lib/python/rose/config_editor/main.py
+++ b/lib/python/rose/config_editor/main.py
@@ -777,6 +777,10 @@ class MainController(object):
                     if variable.name != rose.FILE_VAR_SOURCE:
                         continue
                     var_values = rose.variable.array_split(variable.value)
+                    for i, val in enumerate(var_values):
+                        if val.startswith("(") and val.endswith(")"):
+                            # It is optional - e.g. "(namelist:baz)".
+                            var_values[i] = val[1:-1]
                     if set(ok_names) & set(var_values):
                         var_id = variable.metadata['id']
                         see_also += ", " + var_id


### PR DESCRIPTION
This fixes #1034.

@matthewrmshin, please review.
