### PR TITLE
#1426: rose edit: fix spaced widget bug.

### DIFF
--- a/lib/python/rose/config_editor/valuewidget/array/entry.py
+++ b/lib/python/rose/config_editor/valuewidget/array/entry.py
@@ -49,7 +49,6 @@ class EntryArrayValueWidget(gtk.HBox):
         self.metadata = metadata
         self.set_value = set_value
         self.hook = hook
-        self.last_value = value
         self.max_length = self.metadata[rose.META_PROP_LENGTH]
 
         value_array = rose.variable.array_split(self.value)
@@ -113,7 +112,7 @@ class EntryArrayValueWidget(gtk.HBox):
                 val = rose.config_editor.util.text_from_character_widget(val)
             elif self.is_quoted_array:
                 val = rose.config_editor.util.text_from_quoted_widget(val)
-            prefix = get_next_delimiter(self.last_value[len(text):], val)
+            prefix = get_next_delimiter(self.value[len(text):], val)
             if entry == self.entry_table.focus_child:
                 return len(text + prefix) + entry.get_position()
             text += prefix + val
@@ -395,9 +394,8 @@ class EntryArrayValueWidget(gtk.HBox):
         entries_have_commas = any(["," in v for v in val_array])
         new_value = rose.variable.array_join(val_array)
         if new_value != self.value:
-            self.last_value = new_value
-            self.set_value(new_value)
             self.value = new_value
+            self.set_value(new_value)
             if (entries_have_commas and
                 not (self.is_char_array or self.is_quoted_array)):
                 new_val_array = rose.variable.array_split(new_value)
@@ -455,6 +453,7 @@ class EntryArrayValueWidget(gtk.HBox):
 
 
 def get_next_delimiter(array_text, next_element):
+    """Return the part of array_text immediately preceding next_element."""
     v = array_text.index(next_element)
     if v == 0 and len(array_text) > 1:  # Null or whitespace element.
         while array_text[v].isspace():

--- a/lib/python/rose/config_editor/valuewidget/array/mixed.py
+++ b/lib/python/rose/config_editor/valuewidget/array/mixed.py
@@ -58,7 +58,6 @@ class MixedArrayValueWidget(gtk.HBox):
         self.metadata = metadata
         self.set_value = set_value
         self.hook = hook
-        self.last_value = value
         self.value_array = rose.variable.array_split(value)
         self.extra_array = []  # For new rows
         self.element_values = []
@@ -134,7 +133,6 @@ class MixedArrayValueWidget(gtk.HBox):
         if any(new_values):
             self.value_array = self.value_array + new_values
             self.value = rose.variable.array_join(self.value_array)
-            self.last_value = self.value
             self.set_value(self.value)
             self.set_num_rows()
         self.normalise_width_widgets()
@@ -148,7 +146,7 @@ class MixedArrayValueWidget(gtk.HBox):
         for r, widget_list in enumerate(self.rows):
             for i, widget in enumerate(widget_list):
                 val = self.value_array[r * self.num_cols + i]
-                prefix_text = get_next_delimiter(self.last_value[len(text):],
+                prefix_text = get_next_delimiter(self.value[len(text):],
                                                  val)
                 if widget == self.entry_table.focus_child:
                     if hasattr(widget, "get_focus_index"):
@@ -370,9 +368,8 @@ class MixedArrayValueWidget(gtk.HBox):
             self.value_array[array_index] = element_value
         new_val = rose.variable.array_join(self.value_array)
         if new_val != self.value:
-            self.last_value = new_val
-            self.set_value(new_val)
             self.value = new_val
+            self.set_value(new_val)
 
 
 class ArrayElementSetter(object):

--- a/lib/python/rose/config_editor/valuewidget/array/python_list.py
+++ b/lib/python/rose/config_editor/valuewidget/array/python_list.py
@@ -50,7 +50,6 @@ class PythonListValueWidget(gtk.HBox):
         self.metadata = metadata
         self.set_value = set_value
         self.hook = hook
-        self.last_value = value
         self.max_length = ":"
         value_array = python_array_split(self.value)
         self.chars_width = max([len(v) for v in value_array] + [1]) + 1
@@ -89,7 +88,7 @@ class PythonListValueWidget(gtk.HBox):
         text = '['
         for entry in self.entries:
             val = entry.get_text()
-            prefix = get_next_delimiter(self.last_value[len(text):], val)
+            prefix = get_next_delimiter(self.value[len(text):], val)
             if entry == self.entry_table.focus_child:
                 return len(text + prefix) + entry.get_position()
             text += prefix + val
@@ -358,9 +357,8 @@ class PythonListValueWidget(gtk.HBox):
         entries_have_commas = any(["," in v for v in val_array])
         new_value = python_array_join(val_array)
         if new_value != self.value:
-            self.last_value = new_value
-            self.set_value(new_value)
             self.value = new_value
+            self.set_value(new_value)
             if entries_have_commas:
                 new_val_array = python_array_split(new_value)
                 if len(new_val_array) != len(self.entries):

--- a/lib/python/rose/config_editor/valuewidget/array/row.py
+++ b/lib/python/rose/config_editor/valuewidget/array/row.py
@@ -49,7 +49,6 @@ class RowArrayValueWidget(gtk.HBox):
         self.metadata = metadata
         self.set_value = set_value
         self.hook = hook
-        self.last_value = value
         self.value_array = rose.variable.array_split(value)
         self.extra_array = []  # For new rows
         self.element_values = []
@@ -146,7 +145,6 @@ class RowArrayValueWidget(gtk.HBox):
                                {rose.META_PROP_TYPE: self.type})
         self.value_array = self.value_array + [w_value]
         self.value = rose.variable.array_join(self.value_array)
-        self.last_value = self.value
         self.set_value(self.value)
         for child in self.entry_table.get_children():
             self.entry_table.remove(child)
@@ -164,7 +162,6 @@ class RowArrayValueWidget(gtk.HBox):
         if any(new_values):
             self.value_array = self.value_array + new_values
             self.value = rose.variable.array_join(self.value_array)
-            self.last_value = self.value
             self.set_value(self.value)
             self.set_num_rows()
         self.normalise_width_widgets()
@@ -179,7 +176,7 @@ class RowArrayValueWidget(gtk.HBox):
                 if value_index > len(self.value_array) - 1:
                     return len(text)
                 val = self.value_array[r * self.num_cols + i]
-                prefix_text = get_next_delimiter(self.last_value[len(text):],
+                prefix_text = get_next_delimiter(self.value[len(text):],
                                                  val)
                 if widget == self.entry_table.focus_child:
                     if hasattr(widget, "get_focus_index"):
@@ -227,7 +224,6 @@ class RowArrayValueWidget(gtk.HBox):
         """Create a new element (non-derived types)."""
         self.value_array.pop()
         self.value = rose.variable.array_join(self.value_array)
-        self.last_value = self.value
         self.set_value(self.value)
         for child in self.entry_table.get_children():
             self.entry_table.remove(child)
@@ -452,9 +448,8 @@ class RowArrayValueWidget(gtk.HBox):
             self.value_array[array_index] = element_value
         new_val = rose.variable.array_join(self.value_array)
         if new_val != self.value:
-            self.last_value = new_val
-            self.set_value(new_val)
             self.value = new_val
+            self.set_value(new_val)
 
 
 class ArrayElementSetter(object):

--- a/lib/python/rose/config_editor/valuewidget/array/spaced_list.py
+++ b/lib/python/rose/config_editor/valuewidget/array/spaced_list.py
@@ -87,7 +87,7 @@ class SpacedListValueWidget(gtk.HBox):
         text = ''
         for entry in self.entries:
             val = entry.get_text()
-            prefix = get_next_delimiter(self.last_value[len(text):], val)
+            prefix = get_next_delimiter(self.value[len(text):], val)
             if entry == self.entry_table.focus_child:
                 return len(text + prefix) + entry.get_position()
             text += prefix + val
@@ -349,8 +349,8 @@ class SpacedListValueWidget(gtk.HBox):
         new_value = spaced_array_join(val_array)
         if new_value != self.value:
             self.last_value = self.value
-            self.set_value(new_value)
             self.value = new_value
+            self.set_value(new_value)
             if entries_have_spaces:
                 new_val_array = spaced_array_split(new_value)
                 if len(new_val_array) != len(self.entries):
@@ -407,6 +407,7 @@ class SpacedListValueWidget(gtk.HBox):
 
 
 def get_next_delimiter(array_text, next_element):
+    """Return the part of array_text immediately preceding next_element."""
     v = array_text.index(next_element)
     return array_text[:v]
 


### PR DESCRIPTION
This fixes #1426. The problem was misuse of the `last_value`
property across all array widgets, which happened to work
as it was always set to the actual current value, except in
the spaced_list widget.

@arjclark, please test and review.
