### PR TITLE
rosie ls: fix incorrect examples in doc

### DIFF
--- a/bin/rosie-ls
+++ b/bin/rosie-ls
@@ -47,7 +47,7 @@
 #     --print-format=FORMAT, --format=FORMAT, -f FORMAT
 #         Control the output format of the results using a string
 #         containing column names or properties preceded by %.
-#         For example: rose suite-list --format="%idx from %owner"
+#         For example: rosie ls --format="%idx from %owner"
 #         might give: abc01 from daisy
 #     --quiet, -q
 #         Shorthand for --format="%idx".

--- a/doc/rose-command.html
+++ b/doc/rose-command.html
@@ -2916,7 +2916,7 @@ abc01 from daisy
       column names or properties preceded by <kbd>%</kbd>.</dd>
 
       <dd>
-        For example: <kbd>rose suite-list --format="%idx from %owner"</kbd>
+        For example: <kbd>rosie ls --format="%idx from %owner"</kbd>
         might give:
         <pre>
 abc01 from daisy


### PR DESCRIPTION
Was referring to `rose suite-list`.

Close #1343.
