### PR TITLE
#1270: fix user-ignoring duplicate section

### DIFF
--- a/demo/rose-config-edit/demo_meta/app/10-duplicate/meta/rose-meta.conf
+++ b/demo/rose-config-edit/demo_meta/app/10-duplicate/meta/rose-meta.conf
@@ -16,6 +16,7 @@ duplicate=true
 title=Icecream Namelist
 
 [namelist:icecream=sprinkles]
+compulsory=true
 title=Sprinkles?
 type=logical
 

--- a/lib/python/rose/macros/compulsory.py
+++ b/lib/python/rose/macros/compulsory.py
@@ -150,7 +150,8 @@ class CompulsoryChecker(rose.macro.MacroBaseRoseEdit):
                     basic_section, []):
                 if self._get_config_has_id(config_data, alias_section):
                     present_section_aliases.append(alias_section)
-                    check_user_ignored_ids.append(alias_section)
+                    if section_data[_SECTION_IS_COMPULSORY_KEY]:
+                        check_user_ignored_ids.append(alias_section)
             
             if not present_section_aliases:
                 # No sections in config_data that belong to basic_section.

--- a/t/rose-macro/08-compulsory-check.t
+++ b/t/rose-macro/08-compulsory-check.t
@@ -50,7 +50,7 @@ my_var8(2)=.true.
 my_var9=.true.
 __CONFIG__
 #-------------------------------------------------------------------------------
-tests 15
+tests 18
 #-------------------------------------------------------------------------------
 # Check compulsory checking.
 TEST_KEY=$TEST_KEY_BASE-ok
@@ -506,5 +506,21 @@ file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<'__OUT__'
         enabled      -> trig-ignored
 __OUT__
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+#-----------------------------------------------------------------------------
+init <<'__CONFIG__'
+[!namelist:icecream(1)]
+sprinkles=true
+__CONFIG__
+init_meta <<'__META_CONFIG__'
+[namelist:icecream]
+duplicate=true
+
+[namelist:icecream=sprinkles]
+compulsory=true
+type=boolean
+__META_CONFIG__
+TEST_KEY=$TEST_KEY_BASE-user-ignore-duplicate
+run_pass "$TEST_KEY" rose macro -V --config=../config --non-interactive
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
 teardown
-exit


### PR DESCRIPTION
If a user user-ignores a duplicate, non-compulsory section that
has a compulsory option, they will get a "Cannot user-ignore
compulsory settings" error displayed for the section.

This fixes #1270.

@matthewrmshin, please review.
