### PR TITLE
Allow rose-stem to read a variable from the rose.conf file

### DIFF
--- a/doc/rose-rug-advanced-tutorials-rose-stem.html
+++ b/doc/rose-rug-advanced-tutorials-rose-stem.html
@@ -397,18 +397,22 @@ rose-stem/app/spaceship/rose-app.conf
       </div>
 
       <div class="slide">
-        <h2 id="portable">Portable Suites</h2>
+        <h2 id="autoopts">Automatic Options</h2>
 
-        <p>It is possible to create more portable rose-stem suites by using
-        a Jinja2 variable named <code>SITE</code> and triggering various
-        parts of the suite.rc using that. This variable can be set normally
-        in the <kbd>rose-suite.conf</kbd> file, or in a section named
-        <code>[rose-stem]</code> in the site <kbd>rose.conf</kbd> file using
-        the variable <code>site</code> (note the case), for example: </p>
+        <p>It is possible to automatically add options to rose-stem using
+        the <kbd>automatic-options</kbd> variable in a section named
+        <code>[rose-stem]</code> in the site <kbd>rose.conf</kbd> file. This
+        takes the syntax of key-value pairs on a single line, and is 
+        functionally equivalent to adding them using the -S option on the 
+        rose-stem command line. For example:</p>
         <pre>
 [rose-stem]
-site=myhouse
+automatic-options=GRAVITY=newtonian PLANET=jupiter
 </pre>
+        <p>sets the variable <kbd>GRAVITY</kbd> to have the value 
+        <code>newtonian</code>, and <kbd>PLANET</kbd> to be 
+        <code>jupiter</code>. These can then be used in the <kbd>suite.rc</kbd>
+        file as Jinja2 variables. </p>
       </div>
 
     </div>

--- a/lib/python/rose/stem.py
+++ b/lib/python/rose/stem.py
@@ -265,15 +265,10 @@ class StemRunner(object):
             raise RoseSuiteConfNotFoundException(suitedir)
         return suitedir
 
-    def _read_site_config_and_return_site(self):
+    def _read_site_config_and_return_options(self):
         """Read the site rose.conf file."""
-        
-        conf = ResourceLocator.default().get_conf()
-        site = conf.get(["rose-stem", "site"])
-        if site:
-            return site.value
-        else:
-            return None
+        return ResourceLocator.default().get_conf().get_value(["rose-stem", 
+                "automatic-options"])
 
     def process(self):
         """Process STEM options into 'rose suite-run' options."""
@@ -312,10 +307,15 @@ class StemRunner(object):
             self.opts.defines.append(SUITE_RC_PREFIX + 'RUN_NAMES=' +
                                      str(expanded_groups))
 
-        # Load the site config file
-        site = self._read_site_config_and_return_site()
-        if site:
-            self._add_define_option("SITE", '"' + site + '"')
+        # Load the config file and return any automatic-options
+        auto_opts = self._read_site_config_and_return_options()
+        if auto_opts:
+            automatic_options = auto_opts.split()
+            for option in automatic_options:
+                elements = option.split("=")
+                if len(elements) == 2:
+                    self._add_define_option(elements[0], 
+                                      '"' + elements[1] + '"')
 
         # Change into the suite directory
         if self.opts.conf_dir:

--- a/t/rose-stem/00-run-basic/suite.rc
+++ b/t/rose-stem/00-run-basic/suite.rc
@@ -17,6 +17,13 @@ echo RUN_NAMES={{RUN_NAMES}}
 echo SOURCE_FOO={{SOURCE_FOO}}
 echo SOURCE_FOO_BASE={{SOURCE_FOO_BASE}}
 echo SOURCE_FOO_REV={{SOURCE_FOO_REV}}
+{%- if TEA is defined %}
+echo TEA={{TEA}}
+{%- endif %}
+{%- if MILK is defined %}
+echo MILK={{MILK}}
+{%- endif %}
+
 """
         [[[event hooks]]]
            succeeded handler=rose suite-hook


### PR DESCRIPTION
Attempt to look into #1315, which is supposed to allow rose-stem to read a 'site' variable from the rose.conf file to allow the value to be defined once per site, rather than by every user on the command line every time they run rose-stem.

@matthewrmshin, when you get chance would you mind reviewing this please? (if you can think of a better way of doing it I'm happy to go with it)
