### PR TITLE
rose_arch: fix mtime+size file source record

### DIFF
--- a/lib/python/rose/checksum.py
+++ b/lib/python/rose/checksum.py
@@ -49,12 +49,12 @@ def get_checksum(name, checksum_func=None):
 
     if checksum_func is None:
         checksum_func = get_checksum_func()
-    name = os.path.normpath(name)
     path_and_checksum_list = []
     if os.path.isfile(name):
-        checksum = checksum_func(name, name)
+        checksum = checksum_func(name, "")
         path_and_checksum_list.append(("", checksum))
     else: # if os.path.isdir(path):
+        name = os.path.normpath(name)
         path_and_checksum_list = []
         for dirpath, dirnames, filenames in os.walk(name):
             path = dirpath[len(name) + 1:]
@@ -100,6 +100,8 @@ def _md5_hexdigest(source, root):
 def _mtime_and_size(source, root):
     """Return a string containing the name, its modified time and its size."""
     stat = os.stat(os.path.realpath(source))
-    return os.pathsep.join(["source=" + os.path.relpath(source, root),
+    if root:
+        source = os.path.relpath(source, root)
+    return os.pathsep.join(["source=" + source,
                             "mtime=" + str(stat.st_mtime),
                             "size=" + str(stat.st_size)])

--- a/t/rose-task-run/04-app-arch-db-2013010100-1.out
+++ b/t/rose-task-run/04-app-arch-db-2013010100-1.out
@@ -14,7 +14,7 @@ foo://2013010100/hello/worlds/uranus.txt||foo put %(target)s %(sources)s; echo '
 foo://2013010100/hello/worlds/dark-matter.txt|hello/dark-matter.txt|d849987cf8a372771652794bc80ee175
 foo://2013010100/hello/worlds/earth.txt|hello/earth.txt|25205c990e801b32e192f72c362d97eb
 foo://2013010100/hello/worlds/jupiter-moons.tar.gz|hello/jupiter-1.txt|cf77cebd08316ae60133c75fcbaeb4ce
-foo://2013010100/hello/worlds/jupiter.txt|hello/jupiter.txt|source=.:mtime=1321819860.0:size=27
+foo://2013010100/hello/worlds/jupiter.txt|hello/jupiter.txt|source=$ROSE_DATAC/hello/jupiter.txt:mtime=1321819860.0:size=27
 foo://2013010100/hello/worlds/neptune-1.txt|hello/neptune-1.txt|f390e332a8dc1186a9c81353cd7f1023
 foo://2013010100/hello/worlds/organisms.tar.gz|hello/organisms/animals/crocodile.txt|2984b5f5271a31321c97c707ff2e3e6a
 foo://2013010100/hello/worlds/organisms.tar.gz|hello/organisms/animals/elephant.txt|66a7288e1580a8f43c232ebf36920eda

--- a/t/rose-task-run/04-app-arch-db-2013010100-2.out
+++ b/t/rose-task-run/04-app-arch-db-2013010100-2.out
@@ -14,7 +14,7 @@ foo://2013010100/hello/worlds/uranus.txt||foo put %(target)s %(sources)s; echo '
 foo://2013010100/hello/worlds/dark-matter.txt|hello/dark-matter.txt|d849987cf8a372771652794bc80ee175
 foo://2013010100/hello/worlds/earth.txt|hello/earth.txt|25205c990e801b32e192f72c362d97eb
 foo://2013010100/hello/worlds/jupiter-moons.tar.gz|hello/jupiter-1.txt|cf77cebd08316ae60133c75fcbaeb4ce
-foo://2013010100/hello/worlds/jupiter.txt|hello/jupiter.txt|source=.:mtime=1356034320.0:size=27
+foo://2013010100/hello/worlds/jupiter.txt|hello/jupiter.txt|source=$ROSE_DATAC/hello/jupiter.txt:mtime=1356034320.0:size=27
 foo://2013010100/hello/worlds/neptune-1.txt|hello/neptune-1.txt|f390e332a8dc1186a9c81353cd7f1023
 foo://2013010100/hello/worlds/organisms.tar.gz|hello/organisms/animals/crocodile.txt|2984b5f5271a31321c97c707ff2e3e6a
 foo://2013010100/hello/worlds/organisms.tar.gz|hello/organisms/animals/elephant.txt|66a7288e1580a8f43c232ebf36920eda

--- a/t/rose-task-run/04-app-arch-db-2013010112-1.out
+++ b/t/rose-task-run/04-app-arch-db-2013010112-1.out
@@ -14,7 +14,7 @@ foo://2013010112/hello/worlds/uranus.txt||foo put %(target)s %(sources)s; echo '
 foo://2013010112/hello/worlds/dark-matter.txt|hello/dark-matter.txt|0752d8326a675d55ed2568648b347faf
 foo://2013010112/hello/worlds/earth.txt|hello/earth.txt|58a85149e24a2f26af37bbe10d0b4fef
 foo://2013010112/hello/worlds/jupiter-moons.tar.gz|hello/jupiter-1.txt|265db2877a7af1802852a73e2a076ed5
-foo://2013010112/hello/worlds/jupiter.txt|hello/jupiter.txt|source=.:mtime=1321819860.0:size=27
+foo://2013010112/hello/worlds/jupiter.txt|hello/jupiter.txt|source=$ROSE_DATAC/hello/jupiter.txt:mtime=1321819860.0:size=27
 foo://2013010112/hello/worlds/neptune-1.txt|hello/neptune-1.txt|5b8a580f298b438f6d4809220bb93f6c
 foo://2013010112/hello/worlds/organisms.tar.gz|hello/organisms/animals/crocodile.txt|c8ab09ebc9f0ea252c85e3226cd4bf1b
 foo://2013010112/hello/worlds/organisms.tar.gz|hello/organisms/animals/elephant.txt|8dd338fe56dd28f396e1c75c94734c19

--- a/t/rose-task-run/04-app-arch-db-2013010112-2.out
+++ b/t/rose-task-run/04-app-arch-db-2013010112-2.out
@@ -14,7 +14,7 @@ foo://2013010112/hello/worlds/uranus.txt||foo put %(target)s %(sources)s; echo '
 foo://2013010112/hello/worlds/dark-matter.txt|hello/dark-matter.txt|0752d8326a675d55ed2568648b347faf
 foo://2013010112/hello/worlds/earth.txt|hello/earth.txt|58a85149e24a2f26af37bbe10d0b4fef
 foo://2013010112/hello/worlds/jupiter-moons.tar.gz|hello/jupiter-1.txt|265db2877a7af1802852a73e2a076ed5
-foo://2013010112/hello/worlds/jupiter.txt|hello/jupiter.txt|source=.:mtime=1356034320.0:size=27
+foo://2013010112/hello/worlds/jupiter.txt|hello/jupiter.txt|source=$ROSE_DATAC/hello/jupiter.txt:mtime=1356034320.0:size=27
 foo://2013010112/hello/worlds/neptune-1.txt|hello/neptune-1.txt|5b8a580f298b438f6d4809220bb93f6c
 foo://2013010112/hello/worlds/organisms.tar.gz|hello/organisms/animals/crocodile.txt|c8ab09ebc9f0ea252c85e3226cd4bf1b
 foo://2013010112/hello/worlds/organisms.tar.gz|hello/organisms/animals/elephant.txt|8dd338fe56dd28f396e1c75c94734c19

--- a/t/rose-task-run/04-app-arch-db-2013010200-1.out
+++ b/t/rose-task-run/04-app-arch-db-2013010200-1.out
@@ -14,7 +14,7 @@ foo://2013010200/hello/worlds/uranus.txt||foo put %(target)s %(sources)s; echo '
 foo://2013010200/hello/worlds/dark-matter.txt|hello/dark-matter.txt|f95326c55075aa12d3a3aaf5958dbe67
 foo://2013010200/hello/worlds/earth.txt|hello/earth.txt|dde4e4b505256a1fe9f30fe80b892d24
 foo://2013010200/hello/worlds/jupiter-moons.tar.gz|hello/jupiter-1.txt|2771a019e844e7064e83c62c05899b29
-foo://2013010200/hello/worlds/jupiter.txt|hello/jupiter.txt|source=.:mtime=1321819860.0:size=27
+foo://2013010200/hello/worlds/jupiter.txt|hello/jupiter.txt|source=$ROSE_DATAC/hello/jupiter.txt:mtime=1321819860.0:size=27
 foo://2013010200/hello/worlds/neptune-1.txt|hello/neptune-1.txt|cb38085eee420b15d56f8f701f988fe0
 foo://2013010200/hello/worlds/organisms.tar.gz|hello/organisms/animals/crocodile.txt|9bfd75677f1d17b743d9d0d7c9b829d3
 foo://2013010200/hello/worlds/organisms.tar.gz|hello/organisms/animals/elephant.txt|00f9c60bc048ae85ded02eda20ff2a13

--- a/t/rose-task-run/04-app-arch-db-2013010200-2.out
+++ b/t/rose-task-run/04-app-arch-db-2013010200-2.out
@@ -14,7 +14,7 @@ foo://2013010200/hello/worlds/uranus.txt||foo put %(target)s %(sources)s; echo '
 foo://2013010200/hello/worlds/dark-matter.txt|hello/dark-matter.txt|f95326c55075aa12d3a3aaf5958dbe67
 foo://2013010200/hello/worlds/earth.txt|hello/earth.txt|dde4e4b505256a1fe9f30fe80b892d24
 foo://2013010200/hello/worlds/jupiter-moons.tar.gz|hello/jupiter-1.txt|2771a019e844e7064e83c62c05899b29
-foo://2013010200/hello/worlds/jupiter.txt|hello/jupiter.txt|source=.:mtime=1356034320.0:size=27
+foo://2013010200/hello/worlds/jupiter.txt|hello/jupiter.txt|source=$ROSE_DATAC/hello/jupiter.txt:mtime=1356034320.0:size=27
 foo://2013010200/hello/worlds/neptune-1.txt|hello/neptune-1.txt|cb38085eee420b15d56f8f701f988fe0
 foo://2013010200/hello/worlds/organisms.tar.gz|hello/organisms/animals/crocodile.txt|9bfd75677f1d17b743d9d0d7c9b829d3
 foo://2013010200/hello/worlds/organisms.tar.gz|hello/organisms/animals/elephant.txt|00f9c60bc048ae85ded02eda20ff2a13

--- a/t/rose-task-run/04-app-arch.t
+++ b/t/rose-task-run/04-app-arch.t
@@ -70,9 +70,10 @@ for CYCLE in 2013010100 2013010112 2013010200; do
         "$TEST_KEY-$CYCLE.out" "$TEST_KEY-$CYCLE.out.expected"
     TEST_KEY="$TEST_KEY_BASE-db"
     for TRY in 1 2; do
-        ACTUAL=$SUITE_RUN_DIR/work/archive.$CYCLE/rose-arch-db-$TRY.out
-        file_cmp "$TEST_KEY-$CYCLE.out" \
-            "$TEST_SOURCE_DIR/$TEST_KEY-$CYCLE-$TRY.out" $ACTUAL
+        FILE=$SUITE_RUN_DIR/work/archive.$CYCLE/rose-arch-db-$TRY.out
+        sed "s?\\\$ROSE_DATAC?$SUITE_RUN_DIR/share/data/$CYCLE?" \
+            "$TEST_SOURCE_DIR/$TEST_KEY-$CYCLE-$TRY.out" >$FILE.expected
+        file_cmp "$TEST_KEY-$CYCLE.out" $FILE.expected $FILE
     done
     for KEY in dark-matter.txt jupiter.txt try.nl uranus.txt; do
         TEST_KEY="$TEST_KEY_BASE-$CYCLE-grep-$KEY-foo-log-2"


### PR DESCRIPTION
A file source using `mtime+size` as the `update-check` does not get
stored uniquely. If a number of sources have the same mtimes and sizes,
they will not be archived. This change fixes the problem.
