### PR TITLE
rose suite-run: check incompatible Cylc global config

### DIFF
--- a/doc/rose-rug-getting-started.html
+++ b/doc/rose-rug-getting-started.html
@@ -95,12 +95,13 @@ geditor=gvim -f
     <h2 id="site">Site Configuration</h2>
 
     <p>You can configure Rose for your site by creating and editing the
-    <var>etc/rose.conf</var> file in a Rose distribution.</p>
+    <var>etc/rose.conf</var> file in a Rose distribution. Valid settings are
+    documented in the <var>etc/rose.conf.example</var> file in a Rose
+    distribution.</p>
 
-    <p>Essential setup includes changing the options in
-    <samp>[rose-host-select]</samp> and <samp>[rose-suite-run]</samp> to
-    appropriate hostnames. You should also probably change the path settings in
-    <samp>[rose-task-run]</samp> to their equivalent for your site.</p>
+    <p>As a start, you should probably change <var>root-dir*</var> settings in
+    <var>[rose-suite-run]</var> section and the <var>path*</var> settings in
+    <var>[rose-task-run]</var> section to suit your site.</p>
 
     <p>If you are using Rosie, you will need to change the paths, urls, and
     hostnames in the <samp>rosie</samp> sections as well.</p>
@@ -108,12 +109,19 @@ geditor=gvim -f
     <p>You may want to make sure the default programs referred to in
     <samp>[external]</samp> are sensible.</p>
 
-    <h2 id="plugins">Plugins</h2>
+    <h2 id="cylc">Configuring Cylc</h2>
 
-    <p>You may want to set up cylc-specific text editor plugins - see the
-    <a href=
-    "http://cylc.github.io/cylc/html/single/cug-html.html#x1-530008.2">Cylc
-    User Guide</a> for details.</p>
+    <p>See <a href=
+    "http://cylc.github.io/cylc/html/single/cug-html.html#x1-160004.2">Cylc
+    Use Guide</a> for detail.</p>
+
+    <p>DO NOT modify the <var>[hosts] &rarr; HOST &rarr; run directory</var> and
+    <var>[hosts] &rarr; HOST &rarr; work directory</var> settings, and they are
+    incompatible with Rose. Equivalent functionalities are provided by the
+    <var>[rose-suite-run]root-dir*</var> settings in the Rose site/user
+    configuration.</p>
+
+    <h2 id="plugins">Plugins</h2>
 
     <p>There are gedit, kate, and vim plugins for syntax highlighting of Rose
     configuration files, located at:</p>
@@ -129,6 +137,11 @@ geditor=gvim -f
     <p><samp>$ROSE_HOME</samp> should be replaced with the path to the root
     directory of your local Rose installation, which you can locate by running
     <code>rose --version</code>. See the files themselves for setup notes.</p>
+
+    <p>You may want to set up cylc-specific text editor plugins - see the
+    <a href=
+    "http://cylc.github.io/cylc/html/single/cug-html.html#x1-530008.2">Cylc
+    User Guide</a> for details.</p>
   </div>
 </body>
 </html>

--- a/lib/python/rose/suite_engine_proc.py
+++ b/lib/python/rose/suite_engine_proc.py
@@ -135,6 +135,16 @@ class CycleOffset(object):
         return timedelta(**{timedelta_unit: multiplier * amount})
 
 
+class SuiteEngineGlobalConfCompatError(Exception):
+
+    """An exception raised on incompatible global configuration."""
+
+    def __str__(self):
+        engine, key, value = self.args
+        return ("%s global configuration incompatible to Rose: %s=%s" %
+                (engine, key, value))
+
+
 class StillRunningError(Exception):
 
     """An exception raised when a suite is still running."""
@@ -262,6 +272,14 @@ class SuiteEngineProcessor(object):
         if fs_util is None:
             fs_util = FileSystemUtil(event_handler)
         self.fs_util = fs_util
+
+    def check_global_conf_compat(self):
+        """Raise exception on suite engine specific incompatibity.
+
+        Should raise SuiteEngineGlobalConfCompatError.
+
+        """
+        raise NotImplementedError()
 
     def clean_hook(self, suite_name=None):
         """Run suite engine dependent logic (at end of "rose suite-clean")."""

--- a/lib/python/rose/suite_run.py
+++ b/lib/python/rose/suite_run.py
@@ -107,6 +107,9 @@ class SuiteRunner(Runner):
             log_context = ReporterContext(None, self.event_handler.VV, f)
             self.event_handler.contexts[uuid] = log_context
 
+        # Check suite engine specific compatibility
+        self.suite_engine_proc.check_global_conf_compat()
+
         # Suite name from the current working directory
         if opts.conf_dir:
             self.fs_util.chdir(opts.conf_dir)


### PR DESCRIPTION
`rose suite-run` will now raise an exception if `[host][localhost]run directory` and `[host][localhost]work directory` are not the defaults.

Close #945.
