### PR TITLE
env-cat: support replace braced only entries

### DIFF
--- a/bin/rose-env-cat
+++ b/bin/rose-env-cat
@@ -34,6 +34,9 @@
 #     the syntax, e.g. \$NAME or \${NAME} will escape the substitution.
 #
 # OPTIONS
+#     --braced-only
+#         The command will only substitute environment variables in the FILE
+#         where the syntax is of the form ${NAME}
 #     --unbound=STRING, --undef=STRING
 #         The command will normally fail on unbound (or undefined) variables.
 #         If this option is specified, the command will substitute an unbound

--- a/doc/rose-command.html
+++ b/doc/rose-command.html
@@ -876,6 +876,13 @@ rosie UTIL [OPTS] [ARG ...]
     <h3>OPTIONS</h3>
 
     <dl>
+      <dt><kbd>--braced-only</kbd></dt>
+
+      <dd>The command will only substitute environment variables in the FILE
+      where the syntax is of the form <kbd>${NAME}</kbd></dd>
+    </dl>
+
+    <dl>
       <dt><kbd>--unbound=STRING</kbd>, <kbd>--undef=STRING</kbd></dt>
 
       <dd>The command will normally fail on unbound (or undefined) variables.

--- a/lib/python/rose/env.py
+++ b/lib/python/rose/env.py
@@ -95,7 +95,7 @@ def env_var_escape(s):
     return ret
 
 
-def env_var_process(s, unbound=None):
+def env_var_process(s, unbound=None, braced_only=False):
     """Substitute environment variables into a string.
 
     For each $NAME and ${NAME} in "s", substitute with the value
@@ -116,13 +116,15 @@ def env_var_process(s, unbound=None):
                 m["brace_open"] = ""
             symbol = m["sigil"] + m["brace_open"] + m["name"] + m["brace_close"]
             substitute = symbol
-            if len(m["escape"]) % 2 == 0:
-                if os.environ.has_key(m["name"]):
-                    substitute = os.environ[m["name"]]
-                elif unbound is not None:
-                    substitute = str(unbound)
-                else:
-                    raise UnboundEnvironmentVariableError(m["name"])
+
+            if (braced_only and m["brace_open"]) or not braced_only:
+                if len(m["escape"]) % 2 == 0:
+                    if os.environ.has_key(m["name"]):
+                        substitute = os.environ[m["name"]]
+                    elif unbound is not None:
+                        substitute = str(unbound)
+                    else:
+                        raise UnboundEnvironmentVariableError(m["name"])
             ret += m["head"] + m["escape"][0 : len(m["escape"]) / 2] + substitute
             tail = m["tail"]
         else:

--- a/lib/python/rose/env_cat.py
+++ b/lib/python/rose/env_cat.py
@@ -29,6 +29,7 @@ def main():
     """Implement "rose env-cat"."""
     opt_parser = RoseOptionParser()
     opt_parser.add_my_options("unbound")
+    opt_parser.add_my_options("braced_only")
     opts, args = opt_parser.parse_args()
     if not args:
         args = ["-"]
@@ -44,7 +45,7 @@ def main():
             if not line:
                 break
             try:
-                sys.stdout.write(env_var_process(line, opts.unbound))
+                sys.stdout.write(env_var_process(line, opts.unbound, opts.braced_only))
             except UnboundEnvironmentVariableError as e:
                 name = arg
                 if arg == "-":

--- a/lib/python/rose/opt_parse.py
+++ b/lib/python/rose/opt_parse.py
@@ -67,6 +67,12 @@ class RoseOptionParser(OptionParser):
                         "default": False,
                         "dest": "type",
                         "help": "Automatically guess types of settings."}],
+               "braced_only": [
+                       ["--braced-only"],
+                       {"action": "store_true",
+                        "default": False,
+                        "dest": "braced_only",
+                        "help": "Only replace entries surrounded by braces."}],
                "case_mode": [
                        ["--case"],
                        {"action": "store",

--- a/t/rose-env-cat/02-braced.t
+++ b/t/rose-env-cat/02-braced.t
@@ -1,0 +1,120 @@
+#!/bin/bash
+#-------------------------------------------------------------------------------
+# (C) British Crown Copyright 2012-4 Met Office.
+#
+# This file is part of Rose, a framework for meteorological suites.
+#
+# Rose is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Rose is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Rose. If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test "rose env-cat" in "braced-only" mode.
+#-------------------------------------------------------------------------------
+. $(dirname $0)/test_header
+#-------------------------------------------------------------------------------
+tests 18
+export USER=${USER:-$(whoami)}
+export HOME=${HOME:-$(cd ~$USER && pwd)}
+#-------------------------------------------------------------------------------
+# Read from STDIN.
+TEST_KEY=$TEST_KEY_BASE-stdin
+setup
+run_pass "$TEST_KEY" rose env-cat --braced-only <<'__STDIN__'
+I am \$USER $USER.
+my \$HOME is at ${HOME}.
+__STDIN__
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<__OUT__
+I am \$USER \$USER.
+my \$HOME is at ${HOME}.
+__OUT__
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+teardown
+#-------------------------------------------------------------------------------
+# Read from STDIN as -.
+TEST_KEY=$TEST_KEY_BASE-stdin-2
+setup
+run_pass "$TEST_KEY" rose env-cat --braced-only - <<'__STDIN__'
+I am \$USER $USER.
+my \$HOME is at ${HOME}.
+__STDIN__
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<__OUT__
+I am \$USER \$USER.
+my \$HOME is at ${HOME}.
+__OUT__
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+teardown
+#-------------------------------------------------------------------------------
+# Files
+TEST_KEY=$TEST_KEY_BASE-files
+setup
+cat >file1 <<'__FILE__'
+I am \$USER \$USER.
+my \$HOME is at ${HOME}.
+__FILE__
+cat >file2 <<'__FILE__'
+The \$PATH to enlightenment is ${PATH}.
+\$PWD is where I am working at the moment. Not sure if I am at \$HOME or not.
+__FILE__
+run_pass "$TEST_KEY" rose env-cat --braced-only file1 file2
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<__OUT__
+I am \$USER \$USER.
+my \$HOME is at ${HOME}.
+The \$PATH to enlightenment is ${PATH}.
+\$PWD is where I am working at the moment. Not sure if I am at \$HOME or not.
+__OUT__
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+teardown
+#-------------------------------------------------------------------------------
+# Unbound
+TEST_KEY=$TEST_KEY_BASE-unbound
+setup
+run_fail "$TEST_KEY" rose env-cat --braced-only <<'__STDIN__'
+I am OK.
+I am ${NOT_OK}.
+__STDIN__
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<'__OUT__'
+I am OK.
+__OUT__
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" <<'__ERR__'
+<STDIN>:2: [UNDEFINED ENVIRONMENT VARIABLE] NOT_OK
+__ERR__
+teardown
+#-------------------------------------------------------------------------------
+# Unbound-OK, empty substitution
+TEST_KEY=$TEST_KEY_BASE-unbound-ok
+setup
+run_pass "$TEST_KEY" rose env-cat --braced-only --unbound= <<'__STDIN__'
+I am OK.
+I am ${NOT_OK}.
+__STDIN__
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<'__OUT__'
+I am OK.
+I am .
+__OUT__
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+teardown
+#-------------------------------------------------------------------------------
+# Unbound-OK, non-empty substitution.
+TEST_KEY=$TEST_KEY_BASE-unbound-ok-2
+setup
+run_pass "$TEST_KEY" rose env-cat --braced-only --unbound=undef <<'__STDIN__'
+I am OK.
+I am ${NOT_OK}.
+__STDIN__
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<'__OUT__'
+I am OK.
+I am undef.
+__OUT__
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+teardown
+#-------------------------------------------------------------------------------
+exit


### PR DESCRIPTION
Closes #1246
- Adds a --braced-only option to rose env-cat to only replace entries in a file/input of form `${VAR}`.
- Add appropriate tests
- Update help
- Update documentation
