### PR TITLE
rosie go: fix File -> New Suite

### DIFF
--- a/lib/python/rosie/browser/main.py
+++ b/lib/python/rosie/browser/main.py
@@ -393,7 +393,8 @@ class MainWindow(gtk.Window):
         self.menubar = rosie.browser.util.MenuBar(
             self.advanced_search_widget.display_columns,
             self.ws_client)
-        menu_list = [('/TopMenuBar/File/New Suite', self.handle_create),
+        menu_list = [('/TopMenuBar/File/New Suite',
+                      lambda m: self.handle_create()),
                      ('/TopMenuBar/File/Quit', self.handle_destroy),
                      ('/TopMenuBar/Edit/Preferences', lambda m: False),
                      ('/TopMenuBar/View/View advanced controls',


### PR DESCRIPTION
This fixes a traceback in rosie go when `File -> New Suite...` is clicked:

```
Traceback (most recent call last):
  File "/opt/rose/lib/python/rosie/browser/main.py", line 656, in handle_create
    from_id, self.prefix)
  File "/opt/rose/lib/python/rosie/vc.py", line 310, in generate_info_config
    from_info_url = "%s/%s/rose-suite.info@%s" % (from_id.to_origin(),
```
