### PR TITLE
rose.date: fix invalid local name

### DIFF
--- a/lib/python/rose/date.py
+++ b/lib/python/rose/date.py
@@ -223,7 +223,7 @@ class RoseDateShifter(object):
         try:
             return self.isoparser.strptime(ref_time, parse_format)
         except ValueError:
-            return self.get_datetime_strptime(d, parse_format)
+            return self.get_datetime_strptime(ref_time, parse_format)
 
     def get_datetime_strftime(self, d, print_format):
         """Use the datetime library's strftime as a fallback."""


### PR DESCRIPTION
`d` is not defined in the local scope.
