### PR TITLE
rose docs: fix upgrade dev example ordering

### DIFF
--- a/doc/rose-rug-advanced-tutorials-upgrade-dev.html
+++ b/doc/rose-rug-advanced-tutorials-upgrade-dev.html
@@ -211,8 +211,8 @@ type=integer
 meta=make-boat/0.2
 
 [namelist:materials]
-misc_branches=4
 hollow_tree_trunks=1
+misc_branches=4
 outrigger_tree_trunks=2
 paddling_branches=1
 </pre>


### PR DESCRIPTION
This fixes the sort ordering of the example in the Upgrade Macro
Development tutorial.

@matthewrmshin, please review.
