### PR TITLE
rosie ws: fix trac links.

### DIFF
--- a/lib/python/rosie/suite_id.py
+++ b/lib/python/rosie/suite_id.py
@@ -188,6 +188,17 @@ class SuiteId(object):
         return local_copy_root
 
     @classmethod
+    def from_idx_branch_revision(cls, idx, branch=None, revision=None):
+        id_ = cls(id_text=idx)
+        if not branch:
+            branch = self.BRANCH_TRUNK
+        if not revision:
+            revision = self.REV_HEAD
+        id_.branch = branch
+        id_.revision = revision
+        return cls(id_text=id_.to_string_with_version())
+
+    @classmethod
     def get_next(cls, prefix=None):
         """Return the next available ID in a repository."""
         id = cls.get_latest(prefix)

--- a/lib/python/rosie/ws.py
+++ b/lib/python/rosie/ws.py
@@ -122,7 +122,8 @@ class PrefixRoot(object):
     def _render(self, all_revs=False, data=None, filters=None, s=None):
         if data:
             for item in data:
-                suite_id = SuiteId(id_text=item["idx"])
+                suite_id = SuiteId.from_idx_branch_revision(
+                    item["idx"], item["branch"], item["revision"])
                 item["href"] = suite_id.to_web()
         template = self.template_env.get_template("prefix-index.html")
         return template.render(


### PR DESCRIPTION
This fixes the generated trac links for the Rosie
web page. These incorrectly give `trunk` and `HEAD`
for the branch and revision for each suite.

The links should now reflect the correct branch
and revision.

@matthewrmshin, please review.
