### PR TITLE
Fix typo. Change title so doesn't mess up auto index.

### DIFF
--- a/doc/rose-configuration-metadata.html
+++ b/doc/rose-configuration-metadata.html
@@ -344,7 +344,7 @@ sort-key=do-not-like-00
 
         <p>For example, the config editor may use this list to determine the
         widget to display the setting. It may display the choices using a set
-        of radio buttons if the list of values is small, or a drop down combon
+        of radio buttons if the list of values is small, or a drop down combo
         box if the list of values is large. If the list only contains one
         value, the config editor will expect the setting to always have this
         value, and may display it as a special setting.</p>

--- a/doc/rose-variables.html
+++ b/doc/rose-variables.html
@@ -273,8 +273,8 @@
       <li><a href="rose-command.html#rose-mpi-launch">rose mpi-launch</a></li>
     </ul>
 
-    <h2 id="ROSE_LAUNCHER_ULIMIT_OPTS">
-    <var>ROSE_LAUNCHER_ULIMIT_OPTS</var></h2>
+    <h2 id="ROSE_LAUNCHER_ULIMIT_OPTS"><var>ROSE_LAUNCHER_ULIMIT_OPTS</var>
+    </h2>
 
     <h3>Description</h3>
 


### PR DESCRIPTION
Makes the following changes:
- Correct a typo
- Alter line so space isn't rendered in the title and by the auto generated contents entry 
