### PR TITLE
Fix bug where rose-stem cannot ascertain name of a suite when cwd is not a working copy

### DIFF
--- a/lib/python/rose/stem.py
+++ b/lib/python/rose/stem.py
@@ -299,8 +299,7 @@ class StemRunner(object):
             basedir = self._ascertain_project(os.getcwd())[1]
         except ProjectNotFoundException:
             if self.opts.conf_dir:
-                basedir = self.opts.conf_dir
-                basedir = re.sub(r'\.', os.getcwd(), basedir)
+                basedir = os.path.abspath(self.opts.conf_dir)
             else:
                 basedir = os.getcwd()
         name = os.path.basename(basedir)


### PR DESCRIPTION
If the current working directory where "rose stem" is invoked is not a working copy, the command will currently fail as it attempts to work out a sensible suite name from the base of the current working copy. 

This generally only occurs when running rose stem with both the --source and --config options, but that is occasionally necessary. This change alters the command so if it is not possible to ascertain a sensible basename of the working copy, it takes the directory specified by --config and uses the basename of that (replacing "." with the actual name), or failing that the basename of the directory in which the user ran the command. 
