### PR TITLE
rosie: add gpg-agent caching of credentials.

### DIFF
--- a/lib/python/rosie/ws_client.py
+++ b/lib/python/rosie/ws_client.py
@@ -175,6 +175,8 @@ class RosieWSClient(object):
             try:
                 response.raise_for_status()
             except requests.exceptions.RequestException:
+                if request_detail["auth_manager"] is not None:
+                    request_detail["auth_manager"].clear_password()
                 self.event_handler(
                     RosieWSClientError(url, kwargs, response.status_code),
                     level=1)


### PR DESCRIPTION
This enables `rosie` to use a gpg-agent daemon for password
caching.

This uses the gpg-agent Assuan protocol to communicate via
a socket. It uses gpg-agent's own password entry mechanism
(the pinentry programs).

@matthewrmshin, please review.
