### PR TITLE
Remove job logs database keys

### DIFF
--- a/lib/python/rose/suite_engine_procs/cylc.py
+++ b/lib/python/rose/suite_engine_procs/cylc.py
@@ -63,10 +63,6 @@ class CylcProcessor(SuiteEngineProcessor):
     EVENT_RANKS = {"submit-init": 0, "submit": 1, "fail(submit)": 1, "init": 2,
                    "success": 3, "fail": 3, "fail(%s)": 4}
     JOB_LOGS_DB = "log/rose-job-logs.db"
-    JOB_LOG_TAIL_KEYS = {
-        "job": "00-script",
-        "job.out": "01-out",
-        "job.err": "02-err"}
     ORDERS = {
             "time_desc":
             "time DESC, task_events.submit_num DESC, name DESC, cycle DESC",
@@ -809,16 +805,13 @@ class CylcProcessor(SuiteEngineProcessor):
                     cycle, task, s_n, ext = self._parse_job_log_base_name(name)
                     if s_n == "NN" or ext == "job.status":
                         continue
-                    key = ext
-                    if ext in self.JOB_LOG_TAIL_KEYS:
-                        key = self.JOB_LOG_TAIL_KEYS[ext]
                     stmt_args = [
                         os.path.join(archive_file_name),
                         name.replace("log/", "", 1),
                         cycle,
                         task,
                         int(s_n),
-                        key]
+                        ext]
                     self._db_exec(self.JOB_LOGS_DB, None, suite_name,
                                   stmt, stmt_args, commit=True)
         finally:
@@ -963,10 +956,7 @@ class CylcProcessor(SuiteEngineProcessor):
                     rel_f_name)
                 if s_n == "NN":
                     continue
-                key = ext
-                if ext in self.JOB_LOG_TAIL_KEYS:
-                    key = self.JOB_LOG_TAIL_KEYS[ext]
-                stmt_args = [cycle, task, int(s_n), key, rel_f_name, "",
+                stmt_args = [cycle, task, int(s_n), ext, rel_f_name, "",
                              stat.st_mtime, stat.st_size]
                 dao.execute(stmt, stmt_args)
         dao.commit()

--- a/t/rose-suite-log/00-update-task.t
+++ b/t/rose-suite-log/00-update-task.t
@@ -49,10 +49,10 @@ TEST_KEY="$TEST_KEY_BASE-db-before"
 sqlite3 "$HOME/cylc-run/$NAME/log/rose-job-logs.db" \
     'SELECT path,key FROM log_files ORDER BY path ASC;' >"$TEST_KEY.out"
 file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<'__OUT__'
-log/job/1/my_task_1/01/job|00-script
+log/job/1/my_task_1/01/job|job
 log/job/1/my_task_1/01/job-activity.log|job-activity.log
-log/job/1/my_task_1/01/job.err|02-err
-log/job/1/my_task_1/01/job.out|01-out
+log/job/1/my_task_1/01/job.err|job.err
+log/job/1/my_task_1/01/job.out|job.out
 __OUT__
 TEST_KEY=$TEST_KEY_BASE-before-log.out
 if [[ -n ${JOB_HOST:-} ]]; then
@@ -69,14 +69,14 @@ TEST_KEY="$TEST_KEY_BASE-db-after"
 sqlite3 "$HOME/cylc-run/$NAME/log/rose-job-logs.db" \
     'SELECT path,key FROM log_files ORDER BY path ASC;' >"$TEST_KEY.out"
 file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<'__OUT__'
-log/job/1/my_task_1/01/job|00-script
+log/job/1/my_task_1/01/job|job
 log/job/1/my_task_1/01/job-activity.log|job-activity.log
-log/job/1/my_task_1/01/job.err|02-err
-log/job/1/my_task_1/01/job.out|01-out
-log/job/1/my_task_2/01/job|00-script
+log/job/1/my_task_1/01/job.err|job.err
+log/job/1/my_task_1/01/job.out|job.out
+log/job/1/my_task_2/01/job|job
 log/job/1/my_task_2/01/job-activity.log|job-activity.log
-log/job/1/my_task_2/01/job.err|02-err
-log/job/1/my_task_2/01/job.out|01-out
+log/job/1/my_task_2/01/job.err|job.err
+log/job/1/my_task_2/01/job.out|job.out
 __OUT__
 #-------------------------------------------------------------------------------
 rose suite-clean -q -y $NAME

--- a/t/rose-suite-log/01-update-cycle.t
+++ b/t/rose-suite-log/01-update-cycle.t
@@ -63,18 +63,18 @@ sqlite3 "$HOME/cylc-run/$NAME/log/rose-job-logs.db" \
     'SELECT path,path_in_tar,key FROM log_files ORDER BY path,path_in_tar ASC;' \
     >"$TEST_KEY-db-1.out"
 file_cmp "$TEST_KEY-db-1.out" "$TEST_KEY-db-1.out" <<'__OUT__'
-log/job/2013010100/my_task_1/01/job||00-script
+log/job/2013010100/my_task_1/01/job||job
 log/job/2013010100/my_task_1/01/job-activity.log||job-activity.log
-log/job/2013010100/my_task_1/01/job.err||02-err
-log/job/2013010100/my_task_1/01/job.out||01-out
-log/job/2013010112/my_task_1/01/job||00-script
+log/job/2013010100/my_task_1/01/job.err||job.err
+log/job/2013010100/my_task_1/01/job.out||job.out
+log/job/2013010112/my_task_1/01/job||job
 log/job/2013010112/my_task_1/01/job-activity.log||job-activity.log
-log/job/2013010112/my_task_1/01/job.err||02-err
-log/job/2013010112/my_task_1/01/job.out||01-out
-log/job/2013010200/my_task_1/01/job||00-script
+log/job/2013010112/my_task_1/01/job.err||job.err
+log/job/2013010112/my_task_1/01/job.out||job.out
+log/job/2013010200/my_task_1/01/job||job
 log/job/2013010200/my_task_1/01/job-activity.log||job-activity.log
-log/job/2013010200/my_task_1/01/job.err||02-err
-log/job/2013010200/my_task_1/01/job.out||01-out
+log/job/2013010200/my_task_1/01/job.err||job.err
+log/job/2013010200/my_task_1/01/job.out||job.out
 __OUT__
 # N_JOB_LOGS should be 4, my_task_1 script, err, out and my_task_2 script
 N_JOB_LOGS=$(wc -l "$TEST_KEY-list-job-logs-before.out" | cut -d' ' -f1)
@@ -99,22 +99,22 @@ sqlite3 "$HOME/cylc-run/$NAME/log/rose-job-logs.db" \
     'SELECT path,path_in_tar,key FROM log_files ORDER BY path,path_in_tar ASC;' \
     >"$TEST_KEY-db-2.out"
 file_cmp "$TEST_KEY-db-2.out" "$TEST_KEY-db-2.out" <<'__OUT__'
-log/job-2013010100.tar.gz|job/2013010100/my_task_1/01/job|00-script
+log/job-2013010100.tar.gz|job/2013010100/my_task_1/01/job|job
 log/job-2013010100.tar.gz|job/2013010100/my_task_1/01/job-activity.log|job-activity.log
-log/job-2013010100.tar.gz|job/2013010100/my_task_1/01/job.err|02-err
-log/job-2013010100.tar.gz|job/2013010100/my_task_1/01/job.out|01-out
-log/job-2013010100.tar.gz|job/2013010100/my_task_2/01/job|00-script
+log/job-2013010100.tar.gz|job/2013010100/my_task_1/01/job.err|job.err
+log/job-2013010100.tar.gz|job/2013010100/my_task_1/01/job.out|job.out
+log/job-2013010100.tar.gz|job/2013010100/my_task_2/01/job|job
 log/job-2013010100.tar.gz|job/2013010100/my_task_2/01/job-activity.log|job-activity.log
-log/job-2013010100.tar.gz|job/2013010100/my_task_2/01/job.err|02-err
-log/job-2013010100.tar.gz|job/2013010100/my_task_2/01/job.out|01-out
-log/job/2013010112/my_task_1/01/job||00-script
+log/job-2013010100.tar.gz|job/2013010100/my_task_2/01/job.err|job.err
+log/job-2013010100.tar.gz|job/2013010100/my_task_2/01/job.out|job.out
+log/job/2013010112/my_task_1/01/job||job
 log/job/2013010112/my_task_1/01/job-activity.log||job-activity.log
-log/job/2013010112/my_task_1/01/job.err||02-err
-log/job/2013010112/my_task_1/01/job.out||01-out
-log/job/2013010200/my_task_1/01/job||00-script
+log/job/2013010112/my_task_1/01/job.err||job.err
+log/job/2013010112/my_task_1/01/job.out||job.out
+log/job/2013010200/my_task_1/01/job||job
 log/job/2013010200/my_task_1/01/job-activity.log||job-activity.log
-log/job/2013010200/my_task_1/01/job.err||02-err
-log/job/2013010200/my_task_1/01/job.out||01-out
+log/job/2013010200/my_task_1/01/job.err||job.err
+log/job/2013010200/my_task_1/01/job.out||job.out
 __OUT__
 #-------------------------------------------------------------------------------
 # Test --update.
@@ -129,30 +129,30 @@ sqlite3 "$HOME/cylc-run/$NAME/log/rose-job-logs.db" \
     'SELECT path,path_in_tar,key FROM log_files ORDER BY path,path_in_tar ASC;' \
     >"$TEST_KEY_BASE-db-final.out"
 file_cmp "$TEST_KEY_BASE-db-final.out" "$TEST_KEY_BASE-db-final.out" <<'__OUT__'
-log/job-2013010100.tar.gz|job/2013010100/my_task_1/01/job|00-script
+log/job-2013010100.tar.gz|job/2013010100/my_task_1/01/job|job
 log/job-2013010100.tar.gz|job/2013010100/my_task_1/01/job-activity.log|job-activity.log
-log/job-2013010100.tar.gz|job/2013010100/my_task_1/01/job.err|02-err
-log/job-2013010100.tar.gz|job/2013010100/my_task_1/01/job.out|01-out
-log/job-2013010100.tar.gz|job/2013010100/my_task_2/01/job|00-script
+log/job-2013010100.tar.gz|job/2013010100/my_task_1/01/job.err|job.err
+log/job-2013010100.tar.gz|job/2013010100/my_task_1/01/job.out|job.out
+log/job-2013010100.tar.gz|job/2013010100/my_task_2/01/job|job
 log/job-2013010100.tar.gz|job/2013010100/my_task_2/01/job-activity.log|job-activity.log
-log/job-2013010100.tar.gz|job/2013010100/my_task_2/01/job.err|02-err
-log/job-2013010100.tar.gz|job/2013010100/my_task_2/01/job.out|01-out
-log/job/2013010112/my_task_1/01/job||00-script
+log/job-2013010100.tar.gz|job/2013010100/my_task_2/01/job.err|job.err
+log/job-2013010100.tar.gz|job/2013010100/my_task_2/01/job.out|job.out
+log/job/2013010112/my_task_1/01/job||job
 log/job/2013010112/my_task_1/01/job-activity.log||job-activity.log
-log/job/2013010112/my_task_1/01/job.err||02-err
-log/job/2013010112/my_task_1/01/job.out||01-out
-log/job/2013010112/my_task_2/01/job||00-script
+log/job/2013010112/my_task_1/01/job.err||job.err
+log/job/2013010112/my_task_1/01/job.out||job.out
+log/job/2013010112/my_task_2/01/job||job
 log/job/2013010112/my_task_2/01/job-activity.log||job-activity.log
-log/job/2013010112/my_task_2/01/job.err||02-err
-log/job/2013010112/my_task_2/01/job.out||01-out
-log/job/2013010200/my_task_1/01/job||00-script
+log/job/2013010112/my_task_2/01/job.err||job.err
+log/job/2013010112/my_task_2/01/job.out||job.out
+log/job/2013010200/my_task_1/01/job||job
 log/job/2013010200/my_task_1/01/job-activity.log||job-activity.log
-log/job/2013010200/my_task_1/01/job.err||02-err
-log/job/2013010200/my_task_1/01/job.out||01-out
-log/job/2013010200/my_task_2/01/job||00-script
+log/job/2013010200/my_task_1/01/job.err||job.err
+log/job/2013010200/my_task_1/01/job.out||job.out
+log/job/2013010200/my_task_2/01/job||job
 log/job/2013010200/my_task_2/01/job-activity.log||job-activity.log
-log/job/2013010200/my_task_2/01/job.err||02-err
-log/job/2013010200/my_task_2/01/job.out||01-out
+log/job/2013010200/my_task_2/01/job.err||job.err
+log/job/2013010200/my_task_2/01/job.out||job.out
 __OUT__
 #-------------------------------------------------------------------------------
 rose suite-clean -q -y $NAME

--- a/t/rose-suite-log/02-update-force.t
+++ b/t/rose-suite-log/02-update-force.t
@@ -74,30 +74,30 @@ TEST_KEY="$TEST_KEY_BASE-db-after"
 sqlite3 "$HOME/cylc-run/$NAME/log/rose-job-logs.db" \
     'SELECT path,key FROM log_files ORDER BY path ASC;' >"$TEST_KEY.out"
 file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<'__OUT__'
-log/job/2013010100/my_task_1/01/job|00-script
+log/job/2013010100/my_task_1/01/job|job
 log/job/2013010100/my_task_1/01/job-activity.log|job-activity.log
-log/job/2013010100/my_task_1/01/job.err|02-err
-log/job/2013010100/my_task_1/01/job.out|01-out
-log/job/2013010100/my_task_2/01/job|00-script
+log/job/2013010100/my_task_1/01/job.err|job.err
+log/job/2013010100/my_task_1/01/job.out|job.out
+log/job/2013010100/my_task_2/01/job|job
 log/job/2013010100/my_task_2/01/job-activity.log|job-activity.log
-log/job/2013010100/my_task_2/01/job.err|02-err
-log/job/2013010100/my_task_2/01/job.out|01-out
-log/job/2013010112/my_task_1/01/job|00-script
+log/job/2013010100/my_task_2/01/job.err|job.err
+log/job/2013010100/my_task_2/01/job.out|job.out
+log/job/2013010112/my_task_1/01/job|job
 log/job/2013010112/my_task_1/01/job-activity.log|job-activity.log
-log/job/2013010112/my_task_1/01/job.err|02-err
-log/job/2013010112/my_task_1/01/job.out|01-out
-log/job/2013010112/my_task_2/01/job|00-script
+log/job/2013010112/my_task_1/01/job.err|job.err
+log/job/2013010112/my_task_1/01/job.out|job.out
+log/job/2013010112/my_task_2/01/job|job
 log/job/2013010112/my_task_2/01/job-activity.log|job-activity.log
-log/job/2013010112/my_task_2/01/job.err|02-err
-log/job/2013010112/my_task_2/01/job.out|01-out
-log/job/2013010200/my_task_1/01/job|00-script
+log/job/2013010112/my_task_2/01/job.err|job.err
+log/job/2013010112/my_task_2/01/job.out|job.out
+log/job/2013010200/my_task_1/01/job|job
 log/job/2013010200/my_task_1/01/job-activity.log|job-activity.log
-log/job/2013010200/my_task_1/01/job.err|02-err
-log/job/2013010200/my_task_1/01/job.out|01-out
-log/job/2013010200/my_task_2/01/job|00-script
+log/job/2013010200/my_task_1/01/job.err|job.err
+log/job/2013010200/my_task_1/01/job.out|job.out
+log/job/2013010200/my_task_2/01/job|job
 log/job/2013010200/my_task_2/01/job-activity.log|job-activity.log
-log/job/2013010200/my_task_2/01/job.err|02-err
-log/job/2013010200/my_task_2/01/job.out|01-out
+log/job/2013010200/my_task_2/01/job.err|job.err
+log/job/2013010200/my_task_2/01/job.out|job.out
 __OUT__
 #-------------------------------------------------------------------------------
 # Test --prune-remote.

--- a/t/rose-suite-log/06-archive-star.t
+++ b/t/rose-suite-log/06-archive-star.t
@@ -65,18 +65,18 @@ sqlite3 "$HOME/cylc-run/$NAME/log/rose-job-logs.db" \
     'SELECT path,path_in_tar,key FROM log_files ORDER BY path,path_in_tar ASC;' \
     >"$TEST_KEY-db-1.out"
 file_cmp "$TEST_KEY-db-1.out" "$TEST_KEY-db-1.out" <<'__OUT__'
-log/job/2013010100/my_task_1/01/job||00-script
+log/job/2013010100/my_task_1/01/job||job
 log/job/2013010100/my_task_1/01/job-activity.log||job-activity.log
-log/job/2013010100/my_task_1/01/job.err||02-err
-log/job/2013010100/my_task_1/01/job.out||01-out
-log/job/2013010112/my_task_1/01/job||00-script
+log/job/2013010100/my_task_1/01/job.err||job.err
+log/job/2013010100/my_task_1/01/job.out||job.out
+log/job/2013010112/my_task_1/01/job||job
 log/job/2013010112/my_task_1/01/job-activity.log||job-activity.log
-log/job/2013010112/my_task_1/01/job.err||02-err
-log/job/2013010112/my_task_1/01/job.out||01-out
-log/job/2013010200/my_task_1/01/job||00-script
+log/job/2013010112/my_task_1/01/job.err||job.err
+log/job/2013010112/my_task_1/01/job.out||job.out
+log/job/2013010200/my_task_1/01/job||job
 log/job/2013010200/my_task_1/01/job-activity.log||job-activity.log
-log/job/2013010200/my_task_1/01/job.err||02-err
-log/job/2013010200/my_task_1/01/job.out||01-out
+log/job/2013010200/my_task_1/01/job.err||job.err
+log/job/2013010200/my_task_1/01/job.out||job.out
 __OUT__
 N_JOB_LOGS=$(wc -l "$TEST_KEY-list-job-logs-before.out" | cut -d' ' -f1)
 (cd $SUITE_RUN_DIR/log && ls job/*) | sort >foo
@@ -115,30 +115,30 @@ sqlite3 "$HOME/cylc-run/$NAME/log/rose-job-logs.db" \
     'SELECT path,path_in_tar,key FROM log_files ORDER BY path,path_in_tar ASC;' \
     >"$TEST_KEY-db-2.out"
 file_cmp "$TEST_KEY-db-2.out" "$TEST_KEY-db-2.out" <<'__OUT__'
-log/job-2013010100.tar.gz|job/2013010100/my_task_1/01/job|00-script
+log/job-2013010100.tar.gz|job/2013010100/my_task_1/01/job|job
 log/job-2013010100.tar.gz|job/2013010100/my_task_1/01/job-activity.log|job-activity.log
-log/job-2013010100.tar.gz|job/2013010100/my_task_1/01/job.err|02-err
-log/job-2013010100.tar.gz|job/2013010100/my_task_1/01/job.out|01-out
-log/job-2013010100.tar.gz|job/2013010100/my_task_2/01/job|00-script
+log/job-2013010100.tar.gz|job/2013010100/my_task_1/01/job.err|job.err
+log/job-2013010100.tar.gz|job/2013010100/my_task_1/01/job.out|job.out
+log/job-2013010100.tar.gz|job/2013010100/my_task_2/01/job|job
 log/job-2013010100.tar.gz|job/2013010100/my_task_2/01/job-activity.log|job-activity.log
-log/job-2013010100.tar.gz|job/2013010100/my_task_2/01/job.err|02-err
-log/job-2013010100.tar.gz|job/2013010100/my_task_2/01/job.out|01-out
-log/job-2013010112.tar.gz|job/2013010112/my_task_1/01/job|00-script
+log/job-2013010100.tar.gz|job/2013010100/my_task_2/01/job.err|job.err
+log/job-2013010100.tar.gz|job/2013010100/my_task_2/01/job.out|job.out
+log/job-2013010112.tar.gz|job/2013010112/my_task_1/01/job|job
 log/job-2013010112.tar.gz|job/2013010112/my_task_1/01/job-activity.log|job-activity.log
-log/job-2013010112.tar.gz|job/2013010112/my_task_1/01/job.err|02-err
-log/job-2013010112.tar.gz|job/2013010112/my_task_1/01/job.out|01-out
-log/job-2013010112.tar.gz|job/2013010112/my_task_2/01/job|00-script
+log/job-2013010112.tar.gz|job/2013010112/my_task_1/01/job.err|job.err
+log/job-2013010112.tar.gz|job/2013010112/my_task_1/01/job.out|job.out
+log/job-2013010112.tar.gz|job/2013010112/my_task_2/01/job|job
 log/job-2013010112.tar.gz|job/2013010112/my_task_2/01/job-activity.log|job-activity.log
-log/job-2013010112.tar.gz|job/2013010112/my_task_2/01/job.err|02-err
-log/job-2013010112.tar.gz|job/2013010112/my_task_2/01/job.out|01-out
-log/job-2013010200.tar.gz|job/2013010200/my_task_1/01/job|00-script
+log/job-2013010112.tar.gz|job/2013010112/my_task_2/01/job.err|job.err
+log/job-2013010112.tar.gz|job/2013010112/my_task_2/01/job.out|job.out
+log/job-2013010200.tar.gz|job/2013010200/my_task_1/01/job|job
 log/job-2013010200.tar.gz|job/2013010200/my_task_1/01/job-activity.log|job-activity.log
-log/job-2013010200.tar.gz|job/2013010200/my_task_1/01/job.err|02-err
-log/job-2013010200.tar.gz|job/2013010200/my_task_1/01/job.out|01-out
-log/job-2013010200.tar.gz|job/2013010200/my_task_2/01/job|00-script
+log/job-2013010200.tar.gz|job/2013010200/my_task_1/01/job.err|job.err
+log/job-2013010200.tar.gz|job/2013010200/my_task_1/01/job.out|job.out
+log/job-2013010200.tar.gz|job/2013010200/my_task_2/01/job|job
 log/job-2013010200.tar.gz|job/2013010200/my_task_2/01/job-activity.log|job-activity.log
-log/job-2013010200.tar.gz|job/2013010200/my_task_2/01/job.err|02-err
-log/job-2013010200.tar.gz|job/2013010200/my_task_2/01/job.out|01-out
+log/job-2013010200.tar.gz|job/2013010200/my_task_2/01/job.err|job.err
+log/job-2013010200.tar.gz|job/2013010200/my_task_2/01/job.out|job.out
 __OUT__
 #-------------------------------------------------------------------------------
 rose suite-clean -q -y $NAME


### PR DESCRIPTION
Now that the job logs are nicely arranged in a directory, this sort key
functionality is no longer necessary.
