### PR TITLE
rose metadata: remove broken icon symlinks

### DIFF
--- a/etc/rose-meta/rose-app-conf/etc/images/icon.png
+++ b/etc/rose-meta/rose-app-conf/etc/images/icon.png
@@ -1,1 +1,0 @@
-../rose-all/etc/images/icon.png

--- a/etc/rose-meta/rose-suite-conf/etc/images/icon.png
+++ b/etc/rose-meta/rose-suite-conf/etc/images/icon.png
@@ -1,1 +1,0 @@
-../rose-all/etc/images/icon.png

--- a/etc/rose-meta/rose-suite-info/etc/images/icon.png
+++ b/etc/rose-meta/rose-suite-info/etc/images/icon.png
@@ -1,1 +1,0 @@
-../rose-all/etc/images/icon.png


### PR DESCRIPTION
The following deleted files(/directories) contained broken symlinks
and were not used.

@matthewrmshin, please review.
