### PR TITLE
Attempt to deal with rose-stem project name for shared repository

### DIFF
--- a/lib/python/rose/stem.py
+++ b/lib/python/rose/stem.py
@@ -221,6 +221,8 @@ class StemRunner(object):
                 if kpresult:
                     project = kpresult.group(1)
                     break
+        # Remove anything after a point
+        project = re.sub(r'\..*', r'', project)
         return project
 
     def _ascertain_project(self, item):

--- a/t/rose-stem/00-run-basic.t
+++ b/t/rose-stem/00-run-basic.t
@@ -35,14 +35,14 @@ BASEINSTALL=$(mktemp -d --tmpdir=$PWD)
 (cd $BASEINSTALL; mkdir -p trunk/rose-stem; svn import -q -m ""  $URL)
 #Keywords for the foo repository
 mkdir -p conf
-echo "location{primary}[foo]=$URL" >conf/keyword.cfg
+echo "location{primary}[foo.xm]=$URL" >conf/keyword.cfg
 export FCM_CONF_PATH=$PWD/conf
 cd $TEST_DIR
 #-------------------------------------------------------------------------------
 #Check out a copy of the repository
 WORKINGCOPY=$(mktemp -d --tmpdir=$PWD)
 SUITENAME=$(basename $WORKINGCOPY)
-fcm checkout -q fcm:foo_tr $WORKINGCOPY
+fcm checkout -q fcm:foo.xm_tr $WORKINGCOPY
 #-------------------------------------------------------------------------------
 #Copy suite into working copy
 cp $TEST_SOURCE_DIR/00-run-basic/suite.rc $WORKINGCOPY/rose-stem
@@ -57,7 +57,7 @@ tests $N_TESTS
 TEST_KEY=$TEST_KEY_BASE-basic-check
 run_pass "$TEST_KEY" \
    rose stem --group=earl_grey --task=milk,sugar --group=spoon,cup,milk \
-             --source=$WORKINGCOPY --source=fcm:foo_tr@head --no-gcontrol \
+             --source=$WORKINGCOPY --source=fcm:foo.xm_tr@head --no-gcontrol \
              --name $SUITENAME -- --debug
 #Test output
 OUTPUT=$HOME/cylc-run/$SUITENAME/log/job/1/my_task_1/01/job.out
@@ -65,7 +65,7 @@ TEST_KEY=$TEST_KEY_BASE-basic-groups-to-run
 file_grep $TEST_KEY "RUN_NAMES=\[earl_grey, milk, sugar, spoon, cup, milk\]" \
           $OUTPUT
 TEST_KEY=$TEST_KEY_BASE-basic-source
-file_grep $TEST_KEY "SOURCE_FOO=$WORKINGCOPY fcm:foo_tr@head" $OUTPUT
+file_grep $TEST_KEY "SOURCE_FOO=$WORKINGCOPY fcm:foo.xm_tr@head" $OUTPUT
 TEST_KEY=$TEST_KEY_BASE-basic-source-base
 file_grep $TEST_KEY "SOURCE_FOO_BASE=$WORKINGCOPY\$" $OUTPUT
 TEST_KEY=$TEST_KEY_BASE-basic-source-rev
@@ -74,16 +74,16 @@ file_grep $TEST_KEY "SOURCE_FOO_REV=\$" $OUTPUT
 # Second test, using suite redirection
 TEST_KEY=$TEST_KEY_BASE-suite-redirection
 run_pass "$TEST_KEY" \
-   rose stem --group=lapsang -C $WORKINGCOPY/rose-stem --source=fcm:foo_tr@head\
+   rose stem --group=lapsang -C $WORKINGCOPY/rose-stem --source=fcm:foo.xm_tr@head\
              --no-gcontrol --name $SUITENAME -- --debug
 #Test output
 OUTPUT=$HOME/cylc-run/$SUITENAME/log/job/1/my_task_1/01/job.out
 TEST_KEY=$TEST_KEY_BASE-suite-redirection-groups-to-run
 file_grep $TEST_KEY "RUN_NAMES=\[lapsang\]" $OUTPUT
 TEST_KEY=$TEST_KEY_BASE-suite-redirection-source
-file_grep $TEST_KEY "SOURCE_FOO=fcm:foo_tr@head\$" $OUTPUT
+file_grep $TEST_KEY "SOURCE_FOO=fcm:foo.xm_tr@head\$" $OUTPUT
 TEST_KEY=$TEST_KEY_BASE-suite-redirection-source-base
-file_grep $TEST_KEY "SOURCE_FOO_BASE=fcm:foo_tr\$" $OUTPUT
+file_grep $TEST_KEY "SOURCE_FOO_BASE=fcm:foo.xm_tr\$" $OUTPUT
 TEST_KEY=$TEST_KEY_BASE-suite-redirection-source-rev
 file_grep $TEST_KEY "SOURCE_FOO_REV=@1\$" $OUTPUT
 #-------------------------------------------------------------------------------
@@ -133,7 +133,7 @@ EOF
 TEST_KEY=$TEST_KEY_BASE-check-with-config
 run_pass "$TEST_KEY" \
    rose stem --group=earl_grey --task=milk,sugar --group=spoon,cup,milk \
-             --source=$WORKINGCOPY --source=fcm:foo_tr@head --no-gcontrol \
+             --source=$WORKINGCOPY --source=fcm:foo.xm_tr@head --no-gcontrol \
              --name $SUITENAME -- --debug
 #Test output
 OUTPUT=$HOME/cylc-run/$SUITENAME/log/job/1/my_task_1/01/job.out
@@ -141,7 +141,7 @@ TEST_KEY=$TEST_KEY_BASE-check-with-config-groups-to-run
 file_grep $TEST_KEY "RUN_NAMES=\[earl_grey, milk, sugar, spoon, cup, milk\]" \
           $OUTPUT
 TEST_KEY=$TEST_KEY_BASE-check-with-config-source
-file_grep $TEST_KEY "SOURCE_FOO=$WORKINGCOPY fcm:foo_tr@head" $OUTPUT
+file_grep $TEST_KEY "SOURCE_FOO=$WORKINGCOPY fcm:foo.xm_tr@head" $OUTPUT
 TEST_KEY=$TEST_KEY_BASE-check-with-config-source-base
 file_grep $TEST_KEY "SOURCE_FOO_BASE=$WORKINGCOPY\$" $OUTPUT
 TEST_KEY=$TEST_KEY_BASE-check-with-config-source-rev
@@ -171,7 +171,7 @@ cp $TEST_SOURCE_DIR/00-run-basic/rose-suite2.conf $WORKINGCOPY/rose-stem/rose-su
 TEST_KEY=$TEST_KEY_BASE-incompatible_versions
 run_fail "$TEST_KEY" \
    rose stem --group=earl_grey --task=milk,sugar --group=spoon,cup,milk \
-             --source=$WORKINGCOPY --source=fcm:foo_tr@head --no-gcontrol \
+             --source=$WORKINGCOPY --source=fcm:foo.xm_tr@head --no-gcontrol \
              --name $SUITENAME -- --debug 
 OUTPUT=$TEST_DIR/${TEST_KEY}.err
 TEST_KEY=$TEST_KEY_BASE-incompatible-versions-correct_error


### PR DESCRIPTION
A simple way of dealing with . in fcm keywords for rose-stem as something which needs to be fixed before the shared repository. I'm not sure if this is the ideal solution, but it's probably the simplest. @matthewrmshin what do you think?
