### PR TITLE
rose edit: fix preview app metadata refresh

### DIFF
--- a/lib/python/rose/config_editor/main.py
+++ b/lib/python/rose/config_editor/main.py
@@ -1434,6 +1434,8 @@ class MainController(object):
         else:
             configs = [only_this_config]
         for config_name in configs:
+            if self.data.config[config_name].is_preview:
+                continue
             self.data.clear_meta_lookups(config_name)
             config = self.data.dump_to_internal_config(config_name)
             config_data = self.data.config[config_name]


### PR DESCRIPTION
This fixes a bug in metadata refresh for previewed apps where the metadata was incorrectly
loaded, which could cause some metadata problems to be reported.

@arjclark, please review.
