### PR TITLE
#1268: add more default metadata

### DIFF
--- a/etc/rose-meta/rose-app-conf/rose-meta.conf
+++ b/etc/rose-meta/rose-app-conf/rose-meta.conf
@@ -27,6 +27,9 @@ title=command default
 [env]
 description=Environment variable configuration
 
+[file]
+description=File installation configuration
+
 # Note: the following 'file:*' syntax is unique, and has no wildcard.
 # Wildcard operators in metadata sections are not supported.
 [file:*=checksum]
@@ -108,3 +111,6 @@ help=Specify a custom test to be run on each file path in either poll=any-files 
 help=A shell command.
     =
     = This test passes if the command returns a 0 (zero) return code.
+
+[ns=namelist]
+description=Namelist configuration root page - see sub-pages, if any.


### PR DESCRIPTION
This adds some information for `file` and `namelist` root pages.

Close #1268.
