### PR TITLE
rose edit: guarantee cwd for macros.

### DIFF
--- a/doc/rose-api.html
+++ b/doc/rose-api.html
@@ -792,6 +792,11 @@ class SomeTransformer(rose.macro.MacroBase):
         return config, self.reports
 </pre>
 
+    <p>The current working directory within a macro is always the
+    configuration's directory. This makes it easy to access
+    non-<samp>rose-app.conf</samp> files (e.g. in the <samp>file/</samp>
+    subdirectory).</p>
+
     <p>Macros also support the use of keyword arguments, giving you the ability
     to have the user specify some input or override to your macro. For example
     a transformer macro could be written as follows to allow the user to input


### PR DESCRIPTION
This change guarantees that a macro or upgrade macro
runs with a current working directory of the
relevant configuration directory within rose edit.

This is useful for altering other files in the configuration
besides the implicit altering of `rose-app.conf`.
