### PR TITLE
rose edit: fix macro metadata setting for section

### DIFF
--- a/lib/python/rose/config_editor/data.py
+++ b/lib/python/rose/config_editor/data.py
@@ -1144,6 +1144,7 @@ class ConfigDataManager(object):
                         # ns created from variables, not a section - no title.
                         continue
                     if key == rose.META_PROP_MACRO:
+                        macro_info = value
                         if key in ns_metadata:
                             ns_metadata[rose.META_PROP_MACRO] += ", " + macro_info
                         else:


### PR DESCRIPTION
This fixes setting a `macro=my_module.MacroTransformClass` metadata option on a section.

@arjclark, please review.

This can be tested by setting the contents of `demo/rose-config-edit/demo_meta/app/05-validate/meta/rose-meta.conf` to read:

```
[env]
macro=fib.FibonacciChecker
```

and then launching rose edit for that app.
