### PR TITLE
rose documentation: explain model time in SWT

### DIFF
--- a/doc/rose-rug-suite-writing-tutorial.html
+++ b/doc/rose-rug-suite-writing-tutorial.html
@@ -576,7 +576,8 @@ touch suite.rc
 
       <ul class="incremental">
         <li>We've set the suite to run from midnight, 1 June 2013 to midnight,
-        3 June 2013.</li>
+        3 June 2013. This is just a model time - not anything to do with real
+        time.</li>
 
         <li>We've set the <samp>cold-start</samp> task to
         <samp>fcm_make_navigate</samp>.</li>


### PR DESCRIPTION
This adds a sentence to explain the difference between cylc cycle time and
actual wallclock time in the Suite Writing Tutorial.

@kaday, please review.
