### PR TITLE
rose suite-run (gtk): fix RuntimeError for Queues

### DIFF
--- a/lib/python/rose/gtk/run.py
+++ b/lib/python/rose/gtk/run.py
@@ -31,7 +31,7 @@ def run_suite(*args):
     """Run "rose suite-run [args]" with a GTK dialog."""
 
     # Set up reporter
-    queue = multiprocessing.Queue()
+    queue = multiprocessing.Manager().Queue()
     verbosity = Reporter.VV
     out_ctx = ReporterContextQueue(Reporter.KIND_OUT, verbosity, queue=queue)
     err_ctx = ReporterContextQueue(Reporter.KIND_ERR, verbosity, queue=queue)

--- a/lib/python/rose/reporter.py
+++ b/lib/python/rose/reporter.py
@@ -255,7 +255,7 @@ class ReporterContextQueue(ReporterContext):
                  prefix=None):
         ReporterContext.__init__(self, kind, verbosity, None, prefix)
         if queue is None:
-            queue = multiprocessing.Queue()
+            queue = multiprocessing.Manager().Queue()
         self.queue = queue
         self.closed = False
         self._messages_pending = []


### PR DESCRIPTION
When running `rose suite-run` through `rose edit` or `rosie go`, the suite run
process currently stalls with:

```
RuntimeError: Queue objects should only be shared between processes through inheritance
```

for new or newly-named non-trivial suites.

This can be traced back to 77c074ffe, which introduced a lot more file events
that all go into the `Queue` for the special GUI event handler's stdout stream (
`ReporterContextQueue`).

Using a `multiprocessing.Manager` to generate the `Queue` seems to implement
a more sharing-friendly kind of Queue, which prevents the error from
re-occurring.

@matthewrmshin, please review.
