### PR TITLE
rose metadata: fail-if/warn-if: work for duplicate sections

### DIFF
--- a/lib/python/rose/macros/trigger.py
+++ b/lib/python/rose/macros/trigger.py
@@ -489,8 +489,9 @@ class TriggerMacro(rose.macro.MacroBaseRoseEdit):
             section, option = self._get_section_option_from_id(setting_id)
             tiny_config = rose.config.ConfigNode()
             tiny_config.set([section, option], value)
+            tiny_meta_config = rose.config.ConfigNode()
             check_failed = self.evaluator.evaluate_rule(
-                                        rule, setting_id, tiny_config)
+                rule, setting_id, tiny_config, tiny_meta_config)
             if len(self._evaluated_rule_checks) > self.MAX_STORED_RULE_CHECKS:
                 self._evaluated_rule_checks.popitem()
             self._evaluated_rule_checks[(rule, value)] = check_failed

--- a/lib/python/rose/macros/value.py
+++ b/lib/python/rose/macros/value.py
@@ -262,10 +262,11 @@ class ValueChecker(rose.macro.MacroBase):
                 break
             if is_range_complex:
                 tiny_config.set([sect, key], val)
+                tiny_meta_config = rose.config.ConfigNode()
                 evaluator = rose.macros.rule.RuleEvaluator()
                 try:
                     check_ok = evaluator.evaluate_rule(
-                                            range_pat, var_id, tiny_config)
+                        range_pat, var_id, tiny_config, tiny_meta_config)
                 except rose.macros.rule.RuleValueError:
                     pass
             else:

--- a/lib/python/rose/metadata_check.py
+++ b/lib/python/rose/metadata_check.py
@@ -70,7 +70,8 @@ def _check_duplicate(value):
 
 def _check_rule(value, setting_id, meta_config):
     evaluator = rose.macros.rule.RuleEvaluator()
-    ids_used = evaluator.evaluate_rule_id_usage(value, setting_id)
+    ids_used = evaluator.evaluate_rule_id_usage(
+        value, setting_id, meta_config)
     ids_not_found = []
     for id_ in sorted(ids_used):
         id_to_find = rose.macro.REC_ID_STRIP.sub("", id_)
@@ -131,10 +132,11 @@ def _check_range(value):
         test_config = rose.config.ConfigNode()
         test_id = "env=A"
         test_config.set(["env", "A"], "0")
+        test_meta_config = rose.config.ConfigNode()
         evaluator =  rose.macros.rule.RuleEvaluator()
         try:
             check_ok = evaluator.evaluate_rule(
-                                          value, test_id, test_config)
+                value, test_id, test_config, test_meta_config)
         except rose.macros.rule.RuleValueError as e:
             return INVALID_RANGE_RULE_IDS.format(e)
         except Exception as e:

--- a/t/rose-macro/09-rule-check.t
+++ b/t/rose-macro/09-rule-check.t
@@ -85,6 +85,14 @@ control_len_array = 0, 1, 2, 3, 4
 test_var_1 = 1
 test_var_2 = 50
 test_var_3 = -1
+
+[simple:duplicate(1)]
+test_var_1 = 2
+test_var_2 = -1
+
+[simple:duplicate(2)]
+test_var_1 = -1
+test_var_2 = 2
 __CONFIG__
 #-------------------------------------------------------------------------------
 tests 3
@@ -265,6 +273,15 @@ description=Fail if element 2 is not '0A' and element 4 is '0A'
 fail-if=this(2) != "'0A'" and this(4) == "'0A'"
 length=:
 
+[simple:duplicate]
+duplicate=true
+
+[simple:duplicate=test_var_1]
+fail-if=this == 2
+
+[simple:duplicate=test_var_2]
+fail-if=this < simple:duplicate=test_var_1
+
 [simple:scalar_test]
 
 [simple:scalar_test=control_less_than]
@@ -354,7 +371,7 @@ __META_CONFIG__
 run_fail "$TEST_KEY" rose macro --config=../config rose.macros.DefaultValidators
 file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" <<'__CONTENT__'
-[V] rose.macros.DefaultValidators: issues: 19
+[V] rose.macros.DefaultValidators: issues: 21
     complex:array_test=test_array_len_fail=0, 1, 2
         failed because: len(this) > len(complex:array_test=control_len_array) or len(this) < len(complex:array_test=control_len_array)
     complex:array_test=test_var_all_ne_fail=6
@@ -383,6 +400,10 @@ file_cmp "$TEST_KEY.err" "$TEST_KEY.err" <<'__CONTENT__'
         failed because: this(2) != "'0A'" and this(4) == "'0A'"
     simple:array_test=test_array_len_fail=0, 1, 2
         failed because: len(this) != 5
+    simple:duplicate(1)=test_var_1=2
+        failed because: this == 2
+    simple:duplicate(1)=test_var_2=-1
+        failed because: this < simple:duplicate=test_var_1
     simple:scalar_test=test_substring_fail="ABCDEFG"
         failed because: "D" in this
     simple:scalar_test=test_var_div_zero_fail=0


### PR DESCRIPTION
The current logic for checking `fail-if/warn-if` metadata does not know about
duplicate sections - this adds the correct behaviour.

@arjclark, please review.
