### PR TITLE
Fix _BASE variables to be the top-level working copy directory

### DIFF
--- a/lib/python/rose/stem.py
+++ b/lib/python/rose/stem.py
@@ -208,8 +208,16 @@ class StemRunner(object):
                 subtree = result2.group(1)
                 item = re.sub(subtree, r'', target)
 
+        # Similarly for the 'base' variable we need to get the top level
+        # of the working copy
+        result = re.search(r'sub_tree:\s*(.*)', output)
+        if result:
+            subtree = result2.group(1)
+            base = re.sub("%s$"%(subtree), r'', base)
+
         # Remove trailing forwards-slash
         item = re.sub(r'/$',r'',item)
+        base = re.sub(r'/$',r'',base)
         return project, item, base, revision
 
     def _generate_name(self):


### PR DESCRIPTION
I think the FCM/SVN upgrade has broken something, the meaning of `target` in `fcm loc-layout` seems to have changed (it's always `.` now). This fix alters rose-stem so it sets the `_BASE` variable to be the top-level directory of the working copy/branch. 
