### PR TITLE
Fix doc for `rose suite-run -l`

### DIFF
--- a/doc/rose-command.html
+++ b/doc/rose-command.html
@@ -1929,7 +1929,7 @@ launcher-preopts.mpiexec=-n $NPROC
       <dd>Install the suite. Do not run it. Implies
       <kbd>--no-gcontrol</kbd>.</dd>
 
-      <dt><kbd>--local-install-only, -i</kbd></dt>
+      <dt><kbd>--local-install-only, -l</kbd></dt>
 
       <dd>Install the suite locally. Do not install to job hosts. Do not run
       it. Implies <kbd>--no-gcontrol</kbd>.</dd>


### PR DESCRIPTION
The short option was incorrect in the user guide.
