### PR TITLE
t/rose-suite-hook/00: fix instability

### DIFF
--- a/t/rose-suite-hook/00-shutdown/suite.rc
+++ b/t/rose-suite-hook/00-shutdown/suite.rc
@@ -1,9 +1,9 @@
 #!jinja2
 [cylc]
-    UTC mode = True
+    UTC mode=True
     [[event hooks]]
-        timeout handler = "rose suite-hook --shutdown"
-        timeout = 1
+        timeout handler=rose suite-hook --shutdown
+        timeout=1
 [scheduling]
     [[dependencies]]
         graph = """
@@ -14,14 +14,14 @@ my_task_2
 [runtime]
     [[root]]
         [[[event hooks]]]
-           succeeded handler = "rose suite-hook"
-           failed handler = "rose suite-hook --shutdown"
-           submission failed handler = "rose suite-hook --shutdown"
-           submission timeout handler = "rose suite-hook"
-           execution timeout handler = "rose suite-hook"
-           submission timeout = 1
-           execution timeout  = 1
+           succeeded handler=rose suite-hook
+           failed handler=rose suite-hook --shutdown
+           submission failed handler=rose suite-hook --shutdown
+           submission timeout handler=rose suite-hook
+           execution timeout handler=rose suite-hook
+           submission timeout=1
+           execution timeout=1
     [[my_task_1]]
-        command scripting = "false"
+        command scripting=false
     [[my_task_2]]
-        command scripting = "sleep 600"
+        command scripting=true


### PR DESCRIPTION
`sleep 600` is still attached to some devices which causes an NFS resource busy problem on suite clean. It is not really necessary for this test, so I have changed it to `true`.
