### PR TITLE
Add restart to quick reference

### DIFF
--- a/doc/rose-quick-ref.html
+++ b/doc/rose-quick-ref.html
@@ -59,6 +59,10 @@
 
       <dd>Run in debug mode.</dd>
 
+      <dt>rose suite-run --restart</dt>
+
+      <dd>Restart a shutdown suite from its last known state.</dd>
+
       <dt>rose suite-gcontrol</dt>
 
       <dd>Launch the <code>cylc gui</code> for the suite in <var>$PWD</var>.


### PR DESCRIPTION
This adds `rose suite-run --restart` to the quick reference.

@arjclark, please review.
