### PR TITLE
#1105: tweak default page expansion

### DIFF
--- a/lib/python/rose/config_editor/__init__.py
+++ b/lib/python/rose/config_editor/__init__.py
@@ -518,7 +518,9 @@ TITLE_PAGE_PREVIEW_MARKUP = ("<span foreground='" +
                             "'><u>{0}</u>" + "</span>")
 TITLE_PAGE_ROOT_MARKUP = "<b>{0}</b>"
 TITLE_PAGE_SUITE = "suite conf"
-TREE_PANEL_MAX_EXPANDED = 5
+TREE_PANEL_MAX_EXPANDED_ROOTS = 5
+TREE_PANEL_MAX_EXPANDED_DEPTH = 2
+TREE_PANEL_NO_EXPAND_LEAVES_REGEX = "/file$"
 
 # File panel names
 


### PR DESCRIPTION
This addresses part of #1105.

It tweaks the default page expansion for a single app session in
`rose edit`. This adds a default maximum page tree depth limit, and
a way to configure which leaves stay unexpanded (at the moment,
just the "file" leaf.

@arjclark, please review. @dpmatthews, this is related to some of
your comments.
