### PR TITLE
rose edit, rosie go: fix toolbar gtk warning.

### DIFF
--- a/lib/python/rose/gtk/util.py
+++ b/lib/python/rose/gtk/util.py
@@ -231,14 +231,11 @@ class CustomMenuButton(gtk.MenuToolButton):
                  menu_items=[], menu_funcs=[]):
         hbox = None
         if stock_id is not None:
-            hbox = gtk.HBox()
             self.stock_id = stock_id
             self.icon = gtk.Image()
             self.icon.set_from_stock(stock_id, size)
             self.icon.show()
-            hbox.pack_end(self.icon, expand=False, fill=False)
-            hbox.show()
-        gtk.MenuToolButton.__init__(self, hbox, label)
+        gtk.MenuToolButton.__init__(self, self.icon, label)
         self.set_tooltip_text(tip_text)
         self.show()
         button_menu = gtk.Menu()


### PR DESCRIPTION
When loading `rose edit` or `rosie go` with the `--debug` switch,
using a GTK 2.20+ version, they produce the following warning:

```
Warning: invalid cast from `GtkHBox' to `GtkMisc'
  gtk.MenuToolButton.__init__(self, hbox, label)
...
GtkWarning: IA__gtk_misc_set_alignment: assertion `GTK_IS_MISC (misc)' failed
```

which arises from using a hbox instead of a `gtk.Misc` object
for the iconwidget in a `gtk.MenuToolButton`. Just using
a `gtk.Image` works fine.

@matthewrmshin, please review.
