### PR TITLE
Fix an issue with rose-ana where it believes files in the app's file directory are tests

### DIFF
--- a/lib/python/rose/apps/rose_ana.py
+++ b/lib/python/rose/apps/rose_ana.py
@@ -276,6 +276,8 @@ class Analyse(object):
         for task in self.config.value.keys():
             if task is "env":
                 continue
+            if task.startswith("file:"):
+                continue
             newtask = AnalysisTask()
             newtask.name = task
             value = self.config.get_value([task, "resultfile"])


### PR DESCRIPTION
If a developer puts files inside a rose-ana app's file/ directory (potentially a sensible thing to do with KGO), rose-ana treats the resulting additions to the config object (file:......) as tests and tries to process them. We need to exclude these in the same way we exclude "env". 

There's an outside chance someone will put:

[file:hello]
comparison=Exact
extract=.....

but that would be an unlikely name for a test - I'd encourage people not to use colons in that place unless they mean them! 
