### PR TITLE
rose edit: speed up slow loading-up code

### DIFF
--- a/lib/python/rose/config_editor/main.py
+++ b/lib/python/rose/config_editor/main.py
@@ -1921,7 +1921,7 @@ def main():
                                         metadata_off=opts.no_metadata)""",
                         globals(), locals(), f.name)
         p = pstats.Stats(f.name)
-        p.strip_dirs().sort_stats('cumulative').print_stats(200)
+        p.strip_dirs().sort_stats("cumulative").print_stats(50)
         f.close()
     else:
         spawn_window(cwd, debug_mode=opts.debug_mode,


### PR DESCRIPTION
This halves the initial load time for a large configuration by:
- decreasing the number of calls to expensive functions
  (`load_vars_from_config`, `_get_config_sections`)
- caching simple input-output relationships for parsing trigger expressions.

@matthewrmshin, please review.
