### PR TITLE
t/rose-task-run/*-iso.t: fix mixed cylc 5/6 syntax

### DIFF
--- a/t/rose-suite-run/14-reload-null.t
+++ b/t/rose-suite-run/14-reload-null.t
@@ -45,7 +45,8 @@ hello world
 hello earth
 __TXT__
 run_pass "$TEST_KEY" rose suite-run --run=reload -n $NAME --no-gcontrol -C src
-sed '1,/export ROSE_VERSION=/d' "$TEST_KEY.out" >"$TEST_KEY.out.tail"
+sed '1,/export ROSE_VERSION=/d; /\/.cylc\//d' "$TEST_KEY.out" \
+    >"$TEST_KEY.out.tail"
 file_cmp "$TEST_KEY.out" "$TEST_KEY.out.tail" <<__OUT__
 [INFO] install: hello.txt
 [INFO]     source: $PWD/src/hello.txt

--- a/t/rose-task-run/01-run-basic-iso/suite.rc
+++ b/t/rose-task-run/01-run-basic-iso/suite.rc
@@ -2,16 +2,14 @@
 [cylc]
     UTC mode = True
     [[event hooks]]
-        timeout handler = "rose suite-hook --shutdown"
-        timeout = 2
+        timeout handler = rose suite-hook --shutdown
+        timeout = PT2M
 [scheduling]
     initial cycle point = 20130101T0000Z
     final cycle point   = 20130102T0000Z
     [[dependencies]]
         [[[ PT12H ]]]
-            graph = """
-my_task_1
-"""
+            graph = my_task_1
 
 [runtime]
     [[root]]
@@ -19,11 +17,11 @@ my_task_1
 rose task-run --debug --cycle-offset=PT12H --path=MY_PATH='etc/my-path/*'
 """
         [[[event hooks]]]
-           succeeded handler = "rose suite-hook"
-           failed handler = "rose suite-hook --shutdown"
-           submission failed handler = "rose suite-hook --shutdown"
-           submission timeout handler = "rose suite-hook"
-           execution timeout handler = "rose suite-hook"
-           submission timeout = 1
-           execution timeout  = 1
+           succeeded handler = rose suite-hook
+           failed handler = rose suite-hook --shutdown
+           submission failed handler = rose suite-hook --shutdown
+           submission timeout handler = rose suite-hook
+           execution timeout handler = rose suite-hook
+           submission timeout = PT1M
+           execution timeout  = PT1M
     [[my_task_1]]

--- a/t/rose-task-run/03-env-basic-iso/suite.rc
+++ b/t/rose-task-run/03-env-basic-iso/suite.rc
@@ -3,7 +3,7 @@
     UTC mode = True
     [[event hooks]]
         timeout handler = rose suite-hook --shutdown
-        timeout = 2
+        timeout = PT2M
 [scheduling]
     initial cycle point = 20130101T0000Z
     final cycle point = 20130102T0000Z
@@ -23,6 +23,6 @@ eval $(rose task-env --cycle-offset=PT12H --path=MY_PATH='etc/my-path/*')
            submission failed handler = rose suite-hook --shutdown
            submission timeout handler = rose suite-hook
            execution timeout handler = rose suite-hook
-           submission timeout = 1
-           execution timeout = 1
+           submission timeout = PT1M
+           execution timeout = PT1M
     [[my_task_1]]

--- a/t/rose-task-run/06-app-prune-iso/suite.rc
+++ b/t/rose-task-run/06-app-prune-iso/suite.rc
@@ -2,11 +2,11 @@
 [cylc]
     UTC mode = True
     [[event hooks]]
-        timeout handler = "rose suite-hook --shutdown"
-        timeout = 1
+        timeout handler = rose suite-hook --shutdown
+        timeout = PT1M
 [scheduling]
     initial cycle point = 20130101T0000Z
-    final cycle point   = 20130103T0000Z
+    final cycle point = 20130103T0000Z
     [[dependencies]]
         [[[ PT12H ]]]
             graph = """
@@ -19,17 +19,17 @@ WARM[-PT12H]:finish-all => rose_prune
 
 [runtime]
     [[root]]
-        command scripting = "rose task-run"
+        command scripting = rose task-run
         [[[event hooks]]]
-            succeeded handler = "rose suite-hook"
-            failed handler = "rose suite-hook"
-            submission failed handler = "rose suite-hook --shutdown"
-            submission timeout handler = "rose suite-hook"
-            execution timeout handler = "rose suite-hook"
-            submission timeout = 1
-            execution timeout  = 1
+            succeeded handler = rose suite-hook
+            failed handler = rose suite-hook
+            submission failed handler = rose suite-hook --shutdown
+            submission timeout handler = rose suite-hook
+            execution timeout handler = rose suite-hook
+            submission timeout = PT1M
+            execution timeout  = PT1M
     [[cold]]
-        command scripting = "true"
+        command scripting = true
     [[WARM]]
     [[my_task_1]]
         inherit = WARM

--- a/t/rose-task-run/11-specify-cycle-iso/suite.rc
+++ b/t/rose-task-run/11-specify-cycle-iso/suite.rc
@@ -3,7 +3,7 @@
     UTC mode=True
     [[event hooks]]
         timeout handler=rose suite-hook --shutdown
-        timeout=1
+        timeout=PT1M
 [scheduling]
     initial cycle point=20130101T0000Z
     final cycle point=20130101T0000Z
@@ -20,5 +20,5 @@
            submission failed handler=rose suite-hook --shutdown
            submission timeout handler=rose suite-hook
            execution timeout handler=rose suite-hook
-           submission timeout=1
-           execution timeout=1
+           submission timeout=PT1M
+           execution timeout=PT1M


### PR DESCRIPTION
Tests broken by cylc/cylc#1076. They were skipping.

Also make `t/rose-suite-run/14-reload-null.t` more robust.
