### PR TITLE
rose edit, rosie go: filter all warnings by default.

### DIFF
--- a/lib/python/rose/config_editor/main.py
+++ b/lib/python/rose/config_editor/main.py
@@ -1795,6 +1795,8 @@ class MainController(object):
 def spawn_window(config_directory_path=None, debug_mode=False,
                  load_all_apps=False, load_no_apps=False, metadata_off=False):
     """Create a window and load the configuration into it. Run gtk."""
+    if not debug_mode:
+        warnings.filterwarnings('ignore')
     RESOURCER = rose.resource.ResourceLocator(paths=sys.path)
     rose.gtk.util.rc_setup(
         RESOURCER.locate('etc/rose-config-edit/.gtkrc-2.0'))

--- a/lib/python/rosie/browser/main.py
+++ b/lib/python/rosie/browser/main.py
@@ -30,6 +30,7 @@ import threading
 import time
 import traceback
 import urllib
+import warnings
 import webbrowser
 
 import pygtk
@@ -1365,6 +1366,8 @@ if __name__ == "__main__":
     number_of_events = 6
     splash_screen = rose.gtk.splash.SplashScreenProcess(logo, title,
                                                         number_of_events)
+    if not opts.debug_mode:
+        warnings.filterwarnings('ignore')
     try:
         MainWindow(opts, args, splash_screen)
     except BaseException as e:


### PR DESCRIPTION
This switches off all warnings except when in debug mode. Closes #1139.

@arjclark, please review.
