### PR TITLE
rose edit: more specific macro messages

### DIFF
--- a/lib/python/rose/config_editor/__init__.py
+++ b/lib/python/rose/config_editor/__init__.py
@@ -447,10 +447,11 @@ DIALOG_LABEL_CONFIG_CHOOSE_META = "Metadata id:"
 DIALOG_LABEL_CONFIG_CHOOSE_NAME = "New config name:"
 DIALOG_LABEL_MACRO_TRANSFORM_CHANGES = ("<b>{0}:</b> <i>{1}</i>\n" +
                                         "changes: {2}")
-DIALOG_LABEL_MACRO_TRANSFORM_NONE = "No changes from this macro."
+DIALOG_LABEL_MACRO_TRANSFORM_NONE = (
+    "No configuration changes from this macro.")
 DIALOG_LABEL_MACRO_VALIDATE_ISSUES = ("<b>{0}</b> <i>{1}</i>\n" +
                                       "errors: {2}")
-DIALOG_LABEL_MACRO_VALIDATE_NONE = "OK for this macro."
+DIALOG_LABEL_MACRO_VALIDATE_NONE = "Configuration OK for this macro."
 DIALOG_LABEL_MACRO_WARN_ISSUES = ("warnings: {0}")
 DIALOG_LABEL_PREFERENCES = ("Please edit your site and user " +
                             "configurations to make changes.")


### PR DESCRIPTION
This improves the null-error or null-change messages given
when running a macro in `rose edit`. Previously, the message
could seem too generic, when actually it only applied to a
specific macro.

@arjclark, please review.
