### PR TITLE
rose-suite-info metadata: Remove incorrect opts entry.

### DIFF
--- a/etc/rose-meta/rose-suite-info/rose-meta.conf
+++ b/etc/rose-meta/rose-suite-info/rose-meta.conf
@@ -39,13 +39,6 @@ help=Specify a space-separated list of ticket/issue ids.
     =
     = #32 #45
 
-[=opts]
-description=A space-delimited list of optional configurations.
-help=A space-delimited list of optional configuration keys to switch on.
-    =
-    = This tells the run time program to load the relevant optional
-    = configurations in the opt/ sub-directory at run time.
-
 [=owner]
 compulsory=true
 description=Username of the suite owner


### PR DESCRIPTION
Removes the accidentally introduced "opts" entry from rose suite-info metadata.