### PR TITLE
rose metadata-graph: add index in doc/command.html

### DIFF
--- a/doc/rose-command.html
+++ b/doc/rose-command.html
@@ -105,6 +105,10 @@
 
       <dd>Automatically generate metadata from an application or suite</dd>
 
+      <dt><a href="#rose-metadata-graph">rose metadata-graph</a></dt>
+
+      <dd>Graph configuration metadata</dd>
+
       <dt><a href="#rose-mpi-launch">rose mpi-launch</a></dt>
 
       <dd>Provide a portable way to launch an MPI command.</dd>


### PR DESCRIPTION
`rose metadata-graph` had a missing index entry in `doc/command.html`.

@arjclark, please review.
