### PR TITLE
Create _REV and _BASE variables for all projects

### DIFF
--- a/lib/python/rose/stem.py
+++ b/lib/python/rose/stem.py
@@ -253,9 +253,9 @@ class StemRunner(object):
             else:
                 repos[project] = [ url ]
                 self._add_define_option('SOURCE_' + project.upper() + '_REV', 
-                                '"' + rev + '"')
+                                        '"' + rev + '"')
                 self._add_define_option('SOURCE_' + project.upper() + '_BASE', 
-                                '"' + base + '"')
+                                        '"' + base + '"')
             self.reporter(SourceTreeAddedAsBranchEvent(url))
         for project, branches in repos.iteritems():
             var = 'SOURCE_' + project.upper()


### PR DESCRIPTION
It would be helpful to create the SOURCE_project_REV and SOURCE_project_BASE variables for each project rather than just the first. This change alters the logic so the first source tree specified in any project sets these variables, rather than just the first source tree in the first project. A quick test running with maximum verbosity to list the variables being set shows that this is setting the needed variables which can then be picked up in a suite.
