### PR TITLE
rosie.ws_client: new prefixes-ws-default setting

### DIFF
--- a/etc/rose.conf.example
+++ b/etc/rose.conf.example
@@ -281,10 +281,15 @@
 #  prefix-web.PREFIX=URL
 ## E.g.:
 #  prefix-web.foo=http://host/projects/foo/intertrac/source:
-## Web service URL of an ID prefix
+## Discovery service URL of an ID prefix
 #  prefix-ws.PREFIX=URL
 ## E.g.:
 #  prefix-ws.foo=http://host:port/rosie/foo
+## List of default discovery services (space delimited list of prefixes)
+## that will be used by a Rosie discovery service client
+#  prefixes-ws-default=PREFIX ...
+## E.g.:
+#  prefixes-ws-default=foo bar baz
 [rosie-id]
 
 # Configuration related to the adhoc Rosie web service server

--- a/lib/python/rosie/ws_client.py
+++ b/lib/python/rosie/ws_client.py
@@ -81,7 +81,11 @@ class RosieWSClient(object):
                 self.auth_managers[prefix] = RosieWSClientAuthManager(
                     prefix, popen=self.popen, prompt_func=self.prompt_func)
         if not prefixes:
-            prefixes = sorted(self.auth_managers.keys())
+            prefixes_str = conf_rosie_id.get_value(["prefixes-ws-default"])
+            if prefixes_str:
+                prefixes = shlex.split(prefixes_str)
+            else:
+                prefixes = sorted(self.auth_managers.keys())
         self.set_prefixes(prefixes)
 
     def set_prefixes(self, prefixes):

--- a/t/rosie-lookup/01-multi.t
+++ b/t/rosie-lookup/01-multi.t
@@ -24,7 +24,7 @@
 if ! python -c 'import cherrypy, sqlalchemy' 2>/dev/null; then
     skip_all 'python: cherrypy or sqlalchemy not installed'
 fi
-tests 15
+tests 18
 #-------------------------------------------------------------------------------
 # Setup Rose site/user configuration for the tests.
 export TZ='UTC'
@@ -41,7 +41,7 @@ SVN_URL_BAR="file://${PWD}/repos/bar"
 # Setup configuration file.
 mkdir conf
 cat >conf/rose.conf <<__ROSE_CONF__
-opts=port
+opts=port (default)
 
 [rosie-db]
 repos.bar=$PWD/repos/bar
@@ -136,6 +136,20 @@ file_cmp "${TEST_KEY}.err" "${TEST_KEY}.err" </dev/null
 #-------------------------------------------------------------------------------
 TEST_KEY="${TEST_KEY_BASE}-search-single"
 run_pass "${TEST_KEY}" rosie lookup --prefix=foo 'bus'
+file_cmp "${TEST_KEY}.out" "${TEST_KEY}.out" <<__OUT__
+local suite             owner project title
+      foo-aa000/trunk@1 billy bus     Wheels on the bus
+url: http://${HOSTNAME}:${PORT}/foo/search?s=bus
+__OUT__
+file_cmp "${TEST_KEY}.err" "${TEST_KEY}.err" </dev/null
+#-------------------------------------------------------------------------------
+TEST_KEY="${TEST_KEY_BASE}-search-single-by-default"
+cat >'conf/opt/rose-default.conf' <<__ROSE_CONF__
+[rosie-id]
+prefixes-ws-default=foo
+__ROSE_CONF__
+run_pass "${TEST_KEY}" rosie lookup 'bus'
+rm 'conf/opt/rose-default.conf'
 file_cmp "${TEST_KEY}.out" "${TEST_KEY}.out" <<__OUT__
 local suite             owner project title
       foo-aa000/trunk@1 billy bus     Wheels on the bus


### PR DESCRIPTION
Limit default lookup, etc to a subset of configured prefixes.
