### PR TITLE
rose edit: fix general checking for rose-suite.info suites

### DIFF
--- a/demo/rose-config-edit/demo_meta/rose-suite.info
+++ b/demo/rose-config-edit/demo_meta/rose-suite.info
@@ -1,0 +1,3 @@
+owner=rose
+project=rose-edit-demo
+title=Demo suite for rose edit metadata functionality.

--- a/lib/python/rose/config_editor/menu.py
+++ b/lib/python/rose/config_editor/menu.py
@@ -630,7 +630,8 @@ class MainMenuHandler(object):
                 module_name = config_mod_prefix + module_name
         for config_name in configs:
             config_data = self.data.config[config_name]
-            os.chdir(config_data.directory)
+            if config_data.directory is not None:
+                os.chdir(config_data.directory)
             for module in config_data.macros:
                 if module_name is not None and module.__name__ != module_name:
                     continue


### PR DESCRIPTION
#1114 broke general checking for `rose edit` for suites

with a `rose-suite.info` file. This can be tested by
running either check-on-save or general checking on
the altered `demo/rose-config-edit/demo_meta` suite
below.

@arjclark, please review.
