### PR TITLE
isodatetime: update to 2014-03-17-g9d23336

### DIFF
--- a/lib/python/isodatetime/dumpers.py
+++ b/lib/python/isodatetime/dumpers.py
@@ -18,7 +18,6 @@
 
 """This provides data model dumping functionality."""
 
-import copy
 import re
 
 from . import parser_spec
@@ -109,16 +108,23 @@ class TimePointDumper(object):
 
     def _dump_expression_with_properties(self, timepoint, expression,
                                          properties, custom_time_zone=None):
-        if (not timepoint.truncated and
-                ("week_of_year" in properties or
-                 "day_of_week" in properties) and
-                 not ("month_of_year" in properties or
-                      "day_of_month" in properties or
-                      "day_of_year" in properties)):
-            # We need the year to be in week years.
-            timepoint = copy.copy(timepoint).to_week_date()
+        if not timepoint.truncated:
+            if ("week_of_year" in properties or
+                    "day_of_week" in properties):
+                if not ("month_of_year" in properties or
+                            "day_of_month" in properties or
+                            "day_of_year" in properties):
+                    # We need the year to be in week years.
+                    timepoint = timepoint.copy().to_week_date()
+            elif (timepoint.get_is_week_date() and
+                      ("month_of_year" in properties or
+                       "day_of_month" in properties or
+                       "day_of_year" in properties)):
+                # We need the year to be in standard calendar years.
+                timepoint = timepoint.copy().to_calendar_date()
+
         if custom_time_zone is not None:
-            timepoint = copy.copy(timepoint)
+            timepoint = timepoint.copy()
             if custom_time_zone == (0, 0):
                 timepoint.set_time_zone_to_utc()
             else:

--- a/lib/python/isodatetime/tests.py
+++ b/lib/python/isodatetime/tests.py
@@ -134,6 +134,21 @@ def get_timepoint_dumper_tests():
              (u"±XCCYY-MM-DDThh:mm:ssZ", "-000056-11-12T23:01:00Z"),
              ("DD/MM/CCYY is a silly format", "13/11/0056 is a silly format"),
              ("ThhmmZ", "T2301Z")]
+        ),
+        (
+            {"year": 1000, "week_of_year": 1, "day_of_week": 1,
+             "time_zone_hour": 0},
+            [("CCYY-MMDDThhmmZ", "0999-1230T0000Z"),
+             ("CCYY-DDDThhmmZ", "0999-364T0000Z"),
+             ("CCYY-Www-DThhmm+0200", "1000-W01-1T0200+0200"),
+             ("CCYY-Www-DThhmm-0200", "0999-W52-7T2200-0200")]
+        ),
+        (
+            {"year": 999, "day_of_year": 364, "time_zone_hour": 0},
+            [("CCYY-MMDDThhmmZ", "0999-1230T0000Z"),
+             ("CCYY-DDDThhmmZ", "0999-364T0000Z"),
+             ("CCYY-Www-DThhmm+0200", "1000-W01-1T0200+0200"),
+             ("CCYY-Www-DThhmm-0200", "0999-W52-7T2200-0200")]
         )
     ]
 


### PR DESCRIPTION
This pulls in the latest isodatetime master, whose `git describe` is
`2014-03-17-g9d23336`.

This adds the bug fix https://github.com/metomi/isodatetime/pull/32.

@arjclark, please review.
