### PR TITLE
rose suite-run: fix hang if prev cylc gui open

### DIFF
--- a/lib/python/rose/suite_engine_procs/cylc.py
+++ b/lib/python/rose/suite_engine_procs/cylc.py
@@ -655,7 +655,7 @@ class CylcProcessor(SuiteEngineProcessor):
                     tar.add(name)
                 tar.close()
                 # N.B. Python's gzip is slow
-                self.popen.run_simple("gzip", archive_file_name0)
+                self.popen.run_simple("gzip", "-f", archive_file_name0)
                 self.handle_event(FileSystemEvent(FileSystemEvent.CREATE,
                                                   archive_file_name))
                 for name in sorted(names):

--- a/lib/python/rose/suite_run.py
+++ b/lib/python/rose/suite_run.py
@@ -392,6 +392,11 @@ class SuiteRunner(Runner):
                 suite_name, host, environ, opts.run_mode, args)
         open("rose-suite-run.host", "w").write(host + "\n")
 
+        # Disconnect log file handle, so monitoring tool command will no longer
+        # be associated with the log file.
+        self.event_handler.contexts[uuid].handle.close()
+        self.event_handler.contexts.pop(uuid)
+
         # Launch the monitoring tool
         # Note: maybe use os.ttyname(sys.stdout.fileno())?
         if os.getenv("DISPLAY") and host and opts.gcontrol_mode:
@@ -511,7 +516,7 @@ class SuiteRunner(Runner):
                 f.add(log)
                 f.close()
                 # N.B. Python's gzip is slow
-                self.popen.run_simple("gzip", log_tar)
+                self.popen.run_simple("gzip", "-f", log_tar)
                 self.handle_event(SuiteLogArchiveEvent(log_tar + ".gz", log))
                 self.fs_util.delete(log)
 


### PR DESCRIPTION
If `cylc gui` launched by the previous `rose suite-run` is still open,
the `rose suite-run` command fails, and any subsequent invocation hangs.
There are 2 problems:
1. `log/rose-suite-run.log` is still considered opened by `cylc gui`.
   (It looks like the process has inherited the file handle, even though
   it is launched by `nohup`). When the new `rose suite-run` tries to
   remove the log directory, it is unable to do so. This change closes
   the file before launching `cylc gui`.
2. Problem 1 creates a `log-DATETIME.tar.gz` file, but left
   `log-DATETIME/`. On subsequent invocation of `rose suite-run`, the
   `gzip` command hangs, waiting for an overwrite confirmation. This
   change calls `gzip` with `-f` to force an overwrite.
