### PR TITLE
Rose stem in branch name

### DIFF
--- a/lib/python/rose/stem.py
+++ b/lib/python/rose/stem.py
@@ -282,8 +282,8 @@ class StemRunner(object):
 
         # Remove subtree from base and item
         if 'sub_tree' in source_dict:
-            item = item.replace(source_dict['sub_tree'], '', 1)
-            base = base.replace(source_dict['sub_tree'], '', 1)
+            item = re.sub(r'(.*)%s/$' % (source_dict['sub_tree']), r'\1', item, count=1)
+            base = re.sub(r'(.*)%s/$' % (source_dict['sub_tree']), r'\1', base, count=1)
 
         # Remove trailing forwards-slash
         item = re.sub(r'/$',r'',item)

--- a/lib/python/rose/stem.py
+++ b/lib/python/rose/stem.py
@@ -282,8 +282,10 @@ class StemRunner(object):
 
         # Remove subtree from base and item
         if 'sub_tree' in source_dict:
-            item = re.sub(r'(.*)%s/$' % (source_dict['sub_tree']), r'\1', item, count=1)
-            base = re.sub(r'(.*)%s/$' % (source_dict['sub_tree']), r'\1', base, count=1)
+            item = re.sub(r'(.*)%s/?$' % (source_dict['sub_tree']), r'\1', 
+                     item, count=1)
+            base = re.sub(r'(.*)%s/?$' % (source_dict['sub_tree']), r'\1', 
+                     base, count=1)
 
         # Remove trailing forwards-slash
         item = re.sub(r'/$',r'',item)


### PR DESCRIPTION
This should fix #1510 - the problem is the "rose-stem" in the branch (and thus by default the working copy) name, unfortunately Python's string.replace method doesn't seem to have a "work from the right hand side of the string" option, so I've replaced it with a regular expression.

@matthewrmshin would you mind reviewing when you get chance?