### PR TITLE
rose bush: encode cycle time in URL

### DIFF
--- a/lib/html/rose-bush/cycles.html
+++ b/lib/html/rose-bush/cycles.html
@@ -156,13 +156,13 @@ class="btn btn-link"
 {% for entry in entries -%}
 <div class="row-fluid entry">
 <div class="span3">
-<a href="{{script}}/jobs/{{user}}/{{suite}}?cycles={{entry.cycle}}" class="cycle" title="{{entry.cycle}}">{{entry.cycle}}</a>
+<a href="{{script}}/jobs/{{user}}/{{suite}}?cycles={{entry.cycle|replace('+', '%2B')}}" class="cycle" title="{{entry.cycle}}">{{entry.cycle}}</a>
 </div>
 {% for state, icon, label, title in [("active", "play", "info", "active tasks"), ("success", "ok", "success", "succeeded tasks"), ("fail", "warning-sign", "important", "failed tasks")] -%}
 {% set n_state = entry.n_states[state] -%}
 <div class="span2">
 {% if n_state -%}
-{% set state_url = script ~ "/jobs/" ~ user ~ "/" ~ suite ~ "?cycles=" ~ entry.cycle -%}
+{% set state_url = script ~ "/jobs/" ~ user ~ "/" ~ suite ~ "?cycles=" ~ entry.cycle|replace('+', '%2B') -%}
 <a href="{{state_url}}{% for no_state in ["active", "success", "fail"] if no_state != state %}&amp;no_status={{no_state}}{% endfor %}">
 {% endif -%}
 <span class="label{% if n_state %} label-{{label}}{% endif %}">

--- a/lib/html/rose-bush/jobs.html
+++ b/lib/html/rose-bush/jobs.html
@@ -299,7 +299,7 @@ class="btn btn-link"
 {% endif -%}
 <!-- entry: status -->
 {% if entry.cycle != "1" -%}
-<a href="{{script}}/jobs/{{user}}/{{suite}}?cycles={{entry.cycle}}" class="cycle" title="{{entry.cycle}}">{{entry.cycle}}</a>
+<a href="{{script}}/jobs/{{user}}/{{suite}}?cycles={{entry.cycle|replace('+', '%2B')}}" class="cycle" title="{{entry.cycle}}">{{entry.cycle}}</a>
 {% endif -%}
 <a href="{{script}}/jobs/{{user}}/{{suite}}?tasks={{entry.name}}">{{entry.name}}</a>
 {% if entry.submit_num_max > 1 -%}


### PR DESCRIPTION
It may have a + sign, which is normally a delimiter for query arguments.
