### PR TITLE
rose edit: fix pasting into spaced list widget

### DIFF
--- a/lib/python/rose/config_editor/valuewidget/array/spaced_list.py
+++ b/lib/python/rose/config_editor/valuewidget/array/spaced_list.py
@@ -368,7 +368,6 @@ class SpacedListValueWidget(gtk.HBox):
     def _adjust_entry_length(self):
         for entry in self.entries:
             entry.set_width_chars(self.chars_width)
-            entry.set_max_length(self.chars_width)
         self.reshape_table()
 
     def _get_widget_for_focus(self):


### PR DESCRIPTION
This fixes pasting a large amount of text into a spaced_list
widget. This closes #1414.

@arjclark, please review.
