### PR TITLE
file install: rsync: fix sub-dir handling

### DIFF
--- a/lib/python/rose/loc_handlers/rsync.py
+++ b/lib/python/rose/loc_handlers/rsync.py
@@ -99,9 +99,10 @@ elif os.path.isfile(path):
                 if mtime == "-" or size == "-":
                     fake_sum = None
                 else:
+                    access_mode = int(access_mode)
                     fake_sum = "source=%s:mtime=%s:size=%s" % (
                         name, mtime, size)
-                loc.add_path(name, fake_sum, int(access_mode))
+                loc.add_path(name, fake_sum, access_mode)
 
     def pull(self, loc, _):
         """Run "rsync" to pull files or directories of loc to its cache."""

--- a/t/rose-app-run/12-file-incr-3.t
+++ b/t/rose-app-run/12-file-incr-3.t
@@ -50,6 +50,9 @@ echo "Freddie" >hello/stranger1.1.txt
 mkdir hello/stranger2
 echo "Bob" >hello/stranger2/person1.txt
 echo "Alice" >hello/stranger2/person2.txt
+mkdir hello/stranger2/persons
+echo "Holly" >hello/stranger2/persons/person3.txt
+echo "Alex" >hello/stranger2/persons/person4.txt
 # mode=auto, source is a list of files
 mkdir hello/plants
 echo "Heather" >hello/plants/heather.txt


### PR DESCRIPTION
File install rsync mode was failing if source is a directory with
sub-directories. This was due to an incorrect cast of the access mode.

Fix #1401.
