### PR TITLE
rose edit: fix custom macro status bar reporting

### DIFF
--- a/lib/python/rose/config_editor/menu.py
+++ b/lib/python/rose/config_editor/menu.py
@@ -724,7 +724,9 @@ class MainMenuHandler(object):
                 all_conf_text = self._format_macro_config_names(configs)
                 self.reporter.report(null_format.format(all_conf_text),
                                      kind=self.reporter.KIND_OUT)
-        return len(config_macro_errors) + len(config_macro_changes)
+        num_errors = sum([e[2] for e in config_macro_errors])
+        num_changes = sum([c[2] for c in config_macro_changes])
+        return num_errors + num_changes
 
     def _format_macro_config_names(self, config_names):
         if len(config_names) > 5:


### PR DESCRIPTION
This fixes a problem in `rose edit` where the status bar erroneously reports errors from custom macros.

The problem can be replicated by running `rose edit` on the `demo/rose-config-edit/demo_meta/app/05-validate` app, removing the environment variables, and clicking the "Check fail-if, warn-if, and run all custom validator macros" toolbar button. Although no errors will be reported by the individual macros on the command line, the summary of the individual macros will count a non-zero amount of errors.

@arjclark, please review.
