### PR TITLE
rose date: correct typo in documentation.

### DIFF
--- a/bin/rose-date
+++ b/bin/rose-date
@@ -41,7 +41,7 @@
 #         PT6H - 6 hour offset
 #         PT1M - 1 minute offset
 #         -PT1M - (negative) 1 minute offset
-#         P3M - 1 month offset
+#         P3M - 3 month offset
 #         P2W - 2 week offset (note no other units may be combined with weeks)
 #         P2DT5.5H - 2 day, 5.5 hour offset
 #         -P2YT4S - (negative) 2 year, 4 second offset

--- a/doc/rose-command.html
+++ b/doc/rose-command.html
@@ -771,7 +771,7 @@ rosie UTIL [OPTS] [ARG ...]
 
           <li><samp>-PT1M</samp> - (negative) 1 minute offset</li>
 
-          <li><samp>P3M</samp> - 1 month offset</li>
+          <li><samp>P3M</samp> - 3 month offset</li>
 
           <li><samp>P2W</samp> - 2 week offset (note no other units may be
           combined with weeks)</li>


### PR DESCRIPTION
Corrects a typo in the rose-date documentation (both CLI and online).
