### PR TITLE
rose-bush.js: fix format string and int rounding

### DIFF
--- a/lib/html/rose-bush/rose-bush.js
+++ b/lib/html/rose-bush/rose-bush.js
@@ -54,7 +54,7 @@ $(function() {
         else {
             s = s.toString();
         }
-        var m = Math.round(dt.asMinutes());
+        var m = Math.floor(dt.asMinutes());
         return m.toString() + ":" + s;
     }
     var toggle_fuzzy_time = function(on) {
@@ -111,7 +111,7 @@ $(function() {
                 var m_init = moment(s_init);
                 if (m_init.isSame(m_submit, "day")) {
                     m_init.utc();
-                    s_init = m_init.format("HH:mm:SS");
+                    s_init = m_init.format("HH:mm:ss");
                 }
                 $(".t_init", this).text(s_init);
                 var s_exit = $(".t_exit", this).attr("title");
@@ -124,7 +124,7 @@ $(function() {
                 var m_exit = moment(s_exit);
                 if (m_exit.isSame(m_submit, "day")) {
                     m_exit.utc();
-                    s_exit = m_exit.format("HH:mm:SS");
+                    s_exit = m_exit.format("HH:mm:ss");
                 }
                 $(".t_exit", this).text(s_exit);
             });


### PR DESCRIPTION
1. Correct format string for seconds in a minute.
2. Use `Math.floor` instead of `Math.round`.

Reported by @steoxley.
