### PR TITLE
rosie db: fix failure for no-opt-props suite.

### DIFF
--- a/lib/python/rosie/db.py
+++ b/lib/python/rosie/db.py
@@ -392,6 +392,8 @@ class DAO(object):
                     if column.key not in ["name", "value"]:
                         results[-1].update({column.key: value})
             name = row[col_keys.index("name")]
+            if name is None:
+                continue
             value = row[col_keys.index("value")]
             if name.endswith("-list") and value is not None:
                 value = value.split()

--- a/t/rosie-lookup/00-basic.t
+++ b/t/rosie-lookup/00-basic.t
@@ -135,11 +135,21 @@ rosie create -q -y --info-file=rose-suite.info || exit 1
 echo "2009-02-13T23:31:34.000000Z" >foo-date-5.txt
 svnadmin setrevprop $PWD/repos/foo -r 5 svn:date foo-date-5.txt
 
+# Setup repository - create another suite.
+cat >rose-suite.info <<'__ROSE_SUITE_INFO'
+owner=bill
+project=sonnet 54
+title=The rose looks fair...
+__ROSE_SUITE_INFO
+rosie create -q -y --info-file=rose-suite.info || exit 1
+echo "2009-02-13T23:31:35.000000Z" >foo-date-6.txt
+svnadmin setrevprop $PWD/repos/foo -r 6 svn:date foo-date-6.txt
+
 # Setup db.
 run_pass "$TEST_KEY" $ROSE_HOME/sbin/rosa db-create
 file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<__OUT__
 [INFO] sqlite:///$PWD/repos/foo.db: DB created.
-[INFO] $PWD/repos/foo: DB loaded, r5 of 5.
+[INFO] $PWD/repos/foo: DB loaded, r6 of 6.
 __OUT__
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
 
@@ -198,6 +208,7 @@ file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<__OUT__
 local suite             owner  project   title                              
 =     foo-aa001/trunk@3 roses  poetry    Roses are Red, Violets are Blue,...
 =     foo-aa002/trunk@5 aphids eat roses Eat all the roses!                 
+=     foo-aa003/trunk@6 bill   sonnet 54 The rose looks fair...             
 url: http://$HOSTNAME:$PORT/foo/search?s=a
 __OUT__
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
@@ -211,6 +222,7 @@ local suite             owner  project   title
 =     foo-aa001/trunk@3 roses  poetry    Roses are Red, Violets are Blue,...
       foo-aa000/trunk@4 iris   eye pad   Should have gone to ...            
 =     foo-aa002/trunk@5 aphids eat roses Eat all the roses!                 
+=     foo-aa003/trunk@6 bill   sonnet 54 The rose looks fair...             
 url: http://$HOSTNAME:$PORT/foo/search?all_revs=True&s=a
 __OUT__
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
@@ -244,8 +256,9 @@ file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
 TEST_KEY=$TEST_KEY_BASE-query-results-revision
 run_pass "$TEST_KEY" rosie lookup -Q revision gt 3
 file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<__OUT__
-local suite             owner  project   title             
-=     foo-aa002/trunk@5 aphids eat roses Eat all the roses!
+local suite             owner  project   title                 
+=     foo-aa002/trunk@5 aphids eat roses Eat all the roses!    
+=     foo-aa003/trunk@6 bill   sonnet 54 The rose looks fair...
 url: http://$HOSTNAME:$PORT/foo/query?q=and+revision+gt+3
 __OUT__
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
@@ -259,6 +272,7 @@ local suite             owner  project   title
 =     foo-aa001/trunk@3 roses  poetry    Roses are Red, Violets are Blue,...
       foo-aa000/trunk@4 iris   eye pad   Should have gone to ...            
 =     foo-aa002/trunk@5 aphids eat roses Eat all the roses!                 
+=     foo-aa003/trunk@6 bill   sonnet 54 The rose looks fair...             
 url: http://$HOSTNAME:$PORT/foo/query?q=and+title+contains+a&all_revs=True
 __OUT__
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
@@ -280,6 +294,7 @@ file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<__OUT__
 local suite             owner  project   title                  
       foo-aa000/trunk@4 iris   eye pad   Should have gone to ...
 =     foo-aa002/trunk@5 aphids eat roses Eat all the roses!     
+=     foo-aa003/trunk@6 bill   sonnet 54 The rose looks fair... 
 url: http://$HOSTNAME:$PORT/foo/query?q=and+revision+gt+3&all_revs=True
 __OUT__
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
@@ -324,6 +339,7 @@ file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<__OUT__
 suite            
 foo-aa001/trunk@3
 foo-aa002/trunk@5
+foo-aa003/trunk@6
 __OUT__
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
 #-------------------------------------------------------------------------------
@@ -333,6 +349,7 @@ file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<__OUT__
 suite             with status
 foo-aa001/trunk@3 with  M    
 foo-aa002/trunk@5 with A     
+foo-aa003/trunk@6 with A     
 url: http://$HOSTNAME:$PORT/foo/search?s=a
 __OUT__
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
@@ -341,9 +358,10 @@ TEST_KEY=$TEST_KEY_BASE-custom-format-other-props
 run_pass "$TEST_KEY" rosie lookup \
     --format="%suite %local %description %access-list" a
 file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<__OUT__
-suite             local description       access-list
+suite             local description       access-list 
 foo-aa001/trunk@3 =     %description      [u'roses', u'violets']
 foo-aa002/trunk@5 =     Nom nom nom roses [u'allthebugs']
+foo-aa003/trunk@6 =     %description      %access-list
 url: http://$HOSTNAME:$PORT/foo/search?s=a
 __OUT__
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
@@ -352,12 +370,13 @@ TEST_KEY=$TEST_KEY_BASE-custom-format-other-props-all-revs
 run_pass "$TEST_KEY" rosie lookup --all-revs \
     --format="%suite %local %description %access-list" a
 file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<__OUT__
-suite             local description               access-list
+suite             local description               access-list 
 foo-aa000/trunk@1       Bad corn ear and pew pull [u'*']
 foo-aa001/trunk@2 >     Violets are Blue...       [u'*']
 foo-aa001/trunk@3 =     %description              [u'roses', u'violets']
 foo-aa000/trunk@4       Bad corn ear and pew pull [u'*']
 foo-aa002/trunk@5 =     Nom nom nom roses         [u'allthebugs']
+foo-aa003/trunk@6 =     %description              %access-list
 url: http://$HOSTNAME:$PORT/foo/search?all_revs=True&s=a
 __OUT__
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
@@ -368,6 +387,7 @@ file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<__OUT__
 suite             by owner  at date
 foo-aa001/trunk@3 by roses  at 2009-02-13 23:31:32 +0000
 foo-aa002/trunk@5 by aphids at 2009-02-13 23:31:34 +0000
+foo-aa003/trunk@6 by bill   at 2009-02-13 23:31:35 +0000
 url: http://$HOSTNAME:$PORT/foo/search?s=a
 __OUT__
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
@@ -378,6 +398,7 @@ file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<__OUT__
 suite             by owner  at date
 foo-aa001/trunk@3 by roses  at 2009-02-13 23:31:32 +0000
 foo-aa002/trunk@5 by aphids at 2009-02-13 23:31:34 +0000
+foo-aa003/trunk@6 by bill   at 2009-02-13 23:31:35 +0000
 __OUT__
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
This fixes a search or query processing error when the results contain
a suite with no optional properties at all (i.e. just owner, project,
and title).

@matthewrmshin, please review.
