### PR TITLE
rose metadata: fix null first values entry

### DIFF
--- a/lib/python/rose/variable.py
+++ b/lib/python/rose/variable.py
@@ -241,8 +241,7 @@ def get_value_from_metadata(meta_data):
     """Use raw metadata to get a 'correct' value for a variable."""
     var_value = ''
     if rose.META_PROP_VALUES in meta_data:
-        var_value = meta_data[rose.META_PROP_VALUES].replace(' ', '')
-        var_value = var_value.replace(',', ' ').split()[0]
+        var_value = array_split(meta_data[rose.META_PROP_VALUES])[0]
     elif rose.META_PROP_TYPE in meta_data:
         var_type = meta_data[rose.META_PROP_TYPE]
         if var_type == 'logical':


### PR DESCRIPTION
An empty `rose-app.conf` with a `rose-meta.conf` file that looks like this:

```
[env=METASYN]
values=,foo,bar
value-titles=NOTHING,FOOO,BARRR
```

will give a latent variable in `rose edit` with a value of `foo`.
However, the latent variable value should be the first entry in
`values`, which is a null string.

This bug happens because the parsing to get the first values entry is
a bit crude - once we use the `array_split` function instead, it's much
better and will now handle quotes and escaped commas, etc.
