### PR TITLE
rose documentation: add namelist input case convention

### DIFF
--- a/doc/rose-configuration.html
+++ b/doc/rose-configuration.html
@@ -134,6 +134,8 @@
       <li>Declarations are case sensitive. When dealing with case-insensitive
       inputs such as Fortran logicals or numbers in scientific notation,
       lowercase values should be used.</li>
+      
+      <li>When writing namelist inputs, keys should be lowercase.</li>
 
       <li>Declarations start at column 1. Continuations start at column &gt;1.
 


### PR DESCRIPTION
This adds a note on the namelist option lowercase convention,
which is checked by rose and should be considered
compulsory.

@arjclark, please review.
