### PR TITLE
rose app-upgrade: fix HEAD broken macro pathway

### DIFF
--- a/lib/python/rose/upgrade.py
+++ b/lib/python/rose/upgrade.py
@@ -396,7 +396,7 @@ class MacroUpgradeManager(object):
             for macro in list(temp_list[1:]):
                 if macro.BEFORE_TAG not in next_taglist:
                     # Disconnected macro.
-                    temp_list.pop(macro)
+                    temp_list.remove(macro)
             if temp_list:
                 self.version_macros = [temp_list[-1]]
         if not self.version_macros:

--- a/t/rose-app-upgrade/06-broken.t
+++ b/t/rose-app-upgrade/06-broken.t
@@ -1,0 +1,97 @@
+#!/bin/bash
+#-------------------------------------------------------------------------------
+# (C) British Crown Copyright 2012-4 Met Office.
+#
+# This file is part of Rose, a framework for meteorological suites.
+#
+# Rose is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Rose is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Rose. If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test "rose app-upgrade" for broken macros.
+#-------------------------------------------------------------------------------
+. $(dirname $0)/test_header
+#-------------------------------------------------------------------------------
+tests 9
+
+#-------------------------------------------------------------------------------
+# Check complex upgrading
+init <<'__CONFIG__'
+meta=test-app-upgrade/HEAD
+
+__CONFIG__
+setup
+init_meta test-app-upgrade apple fig HEAD
+init_macro test-app-upgrade <<'__MACRO__'
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+
+import rose.upgrade
+
+
+class UpgradeWhatevertoOtherWhatever(rose.upgrade.MacroUpgrade):
+
+    """Upgrade from Whatever to Other Whatever."""
+
+    BEFORE_TAG = "whatever"
+    AFTER_TAG = "other whatever"
+
+    def upgrade(self, config, meta_config=None):
+        return config, self.reports
+
+
+class UpgradeDunnoToOtherDunno(rose.upgrade.MacroUpgrade):
+
+    """Upgrade from Dunno to Other Dunno."""
+
+    BEFORE_TAG = "dunno"
+    AFTER_TAG = "other dunno"
+
+    def upgrade(self, config, meta_config=None):
+        return config, self.reports
+__MACRO__
+
+#-----------------------------------------------------------------------------
+TEST_KEY=$TEST_KEY_BASE-HEAD
+# Check a broken upgrade pathway from HEAD
+run_pass "$TEST_KEY" rose app-upgrade --non-interactive \
+ --meta-path=../rose-meta/ -C ../config
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<'__OUTPUT__'
+= HEAD
+__OUTPUT__
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+#-----------------------------------------------------------------------------
+TEST_KEY=$TEST_KEY_BASE-random
+# Check a broken upgrade pathway from an arbitrary made-up version.
+init <<'__CONFIG__'
+meta=test-app-upgrade/not-sure
+__CONFIG__
+run_pass "$TEST_KEY" rose app-upgrade --non-interactive \
+ --meta-path=../rose-meta/ -C ../config
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<'__OUTPUT__'
+= not-sure
+__OUTPUT__
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+#-----------------------------------------------------------------------------
+TEST_KEY=$TEST_KEY_BASE-after-tag
+# Check a broken upgrade pathway from an arbitrary made-up version.
+init <<'__CONFIG__'
+meta=test-app-upgrade/other whatever
+__CONFIG__
+run_pass "$TEST_KEY" rose app-upgrade --non-interactive \
+ --meta-path=../rose-meta/ -C ../config
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<'__OUTPUT__'
+= other whatever
+__OUTPUT__
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+teardown


### PR DESCRIPTION
When a metadata version is "HEAD" and there is one or more
upgrade macro that does not fit into the main upgrade sequence,
the attempt in the code to bypass these macros will fail with:

```
temp_list.pop(macro)
TypeError: an integer is required
```

This fixes the bug and adds some more tests.

@arjclark, please review.
