### PR TITLE
rose config-dump: fix tidying metadata

### DIFF
--- a/lib/python/rose/config_dump.py
+++ b/lib/python/rose/config_dump.py
@@ -23,6 +23,8 @@
 import filecmp
 import fnmatch
 import os
+
+from rose import META_CONFIG_NAME
 from rose.config import ConfigDumper, ConfigLoader
 from rose.fs_util import FileSystemUtil
 from rose.macro import pretty_format_config
@@ -58,7 +60,7 @@ def main():
     for file_name in file_names:
         t = NamedTemporaryFile()
         node = ConfigLoader()(file_name)
-        if not opts.no_pretty_mode:
+        if not opts.no_pretty_mode and file_name != META_CONFIG_NAME:
             pretty_format_config(node)
         ConfigDumper()(node, t)
         t.seek(0)

--- a/t/rose-config-dump/03-prettyprint.t
+++ b/t/rose-config-dump/03-prettyprint.t
@@ -21,7 +21,7 @@
 #-------------------------------------------------------------------------------
 . $(dirname $0)/test_header
 #-------------------------------------------------------------------------------
-tests 4
+tests 8
 #-------------------------------------------------------------------------------
 # Mixed string-integer section indices.
 TEST_KEY=$TEST_KEY_BASE-basic
@@ -52,7 +52,7 @@ file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<'__OUT__'
 [INFO] M rose-app.conf
 __OUT__
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
-cat > f1 <<'__CONF__'
+cat > f2 <<'__CONF__'
 [namelist:bacon_and_beans]
 recipe='Fry ',6,
       ='slices of bacon until nearly crispy then cut them up',
@@ -84,7 +84,21 @@ happy=1,7,10,13,19,23,28,31,32,44,49,68,70,79,82,86,91,94,97,100,
 perfect=6,28,496,8128,33550336,8589869056,137438691328
 powers_of_one=54*1
 __CONF__
-file_cmp "$TEST_KEY.f1" f1 rose-app.conf
+file_cmp "$TEST_KEY.f2" f2 rose-app.conf
+TEST_KEY=$TEST_KEY_BASE-basic-metadata
+rm rose-app.conf
+cat > f3 <<'__CONF__'
+[namelist:sequences=fibonacci]
+help=Here are some values in the sequence:
+    =0,1,1,2,3,5,8,13,21,34,55,89,144,233,377,610,987,1597,2584,4181,6765,10946,17711,28657,46368,75025,121393,196418,
+    =317811,514229,832040,1346269,2178309,3524578,5702887,
+    =9227465,14930352,24157817,39088169
+__CONF__
+cp f3 rose-meta.conf
+run_pass "$TEST_KEY" rose config-dump
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+file_cmp "$TEST_KEY.f3" f3 rose-meta.conf
 teardown
 #-------------------------------------------------------------------------------
 exit 0


### PR DESCRIPTION
`rose config-dump` treats all sections beginning with `namelist:` as
Fortran namelists, regardless of file type. This can lead to some
undesirable pretty-printing in `rose-meta.conf` files.

This change switches the format-specific prettyprinting off for
`rose-meta.conf` files.

@arjclark, please review.
