### PR TITLE
Fix tests for cylc/cylc#1118

### DIFF
--- a/t/rose-suite-log/00-update-task.t
+++ b/t/rose-suite-log/00-update-task.t
@@ -50,7 +50,7 @@ sqlite3 "$HOME/cylc-run/$NAME/log/rose-job-logs.db" \
     'SELECT path,key FROM log_files ORDER BY path ASC;' >"$TEST_KEY.out"
 file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<'__OUT__'
 log/job/1/my_task_1/01/job|00-script
-log/job/1/my_task_1/01/job-submit.out|job-submit.out
+log/job/1/my_task_1/01/job-activity.log|job-activity.log
 log/job/1/my_task_1/01/job.err|02-err
 log/job/1/my_task_1/01/job.out|01-out
 __OUT__
@@ -70,11 +70,11 @@ sqlite3 "$HOME/cylc-run/$NAME/log/rose-job-logs.db" \
     'SELECT path,key FROM log_files ORDER BY path ASC;' >"$TEST_KEY.out"
 file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<'__OUT__'
 log/job/1/my_task_1/01/job|00-script
-log/job/1/my_task_1/01/job-submit.out|job-submit.out
+log/job/1/my_task_1/01/job-activity.log|job-activity.log
 log/job/1/my_task_1/01/job.err|02-err
 log/job/1/my_task_1/01/job.out|01-out
 log/job/1/my_task_2/01/job|00-script
-log/job/1/my_task_2/01/job-submit.out|job-submit.out
+log/job/1/my_task_2/01/job-activity.log|job-activity.log
 log/job/1/my_task_2/01/job.err|02-err
 log/job/1/my_task_2/01/job.out|01-out
 __OUT__

--- a/t/rose-suite-log/01-update-cycle.t
+++ b/t/rose-suite-log/01-update-cycle.t
@@ -52,7 +52,7 @@ fi
 # Test --archive.
 CYCLE=2013010100
 TEST_KEY="$TEST_KEY_BASE-archive-$CYCLE"
-(cd $SUITE_RUN_DIR/log; ls job/$CYCLE/*/01/{job,job-submit.out,job.err,job.out}) \
+(cd $SUITE_RUN_DIR/log; ls job/$CYCLE/*/01/{job,job-activity.log,job.err,job.out}) \
     >"$TEST_KEY-list-job-logs-before.out"
 if [[ -n ${JOB_HOST:-} ]]; then
     ssh -oBatchMode=yes $JOB_HOST \
@@ -64,15 +64,15 @@ sqlite3 "$HOME/cylc-run/$NAME/log/rose-job-logs.db" \
     >"$TEST_KEY-db-1.out"
 file_cmp "$TEST_KEY-db-1.out" "$TEST_KEY-db-1.out" <<'__OUT__'
 log/job/2013010100/my_task_1/01/job||00-script
-log/job/2013010100/my_task_1/01/job-submit.out||job-submit.out
+log/job/2013010100/my_task_1/01/job-activity.log||job-activity.log
 log/job/2013010100/my_task_1/01/job.err||02-err
 log/job/2013010100/my_task_1/01/job.out||01-out
 log/job/2013010112/my_task_1/01/job||00-script
-log/job/2013010112/my_task_1/01/job-submit.out||job-submit.out
+log/job/2013010112/my_task_1/01/job-activity.log||job-activity.log
 log/job/2013010112/my_task_1/01/job.err||02-err
 log/job/2013010112/my_task_1/01/job.out||01-out
 log/job/2013010200/my_task_1/01/job||00-script
-log/job/2013010200/my_task_1/01/job-submit.out||job-submit.out
+log/job/2013010200/my_task_1/01/job-activity.log||job-activity.log
 log/job/2013010200/my_task_1/01/job.err||02-err
 log/job/2013010200/my_task_1/01/job.out||01-out
 __OUT__
@@ -100,19 +100,19 @@ sqlite3 "$HOME/cylc-run/$NAME/log/rose-job-logs.db" \
     >"$TEST_KEY-db-2.out"
 file_cmp "$TEST_KEY-db-2.out" "$TEST_KEY-db-2.out" <<'__OUT__'
 log/job-2013010100.tar.gz|job/2013010100/my_task_1/01/job|00-script
-log/job-2013010100.tar.gz|job/2013010100/my_task_1/01/job-submit.out|job-submit.out
+log/job-2013010100.tar.gz|job/2013010100/my_task_1/01/job-activity.log|job-activity.log
 log/job-2013010100.tar.gz|job/2013010100/my_task_1/01/job.err|02-err
 log/job-2013010100.tar.gz|job/2013010100/my_task_1/01/job.out|01-out
 log/job-2013010100.tar.gz|job/2013010100/my_task_2/01/job|00-script
-log/job-2013010100.tar.gz|job/2013010100/my_task_2/01/job-submit.out|job-submit.out
+log/job-2013010100.tar.gz|job/2013010100/my_task_2/01/job-activity.log|job-activity.log
 log/job-2013010100.tar.gz|job/2013010100/my_task_2/01/job.err|02-err
 log/job-2013010100.tar.gz|job/2013010100/my_task_2/01/job.out|01-out
 log/job/2013010112/my_task_1/01/job||00-script
-log/job/2013010112/my_task_1/01/job-submit.out||job-submit.out
+log/job/2013010112/my_task_1/01/job-activity.log||job-activity.log
 log/job/2013010112/my_task_1/01/job.err||02-err
 log/job/2013010112/my_task_1/01/job.out||01-out
 log/job/2013010200/my_task_1/01/job||00-script
-log/job/2013010200/my_task_1/01/job-submit.out||job-submit.out
+log/job/2013010200/my_task_1/01/job-activity.log||job-activity.log
 log/job/2013010200/my_task_1/01/job.err||02-err
 log/job/2013010200/my_task_1/01/job.out||01-out
 __OUT__
@@ -130,27 +130,27 @@ sqlite3 "$HOME/cylc-run/$NAME/log/rose-job-logs.db" \
     >"$TEST_KEY_BASE-db-final.out"
 file_cmp "$TEST_KEY_BASE-db-final.out" "$TEST_KEY_BASE-db-final.out" <<'__OUT__'
 log/job-2013010100.tar.gz|job/2013010100/my_task_1/01/job|00-script
-log/job-2013010100.tar.gz|job/2013010100/my_task_1/01/job-submit.out|job-submit.out
+log/job-2013010100.tar.gz|job/2013010100/my_task_1/01/job-activity.log|job-activity.log
 log/job-2013010100.tar.gz|job/2013010100/my_task_1/01/job.err|02-err
 log/job-2013010100.tar.gz|job/2013010100/my_task_1/01/job.out|01-out
 log/job-2013010100.tar.gz|job/2013010100/my_task_2/01/job|00-script
-log/job-2013010100.tar.gz|job/2013010100/my_task_2/01/job-submit.out|job-submit.out
+log/job-2013010100.tar.gz|job/2013010100/my_task_2/01/job-activity.log|job-activity.log
 log/job-2013010100.tar.gz|job/2013010100/my_task_2/01/job.err|02-err
 log/job-2013010100.tar.gz|job/2013010100/my_task_2/01/job.out|01-out
 log/job/2013010112/my_task_1/01/job||00-script
-log/job/2013010112/my_task_1/01/job-submit.out||job-submit.out
+log/job/2013010112/my_task_1/01/job-activity.log||job-activity.log
 log/job/2013010112/my_task_1/01/job.err||02-err
 log/job/2013010112/my_task_1/01/job.out||01-out
 log/job/2013010112/my_task_2/01/job||00-script
-log/job/2013010112/my_task_2/01/job-submit.out||job-submit.out
+log/job/2013010112/my_task_2/01/job-activity.log||job-activity.log
 log/job/2013010112/my_task_2/01/job.err||02-err
 log/job/2013010112/my_task_2/01/job.out||01-out
 log/job/2013010200/my_task_1/01/job||00-script
-log/job/2013010200/my_task_1/01/job-submit.out||job-submit.out
+log/job/2013010200/my_task_1/01/job-activity.log||job-activity.log
 log/job/2013010200/my_task_1/01/job.err||02-err
 log/job/2013010200/my_task_1/01/job.out||01-out
 log/job/2013010200/my_task_2/01/job||00-script
-log/job/2013010200/my_task_2/01/job-submit.out||job-submit.out
+log/job/2013010200/my_task_2/01/job-activity.log||job-activity.log
 log/job/2013010200/my_task_2/01/job.err||02-err
 log/job/2013010200/my_task_2/01/job.out||01-out
 __OUT__

--- a/t/rose-suite-log/02-update-force.t
+++ b/t/rose-suite-log/02-update-force.t
@@ -75,27 +75,27 @@ sqlite3 "$HOME/cylc-run/$NAME/log/rose-job-logs.db" \
     'SELECT path,key FROM log_files ORDER BY path ASC;' >"$TEST_KEY.out"
 file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<'__OUT__'
 log/job/2013010100/my_task_1/01/job|00-script
-log/job/2013010100/my_task_1/01/job-submit.out|job-submit.out
+log/job/2013010100/my_task_1/01/job-activity.log|job-activity.log
 log/job/2013010100/my_task_1/01/job.err|02-err
 log/job/2013010100/my_task_1/01/job.out|01-out
 log/job/2013010100/my_task_2/01/job|00-script
-log/job/2013010100/my_task_2/01/job-submit.out|job-submit.out
+log/job/2013010100/my_task_2/01/job-activity.log|job-activity.log
 log/job/2013010100/my_task_2/01/job.err|02-err
 log/job/2013010100/my_task_2/01/job.out|01-out
 log/job/2013010112/my_task_1/01/job|00-script
-log/job/2013010112/my_task_1/01/job-submit.out|job-submit.out
+log/job/2013010112/my_task_1/01/job-activity.log|job-activity.log
 log/job/2013010112/my_task_1/01/job.err|02-err
 log/job/2013010112/my_task_1/01/job.out|01-out
 log/job/2013010112/my_task_2/01/job|00-script
-log/job/2013010112/my_task_2/01/job-submit.out|job-submit.out
+log/job/2013010112/my_task_2/01/job-activity.log|job-activity.log
 log/job/2013010112/my_task_2/01/job.err|02-err
 log/job/2013010112/my_task_2/01/job.out|01-out
 log/job/2013010200/my_task_1/01/job|00-script
-log/job/2013010200/my_task_1/01/job-submit.out|job-submit.out
+log/job/2013010200/my_task_1/01/job-activity.log|job-activity.log
 log/job/2013010200/my_task_1/01/job.err|02-err
 log/job/2013010200/my_task_1/01/job.out|01-out
 log/job/2013010200/my_task_2/01/job|00-script
-log/job/2013010200/my_task_2/01/job-submit.out|job-submit.out
+log/job/2013010200/my_task_2/01/job-activity.log|job-activity.log
 log/job/2013010200/my_task_2/01/job.err|02-err
 log/job/2013010200/my_task_2/01/job.out|01-out
 __OUT__

--- a/t/rose-suite-log/06-archive-star.t
+++ b/t/rose-suite-log/06-archive-star.t
@@ -52,7 +52,7 @@ fi
 TEST_KEY="$TEST_KEY_BASE"
 
 set -e
-(cd $SUITE_RUN_DIR/log/job; ls */*/01/{job,job-submit.out,job.err,job.out}) \
+(cd $SUITE_RUN_DIR/log/job; ls */*/01/{job,job-activity.log,job.err,job.out}) \
     >"$TEST_KEY-list-job-logs-before.out"
 if [[ -n ${JOB_HOST:-} ]]; then
     ssh -oBatchMode=yes $JOB_HOST \
@@ -66,15 +66,15 @@ sqlite3 "$HOME/cylc-run/$NAME/log/rose-job-logs.db" \
     >"$TEST_KEY-db-1.out"
 file_cmp "$TEST_KEY-db-1.out" "$TEST_KEY-db-1.out" <<'__OUT__'
 log/job/2013010100/my_task_1/01/job||00-script
-log/job/2013010100/my_task_1/01/job-submit.out||job-submit.out
+log/job/2013010100/my_task_1/01/job-activity.log||job-activity.log
 log/job/2013010100/my_task_1/01/job.err||02-err
 log/job/2013010100/my_task_1/01/job.out||01-out
 log/job/2013010112/my_task_1/01/job||00-script
-log/job/2013010112/my_task_1/01/job-submit.out||job-submit.out
+log/job/2013010112/my_task_1/01/job-activity.log||job-activity.log
 log/job/2013010112/my_task_1/01/job.err||02-err
 log/job/2013010112/my_task_1/01/job.out||01-out
 log/job/2013010200/my_task_1/01/job||00-script
-log/job/2013010200/my_task_1/01/job-submit.out||job-submit.out
+log/job/2013010200/my_task_1/01/job-activity.log||job-activity.log
 log/job/2013010200/my_task_1/01/job.err||02-err
 log/job/2013010200/my_task_1/01/job.out||01-out
 __OUT__
@@ -83,7 +83,7 @@ N_JOB_LOGS=$(wc -l "$TEST_KEY-list-job-logs-before.out" | cut -d' ' -f1)
 run_pass "$TEST_KEY-command" rose suite-log -n $NAME --archive '*' --debug
 run_fail "$TEST_KEY-list-job-logs-after" ls $SUITE_RUN_DIR/log/job/*
 if [[ -n ${JOB_HOST:-} ]]; then
-    ((N_JOB_LOGS += 3)) # job, job.submit.out, job.out and job.err files
+    ((N_JOB_LOGS += 3)) # job, job.activity.log, job.out and job.err files
     run_fail "$TEST_KEY-job-log.out-after-jobhost" \
         ssh -oBatchMode=yes $JOB_HOST \
         test -f cylc-run/$NAME/log/job/*/my_task_2/01/job.out
@@ -116,27 +116,27 @@ sqlite3 "$HOME/cylc-run/$NAME/log/rose-job-logs.db" \
     >"$TEST_KEY-db-2.out"
 file_cmp "$TEST_KEY-db-2.out" "$TEST_KEY-db-2.out" <<'__OUT__'
 log/job-2013010100.tar.gz|job/2013010100/my_task_1/01/job|00-script
-log/job-2013010100.tar.gz|job/2013010100/my_task_1/01/job-submit.out|job-submit.out
+log/job-2013010100.tar.gz|job/2013010100/my_task_1/01/job-activity.log|job-activity.log
 log/job-2013010100.tar.gz|job/2013010100/my_task_1/01/job.err|02-err
 log/job-2013010100.tar.gz|job/2013010100/my_task_1/01/job.out|01-out
 log/job-2013010100.tar.gz|job/2013010100/my_task_2/01/job|00-script
-log/job-2013010100.tar.gz|job/2013010100/my_task_2/01/job-submit.out|job-submit.out
+log/job-2013010100.tar.gz|job/2013010100/my_task_2/01/job-activity.log|job-activity.log
 log/job-2013010100.tar.gz|job/2013010100/my_task_2/01/job.err|02-err
 log/job-2013010100.tar.gz|job/2013010100/my_task_2/01/job.out|01-out
 log/job-2013010112.tar.gz|job/2013010112/my_task_1/01/job|00-script
-log/job-2013010112.tar.gz|job/2013010112/my_task_1/01/job-submit.out|job-submit.out
+log/job-2013010112.tar.gz|job/2013010112/my_task_1/01/job-activity.log|job-activity.log
 log/job-2013010112.tar.gz|job/2013010112/my_task_1/01/job.err|02-err
 log/job-2013010112.tar.gz|job/2013010112/my_task_1/01/job.out|01-out
 log/job-2013010112.tar.gz|job/2013010112/my_task_2/01/job|00-script
-log/job-2013010112.tar.gz|job/2013010112/my_task_2/01/job-submit.out|job-submit.out
+log/job-2013010112.tar.gz|job/2013010112/my_task_2/01/job-activity.log|job-activity.log
 log/job-2013010112.tar.gz|job/2013010112/my_task_2/01/job.err|02-err
 log/job-2013010112.tar.gz|job/2013010112/my_task_2/01/job.out|01-out
 log/job-2013010200.tar.gz|job/2013010200/my_task_1/01/job|00-script
-log/job-2013010200.tar.gz|job/2013010200/my_task_1/01/job-submit.out|job-submit.out
+log/job-2013010200.tar.gz|job/2013010200/my_task_1/01/job-activity.log|job-activity.log
 log/job-2013010200.tar.gz|job/2013010200/my_task_1/01/job.err|02-err
 log/job-2013010200.tar.gz|job/2013010200/my_task_1/01/job.out|01-out
 log/job-2013010200.tar.gz|job/2013010200/my_task_2/01/job|00-script
-log/job-2013010200.tar.gz|job/2013010200/my_task_2/01/job-submit.out|job-submit.out
+log/job-2013010200.tar.gz|job/2013010200/my_task_2/01/job-activity.log|job-activity.log
 log/job-2013010200.tar.gz|job/2013010200/my_task_2/01/job.err|02-err
 log/job-2013010200.tar.gz|job/2013010200/my_task_2/01/job.out|01-out
 __OUT__


### PR DESCRIPTION
Now submit outputs are in the job activity log. Companion change for cylc/cylc#1118.
