### PR TITLE
Print number of values compared in rose-ana

### DIFF
--- a/lib/python/rose/apps/comparisons/exact.py
+++ b/lib/python/rose/apps/comparisons/exact.py
@@ -21,7 +21,7 @@
 
 from rose.apps.rose_ana import DataLengthError
 
-OUTPUT_STRING = "%s %s: %s%%: File %s %s %s"
+OUTPUT_STRING = "%s %s: %s%%: File %s %s %s (%s values)"
 PASS = "=="
 FAIL = "!="
 
@@ -53,6 +53,7 @@ class ExactComparisonFailure(object):
         self.resultfile = task.resultfile
         self.kgo1file = task.kgo1file
         self.extract = task.extract
+        self.numvals = len(task.resultdata)
         if hasattr(task, "subextract"):
             self.extract = self.extract + ":" + task.subextract
         try:
@@ -71,7 +72,8 @@ class ExactComparisonFailure(object):
 
     def __repr__(self):
         return OUTPUT_STRING % ( self.extract, self.location, self.percentage,
-                                 self.resultfile, FAIL, self.kgo1file,)
+                                 self.resultfile, FAIL, self.kgo1file,
+                                 self.numvals)
 
     __str__ = __repr__
 
@@ -84,11 +86,13 @@ class ExactComparisonSuccess(object):
         self.resultfile = task.resultfile
         self.kgo1file = task.kgo1file
         self.extract = task.extract
+        self.numvals = len(task.resultdata)
         if hasattr(task, "subextract"):
             self.extract = self.extract + ":" + task.subextract
 
     def __repr__(self):
         return OUTPUT_STRING % ( self.extract, "all", 0,
-                                 self.resultfile, PASS, self.kgo1file, )
+                                 self.resultfile, PASS, self.kgo1file, 
+                                 self.numvals)
 
     __str__ = __repr__

--- a/lib/python/rose/apps/comparisons/within.py
+++ b/lib/python/rose/apps/comparisons/within.py
@@ -22,7 +22,7 @@
 import re
 from rose.apps.rose_ana import DataLengthError
 
-OUTPUT_STRING = "%s %s%% %s %s: File %s c.f. %s"
+OUTPUT_STRING = "%s %s%% %s %s: File %s c.f. %s (%s values)"
 PASS = "<="
 FAIL = ">"
 
@@ -61,6 +61,7 @@ class WithinComparisonFailure(object):
         self.resultfile = task.resultfile
         self.kgo1file = task.kgo1file
         self.extract = task.extract
+        self.numvals = len(task.resultdata)
         if hasattr(task, "subextract"):
             self.extract = self.extract + ":" + task.subextract
         self.tolerance = task.tolerance
@@ -76,7 +77,7 @@ class WithinComparisonFailure(object):
     def __repr__(self):
         return OUTPUT_STRING % ( self.extract, self.percentage, FAIL,
                                  self.tolerance, self.resultfile,
-                                 self.kgo1file,  )
+                                 self.kgo1file,  self.numvals )
 
     __str__ = __repr__
 
@@ -89,13 +90,15 @@ class WithinComparisonSuccess(object):
         self.resultfile = task.resultfile
         self.kgo1file = task.kgo1file
         self.extract = task.extract
+        self.numvals = len(task.resultdata)
         if hasattr(task, "subextract"):
             self.extract = self.extract + ":" + task.subextract
         self.tolerance = task.tolerance
 
     def __repr__(self):
         return OUTPUT_STRING % ( self.extract, "all", PASS, self.tolerance,
-                                 self.resultfile, self.kgo1file )
+                                 self.resultfile, self.kgo1file,
+                                 self.numvals )
 
     __str__ = __repr__
 


### PR DESCRIPTION
A user has requested that the comparison methods in rose-ana print the number of things they compared - it's possible (and valid) to compare two lists of length zero, but it would be helpful to be able to detect that. This alters rose-ana so it includes the length of the arrays it is comparing in the output.
