### PR TITLE
rose metadata-check: remove gtk dependence.

### DIFF
--- a/lib/python/rose/config_editor/__init__.py
+++ b/lib/python/rose/config_editor/__init__.py
@@ -255,7 +255,6 @@ ERROR_LOAD_OPT_CONFS = "Could not load optional configurations:\n{0}"
 ERROR_LOAD_OPT_CONFS_FORMAT = "{0}\n    {1}: {2}\n"
 ERROR_LOAD_OPT_CONFS_TITLE = "Error loading opt configs"
 ERROR_LOAD_SYNTAX = "Could not load path: {0}\n\nSyntax error:\n{0}\n{1}"
-ERROR_LOCATE_OBJECT = "Could not locate {0}"
 ERROR_METADATA_CHECKER_TITLE = "Flawed metadata warning"
 ERROR_METADATA_CHECKER_TEXT = (
                        "{0} problem(s) found in metadata at {1}.\n" +

--- a/lib/python/rose/config_editor/page.py
+++ b/lib/python/rose/config_editor/page.py
@@ -37,6 +37,7 @@ import rose.config_editor.variable
 import rose.formats
 import rose.gtk.dialog
 import rose.gtk.util
+import rose.resource
 import rose.variable
 
 
@@ -468,7 +469,7 @@ class ConfigPage(gtk.VBox):
                                              (widget_dir in x))
             prefix = re.sub("[^\w]", "_", self.config_name.strip("/"))
             prefix += "/" + rose.META_DIR_WIDGET + "/"
-            custom_widget = rose.config_editor.util.import_object(
+            custom_widget = rose.resource.import_object(
                                         widget_path,
                                         metadata_files,
                                         self.handle_bad_custom_sub_widget,
@@ -642,7 +643,7 @@ class ConfigPage(gtk.VBox):
                 widget_path, widget_args = widget_name_args[0], None
             metadata_files = self.section_ops.get_ns_metadata_files(
                                                   self.namespace)
-            custom_widget = rose.config_editor.util.import_object(
+            custom_widget = rose.resource.import_object(
                                         widget_path,
                                         metadata_files,
                                         self.handle_bad_custom_main_widget)

--- a/lib/python/rose/config_editor/util.py
+++ b/lib/python/rose/config_editor/util.py
@@ -108,66 +108,6 @@ class ImportWidgetError(Exception):
         return self.args[0]
 
 
-def import_object(import_string, from_files, error_handler,
-                  module_prefix=None):
-    """Import a Python callable.
-
-    import_string is the '.' delimited path to the callable,
-    as in normal Python - e.g.
-    rose.config_editor.pagewidget.table.PageTable
-    from_files is a list of available Python file paths to search in
-    error_handler is a function that accepts an Exception instance
-    or string and does something appropriate with it.
-    module_prefix is an optional string to prepend to the module
-    as an alias - this avoids any clashing between same-name modules.
-
-    """
-    is_builtin = False
-    module_name = ".".join(import_string.split(".")[:-1])
-    if module_name.startswith("rose."):
-        is_builtin = True
-    if module_prefix is None:
-        as_name = module_name
-    else:
-        as_name = module_prefix + module_name
-    class_name = import_string.split(".")[-1]
-    module_fpath = "/".join(import_string.rsplit(".")[:-1]) + ".py"
-    if module_fpath == ".py":
-        # Empty module.
-        return None
-    module_files = [f for f in from_files if f.endswith(module_fpath)]
-    if not module_files and not is_builtin:
-        return None
-    module_dirs = set([os.path.dirname(f) for f in module_files])
-    module = None
-    if is_builtin:
-        try:
-            module = __import__(module_name, globals(), locals(),
-                                [], 0)
-        except Exception as e:
-            error_handler(e)
-    else:
-        for filename in module_files:
-            sys.path.insert(0, os.path.dirname(filename))
-            try:
-                module = imp.load_source(as_name, filename)
-            except Exception as e:
-                error_handler(e)
-            sys.path.pop(0)
-    if module is None:
-        error_handler(
-              rose.config_editor.ERROR_LOCATE_OBJECT.format(module_name))
-        return None
-    for submodule in module_name.split(".")[1:]:
-        module = getattr(module, submodule)
-    contents = inspect.getmembers(module)
-    return_object = None
-    for obj_name, obj in contents:
-        if obj_name == class_name and inspect.isclass(obj):
-            return_object = obj
-    return return_object
-
-
 def launch_node_info_dialog(node, changes, search_function):
     """Launch a dialog displaying attributes of a variable or section."""
     title = node.__class__.__name__ + " " + node.metadata['id']

--- a/lib/python/rose/config_editor/variable.py
+++ b/lib/python/rose/config_editor/variable.py
@@ -39,6 +39,7 @@ import rose.config_editor.util
 import rose.gtk.dialog
 import rose.gtk.util
 import rose.reporter
+import rose.resource
 
 
 class VariableWidget(object):
@@ -165,9 +166,9 @@ class VariableWidget(object):
             widget_fpath = os.path.join(lib, *widget_path.split(".")[:-1])
             error_handler = lambda e: self.handle_bad_valuewidget(
                                            str(e), variable, set_value)
-            widget = rose.config_editor.util.import_object(widget_path,
-                                                           files,
-                                                           error_handler)
+            widget = rose.resource.import_object(widget_path,
+                                                 files,
+                                                 error_handler)
             if widget is None:
                 text = rose.config_editor.ERROR_IMPORT_CLASS.format(
                                                                w_val)

--- a/lib/python/rose/metadata_check.py
+++ b/lib/python/rose/metadata_check.py
@@ -24,12 +24,12 @@ import re
 import sys
 
 import rose.config
-import rose.config_editor.util
 import rose.formats.namelist
 import rose.macro
 import rose.macros
 import rose.opt_parse
 import rose.reporter
+import rose.resource
 
 
 ERROR_LOAD_META_CONFIG_DIR = "{0}: not a configuration metadata directory."
@@ -94,10 +94,9 @@ def _check_macro(value, module_files=None, meta_dir=None):
             macro.endswith("." + rose.macro.TRANSFORM_METHOD)):
             macro_name, method = macro.rsplit(".", 1)
         try:
-            macro_obj = rose.config_editor.util.import_object(
-                                                       macro_name,
-                                                       module_files,
-                                                       _import_err_handler)
+            macro_obj = rose.resource.import_object(macro_name,
+                                                    module_files,
+                                                    _import_err_handler)
         except Exception as e:
             return INVALID_IMPORT.format(
                                   macro,
@@ -189,12 +188,12 @@ def _check_widget(value, module_files=None, meta_dir=None):
         return
     widget_name = value.split()[0]
     try:
-        widget = rose.config_editor.util.import_object(widget_name,
-                                                       module_files,
-                                                       _import_err_handler)
+        widget = rose.resource.import_object(widget_name,
+                                             module_files,
+                                             _import_err_handler)
     except Exception as e:
         return INVALID_IMPORT.format(widget_name,
-                                            type(e).__name__ + ": " + str(e))
+                                     type(e).__name__ + ": " + str(e))
     if widget is None:
         return INVALID_OBJECT.format(value)
 

--- a/lib/python/rose/resource.py
+++ b/lib/python/rose/resource.py
@@ -23,10 +23,15 @@ Convenient functions for searching resource files.
 
 import os
 from rose.config import ConfigLoader, ConfigNode
+import imp
+import inspect
 import string
 import sys
 
+
+ERROR_LOCATE_OBJECT = "Could not locate {0}"
 _DEFAULT_RESOURCE_LOCATOR = None
+
 
 class ResourceError(Exception):
 
@@ -145,6 +150,67 @@ class ResourceLocator(object):
                 return file
         raise ResourceError(key)
 
+
 def resource_locate(key):
     """Return the location of the resource key."""
     return ResourceLocator.default().locate(key)
+
+
+def import_object(import_string, from_files, error_handler,
+                  module_prefix=None):
+    """Import a Python callable.
+
+    import_string is the '.' delimited path to the callable,
+    as in normal Python - e.g.
+    rose.config_editor.pagewidget.table.PageTable
+    from_files is a list of available Python file paths to search in
+    error_handler is a function that accepts an Exception instance
+    or string and does something appropriate with it.
+    module_prefix is an optional string to prepend to the module
+    as an alias - this avoids any clashing between same-name modules.
+
+    """
+    is_builtin = False
+    module_name = ".".join(import_string.split(".")[:-1])
+    if module_name.startswith("rose."):
+        is_builtin = True
+    if module_prefix is None:
+        as_name = module_name
+    else:
+        as_name = module_prefix + module_name
+    class_name = import_string.split(".")[-1]
+    module_fpath = "/".join(import_string.rsplit(".")[:-1]) + ".py"
+    if module_fpath == ".py":
+        # Empty module.
+        return None
+    module_files = [f for f in from_files if f.endswith(module_fpath)]
+    if not module_files and not is_builtin:
+        return None
+    module_dirs = set([os.path.dirname(f) for f in module_files])
+    module = None
+    if is_builtin:
+        try:
+            module = __import__(module_name, globals(), locals(),
+                                [], 0)
+        except Exception as e:
+            error_handler(e)
+    else:
+        for filename in module_files:
+            sys.path.insert(0, os.path.dirname(filename))
+            try:
+                module = imp.load_source(as_name, filename)
+            except Exception as e:
+                error_handler(e)
+            sys.path.pop(0)
+    if module is None:
+        error_handler(
+              ERROR_LOCATE_OBJECT.format(module_name))
+        return None
+    for submodule in module_name.split(".")[1:]:
+        module = getattr(module, submodule)
+    contents = inspect.getmembers(module)
+    return_object = None
+    for obj_name, obj in contents:
+        if obj_name == class_name and inspect.isclass(obj):
+            return_object = obj
+    return return_object


### PR DESCRIPTION
This removes the gtk library dependence from
rose metadata-check and the test-battery tests
for it. The importing of widgets and macros
is now via a function in rose.resource.

@matthewrmshin, please test the test-battery change and review.
