### PR TITLE
Add failed jobs totals to cycles page.

### DIFF
--- a/lib/html/rose-bush/cycles.html
+++ b/lib/html/rose-bush/cycles.html
@@ -95,7 +95,7 @@ role="dialog" aria-labelledby="suite-info-label" aria-hidden="true">
 <div class="span3">
 <a href="{{script}}/jobs/{{user}}/{{suite}}?cycles={{entry.cycle}}" class="cycle" title="{{entry.cycle}}">{{entry.cycle}}</a>
 </div>
-{% for state, icon, label in [("active", "play", "info"), ("success", "ok", "success"), ("fail", "warning-sign", "important")] -%}
+{% for state, icon, label, title in [("active", "play", "info", "active tasks"), ("success", "ok", "success", "succeeded tasks"), ("fail", "warning-sign", "important", "failed tasks")] -%}
 {% set n_state = entry.n_states[state] -%}
 <div class="span2">
 {% if n_state -%}
@@ -105,8 +105,9 @@ role="dialog" aria-labelledby="suite-info-label" aria-hidden="true">
 <span class="label{% if n_state %} label-{{label}}{% endif %}">
 <i class="icon-{{icon}} icon-white" title="{{state}}"></i>
 </span>
-<span class="badge{% if n_state %}  badge-{{label}}{% endif %}">{{entry.n_states[state]}}</span>
+<span class="badge{% if n_state %}  badge-{{label}}{% endif %}" title="{{title}}">{{entry.n_states[state]}}</span>
 {% if n_state %}</a>{% endif %}
+{% if state=="fail" and entry.n_states["job_fails"] > 0 %}(<span class="badge  badge-{{label}}" title="job failures">{{entry.n_states["job_fails"]}}</span>){% endif %}
 </div>
 {% endfor -%}
 </div>

--- a/lib/html/rose-bush/jobs.html
+++ b/lib/html/rose-bush/jobs.html
@@ -141,8 +141,8 @@ value="{{per_page}}"
 />
 </div>
 <div class="span3">
-{% for status in ["active", "success", "fail"] -%}
-<label class="checkbox inline" for="no_status_{{status}}">
+{% for status, title in [["active", "active tasks"], ["success", "succeeded tasks"], ["fail", "failed tasks"]] -%}
+<label class="checkbox inline" for="no_status_{{status}}" title="Hide {{title}}">
 <input id="no_status_{{status}}" type="checkbox" name="no_status"
 {% if no_statuses and status in no_statuses -%}
 checked="checked"


### PR DESCRIPTION
This adds a count of the number of _jobs_ that have failed in a given cycle to the cycles summary page (in addition to the failed tasks counter).

Also includes some hover over additions to the icons and counts on the cycle pages to clarify that it is tasks being looked at and adds hover over labels to the jobs page filters (no success? etc.) to clarify they're hiding succeeded tasks, failed tasks etc.
