### PR TITLE
Fix t/rose-mpi-launch --inner: use numeric ulimit

### DIFF
--- a/t/rose-mpi-launch/01-command-inner.t
+++ b/t/rose-mpi-launch/01-command-inner.t
@@ -34,11 +34,15 @@ file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
 #-------------------------------------------------------------------------------
 # Use ROSE_LAUNCHER_ULIMIT_OPTS.
 TEST_KEY=$TEST_KEY_BASE-ulimit-good
-ROSE_LAUNCHER_ULIMIT_OPTS='-s unlimited' \
+ULIMIT_STACK=$(ulimit -s)
+if [[ $ULIMIT_STACK == 'unlimited' ]]; then
+    ULIMIT_STACK_NEW=$ULIMIT_STACK
+else
+    ULIMIT_STACK_NEW=$(($(ulimit -s) / 2))
+fi
+ROSE_LAUNCHER_ULIMIT_OPTS="-s $ULIMIT_STACK_NEW" \
     run_pass "$TEST_KEY" rose mpi-launch --inner bash -c 'ulimit -s'
-file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<'__OUT__'
-unlimited
-__OUT__
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<<$ULIMIT_STACK_NEW
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
 #-------------------------------------------------------------------------------
 # Use bad ROSE_LAUNCHER_ULIMIT_OPTS.


### PR DESCRIPTION
Previously it uses `ulimit -s unlimited`. Some sites do not like this. A
numeric value based on half the site limit should work better for them.
