### PR TITLE
API docs: Add example of removing a namelist in an upgrade macro

### DIFF
--- a/doc/rose-api.html
+++ b/doc/rose-api.html
@@ -1050,6 +1050,14 @@ class Upgrade272to273(rose.upgrade.MacroUpgrade):
                             info="Cheeseburgers are for lunch")
         return config, self.reports
 </pre>
+
+        <p>Example of removing an entire namelist:</p>
+        <pre class="prettyprint">
+    def upgrade(self, config, meta_config=None):
+        self.remove_setting(config, ["namelist:breakfast_nl"],
+                            info="We don't serve breakfast anymore")
+        return config, self.reports
+</pre>
       </dd>
 
       <dt><code>def enable_setting(self, config, keys, info=None):</code></dt>


### PR DESCRIPTION
Adds an example of removing a namelist (rather than a namelist item) in an upgrade macro following user feedback.
