### PR TITLE
rose config --print-conf: print result as conf

### DIFF
--- a/bin/rose-config
+++ b/bin/rose-config
@@ -87,6 +87,10 @@
 #         Cannot be used in conjunction with --file=FILE.
 #     --no-opts
 #         Do not load optional configurations.
+#     --print-conf
+#         If specified, prints result as a Rose configuration file snippet.
+#         This allows the output to be concatenated into another Rose
+#         configuration file.
 #     --print-ignored, -i
 #         If specified, the program will print ignored !OPTION=VALUE where
 #         relevant.

--- a/doc/rose-command.html
+++ b/doc/rose-command.html
@@ -590,6 +590,12 @@ rosie UTIL [OPTS] [ARG ...]
 
       <dd>Do not load optional configurations.</dd>
 
+      <dt><kbd>--print-conf</kbd></dt>
+
+      <dd>If specified, prints result as a Rose configuration file snippet.
+      This allows the output to be concatenated into another Rose configuration
+      file.</dd>
+
       <dt><kbd>--print-ignored, -i</kbd></dt>
 
       <dd>If specified, the program will print ignored <var>!OPTION=VALUE</var>

--- a/lib/python/rose/config.py
+++ b/lib/python/rose/config.py
@@ -263,7 +263,7 @@ class ConfigDumper(object):
         self.char_assign = char_assign
 
     def dump(self, root, target=sys.stdout, sort_sections=None,
-             sort_option_items=None, env_escape_ok=False):
+             sort_option_items=None, env_escape_ok=False, concat_mode=False):
         """Format a ConfigNode object and write result to target.
 
         Arguments:
@@ -278,6 +278,8 @@ class ConfigDumper(object):
         in string values.
         env_escape_ok -- an optional argument to indicate that $NAME
         and ${NAME} syntax in values should be escaped.
+        concat_mode -- switch on concatenation mode. If True, add []
+        before root level options.
 
         """
         if sort_sections is None:
@@ -310,6 +312,8 @@ class ConfigDumper(object):
         if root_option_keys:
             f.write(blank)
             blank = "\n"
+            if concat_mode:
+                f.write("[]\n")
             for key in root_option_keys:
                 self._string_node_dump(key, root.value[key], f, env_escape_ok)
         for section_key in section_keys:

--- a/lib/python/rose/opt_parse.py
+++ b/lib/python/rose/opt_parse.py
@@ -362,6 +362,11 @@ class RoseOptionParser(OptionParser):
                        ["--prefix-delim"],
                        {"metavar": "DELIMITER",
                         "help": "Specify the prefix delimiter."}],
+               "print_conf_mode": [
+                       ["--print-conf"],
+                       {"action": "store_true",
+                        "dest": "print_conf_mode",
+                        "help": "Print result in Rose configuration format."}],
                "print_format": [
                        ["--print-format", "--format", "-f"],
                        {"metavar": "FORMAT",

--- a/t/rose-config/00-basic.t
+++ b/t/rose-config/00-basic.t
@@ -47,7 +47,7 @@ my-home=$HOME
 colour=green
 __CONF__
 #-------------------------------------------------------------------------------
-tests 51
+tests 69
 #-------------------------------------------------------------------------------
 # Empty file.
 TEST_KEY=$TEST_KEY_BASE-empty
@@ -124,12 +124,34 @@ __OUT__
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
 teardown
 #-------------------------------------------------------------------------------
+# Value at root level, print-conf.
+TEST_KEY=$TEST_KEY_BASE-value-root--print-conf
+setup
+run_pass "$TEST_KEY" rose config -f $FILE --print-conf greeting
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<'__OUT__'
+[]
+greeting=Hello
+__OUT__
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+teardown
+#-------------------------------------------------------------------------------
 # Value.
 TEST_KEY=$TEST_KEY_BASE-value
 setup
 run_pass "$TEST_KEY" rose config -f $FILE bus colour
 file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<'__OUT__'
 red
+__OUT__
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+teardown
+#-------------------------------------------------------------------------------
+# Value.
+TEST_KEY=$TEST_KEY_BASE-value--print-conf
+setup
+run_pass "$TEST_KEY" rose config -f $FILE --print-conf bus colour
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<'__OUT__'
+[bus]
+colour=red
 __OUT__
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
 teardown
@@ -152,6 +174,17 @@ __OUT__
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
 teardown
 #-------------------------------------------------------------------------------
+# Value, ignored, default, --print-conf
+TEST_KEY=$TEST_KEY_BASE-value-ignored-default--print-conf
+setup
+run_pass "$TEST_KEY" rose config -f $FILE --default=-na- --print-conf taxi decks
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<'__OUT__'
+[taxi]
+decks=-na-
+__OUT__
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+teardown
+#-------------------------------------------------------------------------------
 # Value, ignored, print.
 TEST_KEY=$TEST_KEY_BASE-value-ignored-print
 setup
@@ -170,12 +203,32 @@ file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
 teardown
 #-------------------------------------------------------------------------------
+# Value, no-such-item.
+TEST_KEY=$TEST_KEY_BASE-value-no-such-item--print-conf
+setup
+run_fail "$TEST_KEY" rose config -f $FILE --print-conf taxi oyster
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+teardown
+#-------------------------------------------------------------------------------
 # Value, no-such-item, default.
 TEST_KEY=$TEST_KEY_BASE-value-no-such-item-default
 setup
 run_pass "$TEST_KEY" rose config -f $FILE --default=false taxi oyster
 file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<'__OUT__'
 false
+__OUT__
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+teardown
+#-------------------------------------------------------------------------------
+# Value, no-such-item, default, --print-conf.
+TEST_KEY=$TEST_KEY_BASE-value-no-such-item-default--print-conf
+setup
+run_pass "$TEST_KEY" \
+    rose config -f $FILE --print-conf --default=false taxi oyster
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<'__OUT__'
+[taxi]
+oyster=false
 __OUT__
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
 teardown
@@ -233,6 +286,19 @@ setup
 run_pass "$TEST_KEY" rose config -f $FILE taxi
 file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<__OUT__
 colour=black
+name=Hackney Carriage
+__OUT__
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+teardown
+#-------------------------------------------------------------------------------
+# Non-ignored keys
+TEST_KEY=$TEST_KEY_BASE-section-with-ignored-option--print-conf
+setup
+run_pass "$TEST_KEY" rose config -f $FILE --print-conf taxi
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<__OUT__
+[taxi]
+colour=black
+!decks=1
 name=Hackney Carriage
 __OUT__
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null


### PR DESCRIPTION
Allow output to be concatenated into another Rose configuration file.

Close #1201.
