### PR TITLE
rose suite-log -U --prune-remote now works

### DIFF
--- a/lib/python/rose/opt_parse.py
+++ b/lib/python/rose/opt_parse.py
@@ -378,7 +378,7 @@ class RoseOptionParser(OptionParser):
                         "metavar": "PROPERTY",
                         "help": "Specify a property."}],
                "prune_remote_mode": [
-                       ["--tidy-remote"],
+                       ["--prune-remote", "--tidy-remote"],
                        {"action": "store_true",
                         "dest": "prune_remote_mode",
                         "help": "Remove remote job logs after retrieval."}],


### PR DESCRIPTION
The documented option was not implemented correctly under
`rose.opt_parse`.
