### PR TITLE
Use configured email host in suite hook emails.

### DIFF
--- a/lib/python/rose/suite_hook.py
+++ b/lib/python/rose/suite_hook.py
@@ -90,6 +90,7 @@ class RoseSuiteHook(object):
                         mail_cc_address += "@" + host
                     mail_cc_addresses.append(mail_cc_address)
                 msg["Cc"] = ", ".join(mail_cc_addresses)
+                mail_cc_list = mail_cc_addresses
             else:
                 mail_cc_list = []
             msg["Subject"] = "[%s] %s" % (hook_event, suite_name)


### PR DESCRIPTION
#947 added a configurable host for email addresses but didn't actually use it in the `sendmail()` call.

(which also suggests #948 was closed for the wrong reason?) 
