### PR TITLE
rose macro tutorial: Simplify macro via curl.

### DIFF
--- a/doc/etc/rose-rug-advanced-tutorials-macro/planet.py.validate.html
+++ b/doc/etc/rose-rug-advanced-tutorials-macro/planet.py.validate.html
@@ -70,7 +70,7 @@ class PlanetChecker(rose.macro.MacroBase):
 
     def _get_allowed_planets(self):
         # Retrieve planets less than a certain distance away.
-        cmd_strings = ["wget", "-q", "-O", "-",
+        cmd_strings = ["curl", "-s",
                        "http://www.heavens-above.com/planetsummary.aspx"]
         p = subprocess.Popen(cmd_strings, stdout=subprocess.PIPE)
         text = p.communicate()[0]

--- a/doc/rose-rug-advanced-tutorials-macro.html
+++ b/doc/rose-rug-advanced-tutorials-macro.html
@@ -200,7 +200,7 @@ touch meta/lib/python/macros/planet.py
       <pre class="prettyprint">
     def _get_allowed_planets(self):
         # Retrieve planets less than a certain distance away.
-        cmd_strings = ["wget", "-q", "-O", "-",
+        cmd_strings = ["curl", "-s",
                        "http://www.heavens-above.com/planetsummary.aspx"]
         p = subprocess.Popen(cmd_strings, stdout=subprocess.PIPE)
         text = p.communicate()[0]


### PR DESCRIPTION
Use of wget is overly complex for the needs of the macro tutorial. This replaces the wget call with a simpler call to the more frequently used curl command.
