### PR TITLE
training feedback: Add CLI output to the rose-rug-brief-tour script.

### DIFF
--- a/bin/rose-rug-brief-tour
+++ b/bin/rose-rug-brief-tour
@@ -33,7 +33,7 @@ run rsync \
     -a --exclude='.svn' --timeout=1800 \
     --rsh='ssh -oBatchMode=yes -oStrictHostKeyChecking=no' \
     $ROSE_HOME/etc/$(basename $0)/* .
-if [ $? == 0 ]; then
+if [[ $? == 0 ]]; then
     echo ...done
 else
     echo ...failed


### PR DESCRIPTION
The brief tour script can confuse people as not doing anything or being unclear on what it is doing. This adds basic output to the terminal to indicate what happens.
