### PR TITLE
Rose Bush: display if job log db present.

### DIFF
--- a/lib/python/rose/bush.py
+++ b/lib/python/rose/bush.py
@@ -243,9 +243,11 @@ class Root(object):
                 "entries": []}
         if os.path.isdir(user_suite_dir_root):
             for name in os.listdir(user_suite_dir_root):
+                suite_conf = os.path.join(user_suite_dir_root, name,
+                                          self.suite_engine_proc.SUITE_CONF)
                 job_logs_db = os.path.join(user_suite_dir_root, name,
                                           self.suite_engine_proc.JOB_LOGS_DB)
-                if not os.path.exists(job_logs_db):
+                if not os.path.exists(job_logs_db) and not os.path.exists(suite_conf):
                     continue
                 suite_db = os.path.join(user_suite_dir_root, name,
                                         self.suite_engine_proc.SUITE_DB)


### PR DESCRIPTION
Currently Rose Bush only displays suites if the suite definition file is found in the suite run directory.  It seems to me the correct test is whether or not a rose job log db exists, not the suite definition.  This then opens up the most excellent Rose Bush to raw cylc suites (which typically don't install the suite definition to the run directory) that just use the rose task-hook event handler (we have some operational suites that have not yet been fully "rosed"). 
