### PR TITLE
Test battery: fix xxdiff dependency

### DIFF
--- a/etc/rose.conf.example
+++ b/etc/rose.conf.example
@@ -312,6 +312,12 @@
 
 # Test Battery Configuration
 #
+## Tool to compare 2 files when there are differences.
+## (default="diff -u")
+#  difftool=COMMAND ...
+## E.g.:
+#  difftool=xxdiff
+#
 ## List of selectable host groups
 #  host-groups=GROUP ...
 ## E.g.:

--- a/t/lib/bash/test_header
+++ b/t/lib/bash/test_header
@@ -139,22 +139,12 @@ function file_cmp() {
     local TEST_KEY=$1
     local FILE_ACTUAL=$2
     local FILE_EXPECT=${3:--}
-    if diff -u $FILE_EXPECT $FILE_ACTUAL >&2; then
+    if cmp -s $FILE_EXPECT $FILE_ACTUAL; then
         pass $TEST_KEY
         return
     fi
     fail $TEST_KEY
-}
-
-function file_xxdiff() {
-    local TEST_KEY=$1
-    local FILE_ACTUAL=$2
-    local FILE_EXPECT=${3:--}
-    if xxdiff -D $FILE_ACTUAL $FILE_EXPECT; then
-        pass $TEST_KEY
-        return
-    fi
-    fail $TEST_KEY
+    ${DIFFTOOL} "${FILE_EXPECT}" "${FILE_ACTUAL}" >&2
 }
 
 function file_test() {
@@ -244,6 +234,8 @@ function port_is_busy() {
 
 ROSE_HOME=${ROSE_HOME:-$(cd $(dirname $BASH_SOURCE)/../../.. && pwd)}
 PATH=$ROSE_HOME/bin:$PATH
+
+DIFFTOOL=$(rose config '--default=diff -u' t difftool)
 
 TEST_KEY_BASE=$(basename $0 .t)
 TEST_SOURCE_DIR=$(cd $(dirname $0) && pwd)

--- a/t/rose-app-run/15-file-permission.t
+++ b/t/rose-app-run/15-file-permission.t
@@ -39,9 +39,9 @@ test_setup
 mkdir read_only_dest
 chmod u-w read_only_dest
 run_fail "$TEST_KEY" rose app-run --config=../config -q
-file_xxdiff "$TEST_KEY.out" "$TEST_KEY.out" <<'__OUT__'
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<'__OUT__'
 __OUT__
-file_xxdiff "$TEST_KEY.err" "$TEST_KEY.err" <<'__ERR__'
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" <<'__ERR__'
 [FAIL] [Errno 13] Permission denied: 'read_only_dest/foo.nl'
 __ERR__
 chmod u+w read_only_dest
@@ -58,9 +58,9 @@ TEST_KEY=$TEST_KEY_BASE-no-read-target-file
 touch $TEST_DIR/no_read_target
 chmod u-r $TEST_DIR/no_read_target
 run_fail "$TEST_KEY" rose app-run --config=../config -q
-file_xxdiff "$TEST_KEY.out" "$TEST_KEY.out" <<'__OUT__'
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<'__OUT__'
 __OUT__
-file_xxdiff "$TEST_KEY.err" "$TEST_KEY.err" <<__ERR__
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" <<__ERR__
 [FAIL] [Errno 13] Permission denied: '$TEST_DIR/no_read_target'
 __ERR__
 chmod u+r $TEST_DIR/no_read_target
@@ -78,7 +78,7 @@ TEST_KEY=$TEST_KEY_BASE-no-read-target-dir
 mkdir $TEST_DIR/no_read_target_dir
 chmod u-r $TEST_DIR/no_read_target_dir
 run_fail "$TEST_KEY" rose app-run --config=../config -q
-file_xxdiff "$TEST_KEY.out" "$TEST_KEY.out" <<'__OUT__'
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<'__OUT__'
 __OUT__
 file_grep "$TEST_KEY.err" "Permission denied" "$TEST_KEY.err"
 chmod u+r $TEST_DIR/no_read_target_dir
@@ -97,9 +97,9 @@ mkdir $TEST_DIR/no_read_target_dir
 touch $TEST_DIR/no_read_target_dir/qux
 chmod u-x $TEST_DIR/no_read_target_dir
 run_fail "$TEST_KEY" rose app-run --config=../config -q
-file_xxdiff "$TEST_KEY.out" "$TEST_KEY.out" <<'__OUT__'
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<'__OUT__'
 __OUT__
-file_xxdiff "$TEST_KEY.err" "$TEST_KEY.err" <<__ERR__
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" <<__ERR__
 [FAIL] file:qux=source=$TEST_DIR/no_read_target_dir/qux: bad setting
 __ERR__
 chmod u+x $TEST_DIR/no_read_target_dir

--- a/t/rose-app-upgrade/00-null.t
+++ b/t/rose-app-upgrade/00-null.t
@@ -41,7 +41,7 @@ setup
 CONFIG_DIR=$(cd .. && pwd -P)/config
 run_fail "$TEST_KEY" rose app-upgrade --non-interactive -C ../config
 file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
-file_xxdiff "$TEST_KEY.err" "$TEST_KEY.err" <<__CONTENT__
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" <<__CONTENT__
 [FAIL] $CONFIG_DIR: not an application directory.
 __CONTENT__
 teardown

--- a/t/rose-app-upgrade/04-upgrade-trigger.t
+++ b/t/rose-app-upgrade/04-upgrade-trigger.t
@@ -75,7 +75,7 @@ TEST_KEY=$TEST_KEY_BASE-add-and-trigger-non-interactive
 # Check adding
 run_pass "$TEST_KEY" rose app-upgrade --non-interactive \
  --meta-path=../rose-meta/ -C ../config 0.2
-file_xxdiff "$TEST_KEY.out" "$TEST_KEY.out" <<'__OUTPUT__'
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<'__OUTPUT__'
 [U] Upgrade_0.1-0.2: changes: 2
     env=Z=1
         only one Z

--- a/t/rose-macro/17-import.t
+++ b/t/rose-macro/17-import.t
@@ -91,7 +91,7 @@ SPONGE_DENSITY=20.0
 __CONFIG__
 run_fail "$TEST_KEY" rose macro -M $TEST_DIR/rose-meta --config=../config rose.macros.DefaultValidators
 file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
-file_xxdiff "$TEST_KEY.err" "$TEST_KEY.err" <<'__ERR__'
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" <<'__ERR__'
 [V] rose.macros.DefaultValidators: issues: 4
     env=ICECREAM_FLAVOUR=chocolate
         Value chocolate should be vanilla
@@ -128,7 +128,7 @@ class SpongeDeSoggifier(rose.macro.MacroBase):
         return config, self.reports
 __MACRO__
 run_pass "$TEST_KEY" rose macro -M $TEST_DIR/rose-meta --config=../config
-file_xxdiff "$TEST_KEY.out" "$TEST_KEY.out" <<'__OUT__'
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<'__OUT__'
 [V] rose.macros.DefaultValidators
     # Runs all the default checks, such as compulsory checking.
 [T] desoggy.SpongeDeSoggifier
@@ -136,18 +136,18 @@ file_xxdiff "$TEST_KEY.out" "$TEST_KEY.out" <<'__OUT__'
 [T] rose.macros.DefaultTransforms
     # Runs all the default fixers, such as trigger fixing.
 __OUT__
-file_xxdiff "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
 #-------------------------------------------------------------------------------
 # Run the custom macro.
 TEST_KEY=$TEST_KEY_BASE-basic-custom-macro-run
 # Check that it gets the correct metadata.
 run_pass "$TEST_KEY" rose macro -y -M $TEST_DIR/rose-meta --config=../config desoggy.SpongeDeSoggifier
-file_xxdiff "$TEST_KEY.out" "$TEST_KEY.out" <<'__OUT__'
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<'__OUT__'
 [T] desoggy.SpongeDeSoggifier: changes: 1
     env=SPONGE_DENSITY=0.3
         de-soggified
 __OUT__
-file_xxdiff "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
 teardown
 #-------------------------------------------------------------------------------
 exit

--- a/t/rose-metadata-graph/00-null.t
+++ b/t/rose-metadata-graph/00-null.t
@@ -33,8 +33,8 @@ tests 15
 TEST_KEY=$TEST_KEY_BASE-base
 setup
 run_fail "$TEST_KEY" rose metadata-graph --debug
-file_xxdiff "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
-file_xxdiff "$TEST_KEY.err" "$TEST_KEY.err" <<__CONTENT__
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" <<__CONTENT__
 [FAIL] Could not load metadata 
 __CONTENT__
 teardown
@@ -43,8 +43,8 @@ teardown
 TEST_KEY=$TEST_KEY_BASE-C
 setup
 run_fail "$TEST_KEY" rose metadata-graph --debug -C ../config
-file_xxdiff "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
-file_xxdiff "$TEST_KEY.err" "$TEST_KEY.err" <<'__CONTENT__'
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" <<'__CONTENT__'
 [FAIL] Could not load metadata 
 __CONTENT__
 teardown
@@ -53,8 +53,8 @@ teardown
 TEST_KEY=$TEST_KEY_BASE-unknown-option
 setup
 run_fail "$TEST_KEY" rose metadata-graph --unknown-option
-file_xxdiff "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
-file_xxdiff "$TEST_KEY.err" "$TEST_KEY.err" <<'__CONTENT__'
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" <<'__CONTENT__'
 Usage: rose metadata-graph [OPTIONS] [SECTION ...]
 
 rose metadata-graph: error: no such option: --unknown-option
@@ -66,8 +66,8 @@ init </dev/null
 TEST_KEY=$TEST_KEY_BASE-no-metadata
 setup
 run_fail "$TEST_KEY" rose metadata-graph --debug -C ../config
-file_xxdiff "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
-file_xxdiff "$TEST_KEY.err" "$TEST_KEY.err" <<'__ERROR__'
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" <<'__ERROR__'
 [FAIL] Could not load metadata 
 __ERROR__
 teardown
@@ -78,8 +78,8 @@ init_meta </dev/null
 TEST_KEY=$TEST_KEY_BASE-null-metadata
 setup
 run_fail "$TEST_KEY" rose metadata-graph --debug -C ../config
-file_xxdiff "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
-file_xxdiff "$TEST_KEY.err" "$TEST_KEY.err" <<'__ERROR__'
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" <<'__ERROR__'
 [FAIL] Could not load metadata 
 __ERROR__
 teardown

--- a/t/rose-metadata-graph/01-data.t
+++ b/t/rose-metadata-graph/01-data.t
@@ -37,7 +37,7 @@ run_pass "$TEST_KEY" rose metadata-graph --debug --config=../config
 sort "$TEST_KEY.out" -o "$TEST_KEY.out"
 sed -i -e 's/\(pos\|bb\|width\|height\|lp\)="[^"]*\("\|$\)//g;' \
        -e 's/[, ]*\]\?;\? *$//g; /^\t/!d;' "$TEST_KEY.out"
-file_xxdiff "$TEST_KEY.out" "$TEST_KEY.out" <<__OUTPUT__
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<__OUTPUT__
 		
 	"env=CONTROL" -> "env=CONTROL=None" [color=green, label=foo
 	"env=CONTROL" -> "env=CONTROL=bar" [color=red, label=foo
@@ -93,7 +93,7 @@ file_xxdiff "$TEST_KEY.out" "$TEST_KEY.out" <<__OUTPUT__
 	graph [
 	node [label="\N"
 __OUTPUT__
-file_xxdiff "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
 #-------------------------------------------------------------------------------
 # Check specific section graphing.
 TEST_KEY=$TEST_KEY_BASE-ok-sub-section
@@ -102,7 +102,7 @@ run_pass "$TEST_KEY" rose metadata-graph --debug --config=../config namelist:qux
 sort "$TEST_KEY.out" -o "$TEST_KEY.out"
 sed -i -e 's/\(pos\|bb\|width\|height\|lp\)="[^"]*\("\|$\)//g;' \
        -e 's/[, ]*\]\?;\? *$//g; /^\t/!d;' "$TEST_KEY.out"
-file_xxdiff "$TEST_KEY.out" "$TEST_KEY.out" <<__OUTPUT__
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<__OUTPUT__
 		
 	"env=CONTROL_NAMELIST_QUX" -> "env=CONTROL_NAMELIST_QUX=bar" [color=red, label=foo
 	"env=CONTROL_NAMELIST_QUX" [color=green, shape=rectangle
@@ -118,7 +118,7 @@ file_xxdiff "$TEST_KEY.out" "$TEST_KEY.out" <<__OUTPUT__
 	graph [
 	node [label="\N"
 __OUTPUT__
-file_xxdiff "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
 #-------------------------------------------------------------------------------
 # Check specific property graphing.
 TEST_KEY=$TEST_KEY_BASE-ok-property
@@ -128,7 +128,7 @@ run_pass "$TEST_KEY" rose metadata-graph --debug --config=../config \
 sort "$TEST_KEY.out" -o "$TEST_KEY.out"
 sed -i -e 's/\(pos\|bb\|width\|height\|lp\)="[^"]*\("\|$\)//g;' \
        -e 's/[, ]*\]\?;\? *$//g; /^\t/!d;' "$TEST_KEY.out"
-file_xxdiff "$TEST_KEY.out" "$TEST_KEY.out" <<__OUTPUT__
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<__OUTPUT__
 		
 	"env=CONTROL" -> "env=CONTROL=None" [color=green, label=foo
 	"env=CONTROL" -> "env=CONTROL=bar" [color=red, label=foo
@@ -184,7 +184,7 @@ file_xxdiff "$TEST_KEY.out" "$TEST_KEY.out" <<__OUTPUT__
 	graph [
 	node [label="\N"
 __OUTPUT__
-file_xxdiff "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
 #-------------------------------------------------------------------------------
 # Check specific section and specific property graphing.
 TEST_KEY=$TEST_KEY_BASE-ok-property-sub-section
@@ -194,7 +194,7 @@ run_pass "$TEST_KEY" rose metadata-graph --debug --config=../config \
 sort "$TEST_KEY.out" -o "$TEST_KEY.out"
 sed -i -e 's/\(pos\|bb\|width\|height\|lp\)="[^"]*\("\|$\)//g;' \
        -e 's/[, ]*\]\?;\? *$//g; /^\t/!d;' "$TEST_KEY.out"
-file_xxdiff "$TEST_KEY.out" "$TEST_KEY.out" <<__OUTPUT__
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<__OUTPUT__
 		
 	"env=CONTROL" -> "env=CONTROL=None" [color=green, label=foo
 	"env=CONTROL" -> "env=CONTROL=bar" [color=red, label=foo
@@ -241,6 +241,6 @@ file_xxdiff "$TEST_KEY.out" "$TEST_KEY.out" <<__OUTPUT__
 	graph [
 	node [label="\N"
 __OUTPUT__
-file_xxdiff "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
 teardown
 exit

--- a/t/rose-metadata-graph/02-just-metadata.t
+++ b/t/rose-metadata-graph/02-just-metadata.t
@@ -38,7 +38,7 @@ run_pass "$TEST_KEY" rose metadata-graph --debug --config=../config/meta
 sort "$TEST_KEY.out" -o "$TEST_KEY.out"
 sed -i -e 's/\(pos\|bb\|width\|height\|lp\)="[^"]*\("\|$\)//g;' \
        -e 's/[, ]*\]\?;\? *$//g; /^\t/!d;' "$TEST_KEY.out"
-file_xxdiff "$TEST_KEY.out" "$TEST_KEY.out" <<__OUTPUT__
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<__OUTPUT__
 		
 	"env=CONTROL" -> "env=CONTROL=None" [color=grey
 	"env=CONTROL" -> "env=CONTROL=bar" [color=grey

--- a/t/rose-task-run/11-specify-cycle-iso.t
+++ b/t/rose-task-run/11-specify-cycle-iso.t
@@ -39,6 +39,6 @@ tests 1
 rose suite-run -q -C $TEST_SOURCE_DIR/$TEST_KEY_BASE --name=$NAME \
     --no-gcontrol --host=localhost -- --debug
 #-------------------------------------------------------------------------------
-file_xxdiff "$TEST_KEY" "$SUITE_RUN_DIR/file" <<<'20121231T1200Z'
+file_cmp "$TEST_KEY" "$SUITE_RUN_DIR/file" <<<'20121231T1200Z'
 rose suite-clean -q -y $NAME
 exit 0


### PR DESCRIPTION
Tests were requiring `xxdiff` to be installed. This fixes the problem.

The change also allows developers to configure their favourite `difftool` in their `~/.metomi/rose.conf` when running
the test battery. The default is to print a unified diff to STDERR.
