### PR TITLE
Fix pgrep usage

### DIFF
--- a/lib/python/rose/apps/fcm_make.py
+++ b/lib/python/rose/apps/fcm_make.py
@@ -81,8 +81,10 @@ class FCMMakeApp(BuiltinApp):
         cmd += ["-j", cmd_opt_jobs]
         cmd_args = conf_tree.node.get_value(["args"],
                                             os.getenv("ROSE_TASK_OPTIONS"))
-        cmd += shlex.split(cmd_args)
-        cmd += args
+        if cmd_args:
+            cmd += shlex.split(cmd_args)
+        if args:
+            cmd += args
         app_runner.popen(*cmd, stdout=sys.stdout, stderr=sys.stderr)
 
     def _run2(self, app_runner, conf_tree, opts, args, uuid, work_files, t):
@@ -98,6 +100,8 @@ class FCMMakeApp(BuiltinApp):
         cmd += ["-j", cmd_opt_jobs]
         cmd_args = conf_tree.node.get_value(["args"],
                                             os.getenv("ROSE_TASK_OPTIONS"))
-        cmd += shlex.split(cmd_args)
-        cmd += args
+        if cmd_args:
+            cmd += shlex.split(cmd_args)
+        if args:
+            cmd += args
         app_runner.popen(*cmd, stdout=sys.stdout, stderr=sys.stderr)

--- a/t/rose-suite-clean/01-running.t
+++ b/t/rose-suite-clean/01-running.t
@@ -35,7 +35,7 @@ rose suite-run --debug -q \
     -C $TEST_SOURCE_DIR/$TEST_KEY_BASE --name=$NAME --no-gcontrol
 ls -ld $HOME/cylc-run/$NAME 1>/dev/null
 poll ! test -e $SUITE_RUN_DIR/log/job/2013010100/my_task_1/01/job
-SUITE_PROC=$(pgrep -u$USER -fl "python.*cylc-run.*\\<$NAME\\>" \
+SUITE_PROC=$(pgrep -u$USER -fl "python.*cylc-run .*\\<$NAME\\>" \
     | awk '{print "[FAIL]     " $0}')
 #-------------------------------------------------------------------------------
 TEST_KEY=$TEST_KEY_BASE-running

--- a/t/rose-suite-run/00-run-basic.t
+++ b/t/rose-suite-run/00-run-basic.t
@@ -42,10 +42,10 @@ run_pass "$TEST_KEY" \
 HOST=$(<$SUITE_RUN_DIR/log/rose-suite-run.host)
 poll ! test -e $SUITE_RUN_DIR/log/job/my_task_1.2013010100.1
 if [[ $HOST == 'localhost' ]]; then
-    SUITE_PROC=$(pgrep -u$USER -fl "python.*cylc-run.*\\<$NAME\\>")
+    SUITE_PROC=$(pgrep -u$USER -fl "python.*cylc-run .*\\<$NAME\\>")
 else
     CMD_PREFIX="ssh -oBatchMode=yes $HOST"
-    SUITE_PROC=$($CMD_PREFIX "pgrep -u\$USER -fl 'python.*cylc-run.*\\<$NAME\\>'")
+    SUITE_PROC=$($CMD_PREFIX "pgrep -u\$USER -fl 'python.*cylc-run .*\\<$NAME\\>'")
 fi
 SUITE_PROC=$(awk '{print "[FAIL]     " $0}' <<<"$SUITE_PROC")
 #-------------------------------------------------------------------------------

--- a/t/rose-suite-run/08-pgrep.t
+++ b/t/rose-suite-run/08-pgrep.t
@@ -59,9 +59,9 @@ done
 $CMD_PREFIX "mv ~/.cylc/ports/$NAME $NAME.port"
 ERR_HOST=${HOST:-localhost}
 if [[ -n $HOST ]]; then
-    SUITE_PROC=$($CMD_PREFIX "pgrep -u\$USER -fl 'python.*cylc-run.*\\<$NAME\\>'")
+    SUITE_PROC=$($CMD_PREFIX "pgrep -u\$USER -fl 'python.*cylc-run .*\\<$NAME\\>'")
 else
-    SUITE_PROC=$(pgrep -u$USER -fl "python.*cylc-run.*\\<$NAME\\>")
+    SUITE_PROC=$(pgrep -u$USER -fl "python.*cylc-run .*\\<$NAME\\>")
 fi
 SUITE_PROC=$(awk '{print "[FAIL]     " $0}' <<<"$SUITE_PROC")
 run_fail "$TEST_KEY" \


### PR DESCRIPTION
For cylc/cylc#1166.
- Need a slightly improved `pgrep` pattern to avoid matching the new `cylc job-submit` commands.
- The `fcm_make` built-in application change is harmless (and in some way nicer), but it was done to fix an odd behaviour when running this under background jobs in earlier versions of my change for cylc/cylc#1166.
