### PR TITLE
rose suite-run --reload: fix !CYLC_VERSION problem

### DIFF
--- a/lib/python/rose/suite_run.py
+++ b/lib/python/rose/suite_run.py
@@ -160,7 +160,8 @@ class SuiteRunner(Runner):
                     raise ConfigValueError(["env", k], requested_value, e)
                 v = requested_value
             else:
-                conf_tree.node.set(["env", k], v)
+                conf_tree.node.set(["env", k], v,
+                                   state=conf_tree.node.STATE_NORMAL)
             conf_tree.node.set([jinja2_section, k], '"' + v + '"')
 
         # See if suite is running or not

--- a/t/rose-suite-run/13-ignore-cylc-version.t
+++ b/t/rose-suite-run/13-ignore-cylc-version.t
@@ -1,0 +1,45 @@
+#!/bin/bash
+#-------------------------------------------------------------------------------
+# (C) British Crown Copyright 2012-4 Met Office.
+#
+# This file is part of Rose, a framework for meteorological suites.
+#
+# Rose is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Rose is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Rose. If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test "rose suite-run", reload with !CYLC_VERSION.
+# See issue metomi/rose#1143.
+#-------------------------------------------------------------------------------
+. $(dirname $0)/test_header
+tests 1
+export ROSE_CONF_PATH=
+cp -r $TEST_SOURCE_DIR/$TEST_KEY_BASE/* .
+mkdir -p $HOME/cylc-run
+SUITE_RUN_DIR=$(mktemp -d --tmpdir=$HOME/cylc-run 'rose-test-battery.XXXXXX')
+NAME=$(basename $SUITE_RUN_DIR)
+rose suite-run -q -n $NAME --no-gcontrol
+# Wait for the only task to fail, before reload
+ST_FILE=$SUITE_RUN_DIR/log/job/t1.1.1.status
+TIMEOUT=$(($(date +%s) + 60)) # wait 1 minute
+while (($(date +%s) < TIMEOUT)) \
+    && ! grep -q 'CYLC_JOB_EXIT_TIME=' $ST_FILE 2>/dev/null
+do
+    sleep 1
+done
+#-------------------------------------------------------------------------------
+TEST_KEY=$TEST_KEY_BASE
+run_pass "$TEST_KEY" rose suite-run --reload -q -n $NAME --no-gcontrol
+#-------------------------------------------------------------------------------
+rose suite-stop -q -y -n $NAME -- --max-polls=12 --interval=5
+rose suite-clean -q -y $NAME
+exit

--- a/t/rose-suite-run/13-ignore-cylc-version/rose-suite.conf
+++ b/t/rose-suite-run/13-ignore-cylc-version/rose-suite.conf
@@ -1,0 +1,2 @@
+[env]
+!CYLC_VERSION=5.4.8

--- a/t/rose-suite-run/13-ignore-cylc-version/suite.rc
+++ b/t/rose-suite-run/13-ignore-cylc-version/suite.rc
@@ -1,0 +1,12 @@
+#!jinja2
+[cylc]
+UTC mode=True
+[[event hooks]]
+timeout handler=rose suite-hook --shutdown
+timeout=2
+[scheduling]
+[[dependencies]]
+graph=t1
+[runtime]
+[[t1]]
+command scripting=false


### PR DESCRIPTION
Previously, the command fails with nonsense if the original `rose suite-run`
command was invoked with `!CYLC_VERSION=`.

Fix #1143.
