### PR TITLE
rose mpi-launch: fix script exit syntax

### DIFF
--- a/bin/rose-mpi-launch
+++ b/bin/rose-mpi-launch
@@ -127,8 +127,13 @@ while (($# > 0)); do
                 OPT $ROSE_LAUNCHER_ULIMIT_OPTS
             do
                 case "$OPT" in
-                  '?') return 1;;
-                    *) ulimit -$OPT $OPTARG || return $?;;
+                  '?')
+                      err "ROSE_LAUNCHER_ULIMIT_OPTS=$ROSE_LAUNCHER_ULIMIT_OPTS"
+                      :;;
+                    *)
+                      ulimit -$OPT $OPTARG || err \
+                          "ROSE_LAUNCHER_ULIMIT_OPTS=$ROSE_LAUNCHER_ULIMIT_OPTS"
+                      :;;
                 esac
             done
         fi

--- a/t/rose-mpi-launch/01-command-inner.t
+++ b/t/rose-mpi-launch/01-command-inner.t
@@ -21,7 +21,7 @@
 #-------------------------------------------------------------------------------
 . $(dirname $0)/test_header
 #-------------------------------------------------------------------------------
-tests 6
+tests 12
 #-------------------------------------------------------------------------------
 # Basic.
 TEST_KEY=$TEST_KEY_BASE
@@ -33,12 +33,33 @@ __OUT__
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
 #-------------------------------------------------------------------------------
 # Use ROSE_LAUNCHER_ULIMIT_OPTS.
-TEST_KEY=$TEST_KEY_BASE
+TEST_KEY=$TEST_KEY_BASE-ulimit-good
 ROSE_LAUNCHER_ULIMIT_OPTS='-s unlimited' \
     run_pass "$TEST_KEY" rose mpi-launch --inner bash -c 'ulimit -s'
 file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<'__OUT__'
 unlimited
 __OUT__
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+#-------------------------------------------------------------------------------
+# Use bad ROSE_LAUNCHER_ULIMIT_OPTS.
+TEST_KEY=$TEST_KEY_BASE-ulimit-bad-opt
+ROSE_LAUNCHER_ULIMIT_OPTS='-Z' run_fail "$TEST_KEY" rose mpi-launch --inner true
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
+sed -i '1d' "$TEST_KEY.err" # bash error string may not be portable
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" <<__ERR__
+[FAIL] ROSE_LAUNCHER_ULIMIT_OPTS=-Z
+[FAIL] exit 1
+__ERR__
+#-------------------------------------------------------------------------------
+# Use bad argument in ROSE_LAUNCHER_ULIMIT_OPTS.
+TEST_KEY=$TEST_KEY_BASE-ulimit-bad-opt-arg
+ROSE_LAUNCHER_ULIMIT_OPTS='-s bad' run_fail "$TEST_KEY" \
+    rose mpi-launch --inner true
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
+sed -i '1d' "$TEST_KEY.err" # bash error string may not be portable
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" <<__ERR__
+[FAIL] ROSE_LAUNCHER_ULIMIT_OPTS=-s bad
+[FAIL] exit 1
+__ERR__
 #-------------------------------------------------------------------------------
 exit


### PR DESCRIPTION
The on-error `return` statements under `--inner` do not work under
`bash` and may confuse users into thinking that there may be some other
problems. This change should allow errors to be reported with less
confusion.
