### PR TITLE
rose training: suites link broken

### DIFF
--- a/doc/rose-rug-appendix-training.html
+++ b/doc/rose-rug-appendix-training.html
@@ -97,16 +97,14 @@
     <p>Day 2:</p>
 
     <ul>
-      <li>0915 - 0945: Talk: <a href="rose-rug-suites.html">Suites</a> (up to,
-      but not including, <a href="rose-rug-suites.html#dep-syntax">Dependency
-      Syntax</a></li>
+      <li>0915 - 0945: Talk: <a href="rose-rug-suites-I.html">Suites I</a>
+      </li>
 
       <li>0945 - 1115: Desk Work: <a href=
       "rose-rug-suite-writing-tutorial.html">Suite Writing Tutorial</a></li>
 
       <li>1115 - 1215: User Feedback and Talk: <a href=
-      "rose-rug-suites.html">Suites</a>, starting at <a href=
-      "rose-rug-suites.html#dep-syntax">Dependency Syntax</a></li>
+      "rose-rug-suites-II.html">Suites II</a></li>
 
       <li>1215 - 1330: Break</li>
 


### PR DESCRIPTION
Closes #1466 
Uses the split suites url's suites I and II.
