### PR TITLE
rose edit: fix change meta or project flag.

### DIFF
--- a/lib/python/rose/config_editor/data.py
+++ b/lib/python/rose/config_editor/data.py
@@ -350,7 +350,8 @@ class ConfigDataManager(object):
         macro_module_prefix = self.helper.get_macro_module_prefix(name)
         macros = rose.macro.load_meta_macro_modules(
                       meta_files, module_prefix=macro_module_prefix)
-        meta_id = self.helper.get_config_meta_flag(config)
+        meta_id = self.helper.get_config_meta_flag(
+            name, from_this_config_obj=config)
         # Initialise configuration data object.
         self.config[name] = ConfigData(config, s_config, config_directory,
                                        opt_conf_lookup, meta_config,

--- a/lib/python/rose/config_editor/data_helper.py
+++ b/lib/python/rose/config_editor/data_helper.py
@@ -33,13 +33,21 @@ class ConfigDataHelper(object):
         self.data = data
         self.util = util
 
-    def get_config_meta_flag(self, config):
+    def get_config_meta_flag(self, config_name, from_this_config_obj=None):
         """Return the metadata id flag."""
-        for keylist in [[rose.CONFIG_SECT_TOP, rose.CONFIG_OPT_META_TYPE],
-                        [rose.CONFIG_SECT_TOP, rose.CONFIG_OPT_PROJECT]]:
-            type_node = config.get(keylist, no_ignore=True)
-            if type_node is not None and type_node.value:
-                return type_node.value
+        for section, option in [
+                [rose.CONFIG_SECT_TOP, rose.CONFIG_OPT_META_TYPE],
+                [rose.CONFIG_SECT_TOP, rose.CONFIG_OPT_PROJECT]]:
+            if from_this_config_obj is not None:
+                type_node = from_this_config_obj.get(
+                    [section, option], no_ignore=True)
+                if type_node is not None and type_node.value:
+                    return type_node.value
+                continue
+            id_ = self.util.get_id_from_section_option(section, option)
+            var = self.get_variable_by_id(id_, config_name)
+            if var is not None:
+                return var.value
         return None
 
     def is_ns_sub_data(self, ns):

--- a/lib/python/rose/config_editor/updater.py
+++ b/lib/python/rose/config_editor/updater.py
@@ -576,8 +576,7 @@ class Updater(object):
     def update_metadata_id(self, config_name):
         """Update the metadata if the id has changed."""
         config_data = self.data.config[config_name]
-        new_meta_id = self.data.helper.get_config_meta_flag(
-                                                  config_data.config)
+        new_meta_id = self.data.helper.get_config_meta_flag(config_name)
         if config_data.meta_id != new_meta_id:
             config_data.meta_id = new_meta_id
             self.refresh_metadata_func(config_name=config_name)


### PR DESCRIPTION
This fixes changing the =meta or =project variable
within a rose edit session. Due to the old code's
reliance on `ConfigNode` data, which is not updated
as often any more, the update of the metadata does
not get triggered. This change adds the ability to
source the meta or project flag from the variable itself,
which is more correct.

@matthewrmshin, please review.
