### PR TITLE
rose test-battery: enforce LANG=C for all 'sort' commands

### DIFF
--- a/t/rosa-svn-post-commit/01-mail-passwd.t
+++ b/t/rosa-svn-post-commit/01-mail-passwd.t
@@ -33,14 +33,14 @@ TEST_CONF="${TEST_SOURCE_DIR}/${TEST_KEY_BASE}.conf"
 # Get recipients from configuration
 get_recips() {
     local KEY="$1"
-    perl -e \
+    LANG=C perl -e \
         'print(join(", ", map {"'"'"'" . $_ . "'"'"'"} sort(@ARGV)), "\n")' \
         $(rose config -E -f "${TEST_CONF}" "recips.$KEY")
 }
 
 # Sort email recipients
 sort_recips() {
-    perl -e \
+    LANG=C perl -e \
         'print(join(", ", map {"'"'"'" . $_ . "'"'"'"} sort(@ARGV)), "\n")' \
         "$@"
 }

--- a/t/rose-app-run/09-file-incr-0.t
+++ b/t/rose-app-run/09-file-incr-0.t
@@ -83,33 +83,33 @@ tests 9
 TEST_KEY="$TEST_KEY_BASE-null-change"
 test_setup
 rose app-run --config=../config -q || exit 1
-find hello -type f | sort >'find-hello-before.out'
+find hello -type f | LANG=C sort >'find-hello-before.out'
 touch timeline # Nothing should be created after "timeline"
 sleep 1
 run_pass "$TEST_KEY" rose app-run --config=../config -q
-find hello -type f | sort >'find-hello-after.out'
+find hello -type f | LANG=C sort >'find-hello-after.out'
 file_cmp "$TEST_KEY.find-hello" 'find-hello-before.out' 'find-hello-after.out'
-find hello -type f -newer timeline | sort >'find-hello-after-newer.out'
+find hello -type f -newer timeline | LANG=C sort >'find-hello-after-newer.out'
 file_cmp "$TEST_KEY.find-hello-newer" 'find-hello-after-newer.out' </dev/null
 test_teardown
 #-------------------------------------------------------------------------------
 TEST_KEY="$TEST_KEY_BASE-change-content"
 test_setup
 rose app-run --config=../config -q || exit 1
-find hello -type f | sort >'find-hello-before.out'
+find hello -type f | LANG=C sort >'find-hello-before.out'
 touch timeline # Only changes updated after "timeline"
 sleep 1
 echo "Bob" >$TEST_DIR/hello/stranger1.txt
 echo "chicken" >$TEST_DIR/hello/animals/birds/chicken.txt
 run_pass "$TEST_KEY" rose app-run --config=../config -q
-find hello -type f | sort >'find-hello-after.out'
+find hello -type f | LANG=C sort >'find-hello-after.out'
 {
     echo 'hello/animals/chicken.txt'
     cat 'find-hello-before.out'
 } >'find-hello-after-expected.out'
 file_cmp "$TEST_KEY.find-hello" \
     'find-hello-after-expected.out' 'find-hello-after.out'
-find hello -type f -newer timeline | sort >'find-hello-after-newer.out'
+find hello -type f -newer timeline | LANG=C sort >'find-hello-after-newer.out'
 file_cmp "$TEST_KEY.find-hello-newer" 'find-hello-after-newer.out' <<'__OUT__'
 hello/animals/chicken.txt
 hello/stranger1.txt
@@ -119,13 +119,13 @@ test_teardown
 TEST_KEY="$TEST_KEY_BASE-change-source"
 test_setup
 rose app-run --config=../config -q || exit 1
-find hello -type f | sort >'find-hello-before.out'
+find hello -type f | LANG=C sort >'find-hello-before.out'
 touch timeline # Only changes updated after "timeline"
 sleep 1
 run_pass "$TEST_KEY" rose app-run --config=../config -O1.1 -q
-find hello -type f | sort >'find-hello-after.out'
+find hello -type f | LANG=C sort >'find-hello-after.out'
 file_cmp "$TEST_KEY.find-hello" 'find-hello-before.out' 'find-hello-after.out'
-find hello -type f -newer timeline | sort >'find-hello-after-newer.out'
+find hello -type f -newer timeline | LANG=C sort >'find-hello-after-newer.out'
 file_cmp "$TEST_KEY.find-hello-newer" 'find-hello-after-newer.out' <<'__OUT__'
 hello/stranger1.txt
 __OUT__

--- a/t/rose-app-run/11-file-incr-2.t
+++ b/t/rose-app-run/11-file-incr-2.t
@@ -83,26 +83,26 @@ tests 9
 TEST_KEY="$TEST_KEY_BASE-null-change"
 test_setup
 rose app-run --config=../config -q || exit 1
-find hello -type f | sort >'find-hello-before.out'
+find hello -type f | LANG=C sort >'find-hello-before.out'
 touch timeline # Nothing should be created after "timeline"
 sleep 1
 run_pass "$TEST_KEY" rose app-run --config=../config -q
-find hello -type f | sort >'find-hello-after.out'
+find hello -type f | LANG=C sort >'find-hello-after.out'
 file_cmp "$TEST_KEY.find-hello" 'find-hello-before.out' 'find-hello-after.out'
-find hello -type f -newer timeline | sort >'find-hello-after-newer.out'
+find hello -type f -newer timeline | LANG=C sort >'find-hello-after-newer.out'
 file_cmp "$TEST_KEY.find-hello-newer" 'find-hello-after-newer.out' </dev/null
 test_teardown
 #-------------------------------------------------------------------------------
 TEST_KEY="$TEST_KEY_BASE-change-source"
 test_setup
 rose app-run --config=../config -q || exit 1
-find hello -type f | sort >'find-hello-before.out'
+find hello -type f | LANG=C sort >'find-hello-before.out'
 touch timeline # Only changes updated after "timeline"
 sleep 1
 run_pass "$TEST_KEY" rose app-run --config=../config -O1.1 -q
-find hello -type f | sort >'find-hello-after.out'
+find hello -type f | LANG=C sort >'find-hello-after.out'
 file_cmp "$TEST_KEY.find-hello" 'find-hello-before.out' 'find-hello-after.out'
-find hello -type f -newer timeline | sort >'find-hello-after-newer.out'
+find hello -type f -newer timeline | LANG=C sort >'find-hello-after-newer.out'
 file_cmp "$TEST_KEY.find-hello-newer" 'find-hello-after-newer.out' <<'__OUT__'
 hello/stranger1.txt
 __OUT__
@@ -111,7 +111,7 @@ test_teardown
 TEST_KEY="$TEST_KEY_BASE-change-content"
 test_setup
 rose app-run --config=../config -q || exit 1
-find hello -type f | sort >'find-hello-before.out'
+find hello -type f | LANG=C sort >'find-hello-before.out'
 touch timeline # Only changes updated after "timeline"
 sleep 1
 set -e
@@ -123,14 +123,14 @@ svn ci -q -m "$TEST_KEY" $TEST_DIR/hello
 rm -rf $TEST_DIR/hello
 set +e
 run_pass "$TEST_KEY" rose app-run --config=../config -q
-find hello -type f | sort >'find-hello-after.out'
+find hello -type f | LANG=C sort >'find-hello-after.out'
 {
     echo 'hello/animals/chicken.txt'
     cat 'find-hello-before.out'
 } >'find-hello-after-expected.out'
 file_cmp "$TEST_KEY.find-hello" \
     'find-hello-after-expected.out' 'find-hello-after.out'
-find hello -type f -newer timeline | sort >'find-hello-after-newer.out'
+find hello -type f -newer timeline | LANG=C sort >'find-hello-after-newer.out'
 file_cmp "$TEST_KEY.find-hello-newer" 'find-hello-after-newer.out' <<'__OUT__'
 hello/animals/chicken.txt
 hello/stranger1.txt

--- a/t/rose-app-run/12-file-incr-3.t
+++ b/t/rose-app-run/12-file-incr-3.t
@@ -97,26 +97,26 @@ __CONFIG__
 TEST_KEY="$TEST_KEY_BASE-null-change"
 test_setup
 rose app-run --config=../config -q || exit 1
-find hello -type f | sort >'find-hello-before.out'
+find hello -type f | LANG=C sort >'find-hello-before.out'
 touch timeline # Nothing should be created after "timeline"
 sleep 1
 run_pass "$TEST_KEY" rose app-run --config=../config -q
-find hello -type f | sort >'find-hello-after.out'
+find hello -type f | LANG=C sort >'find-hello-after.out'
 file_cmp "$TEST_KEY.find-hello" 'find-hello-before.out' 'find-hello-after.out'
-find hello -type f -newer timeline | sort >'find-hello-after-newer.out'
+find hello -type f -newer timeline | LANG=C sort >'find-hello-after-newer.out'
 file_cmp "$TEST_KEY.find-hello-newer" 'find-hello-after-newer.out' </dev/null
 test_teardown
 #-------------------------------------------------------------------------------
 TEST_KEY="$TEST_KEY_BASE-change-source"
 test_setup
 rose app-run --config=../config -q || exit 1
-find hello -type f | sort >'find-hello-before.out'
+find hello -type f | LANG=C sort >'find-hello-before.out'
 touch timeline # Only changes updated after "timeline"
 sleep 1
 run_pass "$TEST_KEY" rose app-run --config=../config -O1.1 -q
-find hello -type f | sort >'find-hello-after.out'
+find hello -type f | LANG=C sort >'find-hello-after.out'
 file_cmp "$TEST_KEY.find-hello" 'find-hello-before.out' 'find-hello-after.out'
-find hello -type f -newer timeline | sort >'find-hello-after-newer.out'
+find hello -type f -newer timeline | LANG=C sort >'find-hello-after-newer.out'
 file_cmp "$TEST_KEY.find-hello-newer" 'find-hello-after-newer.out' <<'__OUT__'
 hello/stranger1.txt
 __OUT__
@@ -125,7 +125,7 @@ test_teardown
 TEST_KEY="$TEST_KEY_BASE-change-content"
 test_setup
 rose app-run --config=../config -q || exit 1
-find hello -type f | sort >'find-hello-before.out'
+find hello -type f | LANG=C sort >'find-hello-before.out'
 touch timeline # Only changes updated after "timeline"
 sleep 1
 set -e
@@ -134,14 +134,14 @@ echo "chicken" >$TEST_DIR/hello/animals/birds/chicken.txt
 rsync -a $TEST_DIR/hello $JOB_HOST:$JOB_HOST_TEST_DIR/
 set +e
 run_pass "$TEST_KEY" rose app-run --config=../config -q
-find hello -type f | sort >'find-hello-after.out'
+find hello -type f | LANG=C sort >'find-hello-after.out'
 {
     echo 'hello/animals/chicken.txt'
     cat 'find-hello-before.out'
 } >'find-hello-after-expected.out'
 file_cmp "$TEST_KEY.find-hello" \
     'find-hello-after-expected.out' 'find-hello-after.out'
-find hello -type f -newer timeline | sort >'find-hello-after-newer.out'
+find hello -type f -newer timeline | LANG=C sort >'find-hello-after-newer.out'
 file_cmp "$TEST_KEY.find-hello-newer" 'find-hello-after-newer.out' <<'__OUT__'
 hello/animals/chicken.txt
 hello/stranger1.txt

--- a/t/rose-app-run/14-file-source-optional.t
+++ b/t/rose-app-run/14-file-source-optional.t
@@ -129,9 +129,9 @@ file_cmp "$TEST_KEY-sub0.txt" "sub0.txt" </dev/null
 file_cmp "$TEST_KEY-sub1.txt" "sub1.txt" <<'__TXT__'
 I can see the periscope.
 __TXT__
-ls -l hello*.nl foo*.txt sub*.txt | sort >"$TEST_KEY-ls-l-before"
+ls -l hello*.nl foo*.txt sub*.txt | LANG=C sort >"$TEST_KEY-ls-l-before"
 run_pass "$TEST_KEY" rose app-run --config=../config -q
-ls -l hello*.nl foo*.txt sub*.txt | sort >"$TEST_KEY-ls-l-after"
+ls -l hello*.nl foo*.txt sub*.txt | LANG=C sort >"$TEST_KEY-ls-l-after"
 file_cmp "$TEST_KEY-ls-l" "$TEST_KEY-ls-l-before" "$TEST_KEY-ls-l-after"
 test_teardown
 #-------------------------------------------------------------------------------

--- a/t/rose-cli-bash-completion/00-static.t
+++ b/t/rose-cli-bash-completion/00-static.t
@@ -568,7 +568,7 @@ COMP_WORDS=( rose suite-hook --mail-cc = "" )
 COMP_CWORD=4
 COMPREPLY=
 run_pass "$TEST_KEY" _rose
-getent aliases | cut -f1 -d" " | sort | uniq > ok_users
+getent aliases | cut -f1 -d" " | LANG=C sort | uniq > ok_users
 compreply_cmp "$TEST_KEY.reply" < ok_users
 file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
@@ -581,7 +581,7 @@ COMP_WORDS=( rose suite-log --user = "" )
 COMP_CWORD=4
 COMPREPLY=
 run_pass "$TEST_KEY" _rose
-getent aliases | cut -f1 -d" " | sort | uniq > ok_users
+getent aliases | cut -f1 -d" " | LANG=C sort | uniq > ok_users
 compreply_cmp "$TEST_KEY.reply" < ok_users
 file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null

--- a/t/rose-host-select/01-timeout.t
+++ b/t/rose-host-select/01-timeout.t
@@ -34,7 +34,7 @@ file_cmp "$TEST_KEY.err" "$TEST_KEY.err" <<'__ERR__'
 [WARN] sleepy2: (ssh failed)
 [FAIL] No hosts selected.
 __ERR__
-cut -f2- mock-ssh.out | sort >mock-ssh.out.sorted
+cut -f2- mock-ssh.out | LANG=C sort >mock-ssh.out.sorted
 # N.B. Tab between 1 and sleepy?
 file_cmp "$TEST_KEY.mock-ssh.out" mock-ssh.out.sorted <<'__OUT__'
 sleepy1	bash

--- a/t/rose-metadata-graph/01-data.t
+++ b/t/rose-metadata-graph/01-data.t
@@ -34,7 +34,7 @@ init_meta < $TEST_SOURCE_DIR/lib/rose-meta.conf
 CONFIG_PATH=$(cd ../config && pwd -P)
 run_pass "$TEST_KEY" rose metadata-graph --debug --config=../config
 # Sort and filter out non-essential properties from the output file.
-sort "$TEST_KEY.out" -o "$TEST_KEY.out"
+LANG=C sort "$TEST_KEY.out" -o "$TEST_KEY.out"
 sed -i -e 's/\(pos\|bb\|width\|height\|lp\)="[^"]*\("\|$\)//g;' \
        -e 's/[, ]*\]\?;\? *$//g; /^\t/!d;' "$TEST_KEY.out"
 file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<__OUTPUT__
@@ -99,7 +99,7 @@ file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
 TEST_KEY=$TEST_KEY_BASE-ok-sub-section
 run_pass "$TEST_KEY" rose metadata-graph --debug --config=../config namelist:qux
 # Sort and filter out non-essential properties from the output file.
-sort "$TEST_KEY.out" -o "$TEST_KEY.out"
+LANG=C sort "$TEST_KEY.out" -o "$TEST_KEY.out"
 sed -i -e 's/\(pos\|bb\|width\|height\|lp\)="[^"]*\("\|$\)//g;' \
        -e 's/[, ]*\]\?;\? *$//g; /^\t/!d;' "$TEST_KEY.out"
 file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<__OUTPUT__
@@ -125,7 +125,7 @@ TEST_KEY=$TEST_KEY_BASE-ok-property
 run_pass "$TEST_KEY" rose metadata-graph --debug --config=../config \
     --property=trigger
 # Sort and filter out non-essential properties from the output file.
-sort "$TEST_KEY.out" -o "$TEST_KEY.out"
+LANG=C sort "$TEST_KEY.out" -o "$TEST_KEY.out"
 sed -i -e 's/\(pos\|bb\|width\|height\|lp\)="[^"]*\("\|$\)//g;' \
        -e 's/[, ]*\]\?;\? *$//g; /^\t/!d;' "$TEST_KEY.out"
 file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<__OUTPUT__
@@ -191,7 +191,7 @@ TEST_KEY=$TEST_KEY_BASE-ok-property-sub-section
 run_pass "$TEST_KEY" rose metadata-graph --debug --config=../config \
     --property=trigger env
 # Sort and filter out non-essential properties from the output file.
-sort "$TEST_KEY.out" -o "$TEST_KEY.out"
+LANG=C sort "$TEST_KEY.out" -o "$TEST_KEY.out"
 sed -i -e 's/\(pos\|bb\|width\|height\|lp\)="[^"]*\("\|$\)//g;' \
        -e 's/[, ]*\]\?;\? *$//g; /^\t/!d;' "$TEST_KEY.out"
 file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<__OUTPUT__

--- a/t/rose-metadata-graph/02-just-metadata.t
+++ b/t/rose-metadata-graph/02-just-metadata.t
@@ -35,7 +35,7 @@ init_meta < $TEST_SOURCE_DIR/lib/rose-meta.conf
 META_CONFIG_PATH=$(cd ../config/meta && pwd -P)
 run_pass "$TEST_KEY" rose metadata-graph --debug --config=../config/meta
 # Sort and filter out non-essential properties from the output file.
-sort "$TEST_KEY.out" -o "$TEST_KEY.out"
+LANG=C sort "$TEST_KEY.out" -o "$TEST_KEY.out"
 sed -i -e 's/\(pos\|bb\|width\|height\|lp\)="[^"]*\("\|$\)//g;' \
        -e 's/[, ]*\]\?;\? *$//g; /^\t/!d;' "$TEST_KEY.out"
 file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<__OUTPUT__

--- a/t/rose-rug-simple/00-normal.t
+++ b/t/rose-rug-simple/00-normal.t
@@ -43,7 +43,7 @@ file_cmp "$TEST_KEY_BASE.hello.log" \
 __LOG__
 sqlite3 $SUITE_RUN_DIR/cylc-suite.db \
     'select cycle,name,status from task_states where status=="succeeded";' \
-    | sort >"$TEST_KEY_BASE.db"
+    | LANG=C sort >"$TEST_KEY_BASE.db"
 file_cmp "$TEST_KEY_BASE.db" "$TEST_KEY_BASE.db" <<'__DB__'
 20130101T0000Z|hello|succeeded
 20130101T0600Z|hello|succeeded

--- a/t/rose-suite-clean/04-only-3.t
+++ b/t/rose-suite-clean/04-only-3.t
@@ -51,7 +51,7 @@ run_suite
 TEST_KEY="$TEST_KEY_BASE-work"
 run_pass "$TEST_KEY" rose suite-clean -y -n "$NAME" --only=work
 sed -i '/\/\.cylc\//d' "$TEST_KEY.out"
-sort >"$TEST_KEY.out.expected" <<__OUT__
+LANG=C sort >"$TEST_KEY.out.expected" <<__OUT__
 [INFO] delete: $SUITE_RUN_DIR/work
 [INFO] delete: $ROOT_DIR_WORK/cylc-run/$NAME/work/
 __OUT__

--- a/t/rose-suite-clean/06-only-5.t
+++ b/t/rose-suite-clean/06-only-5.t
@@ -62,7 +62,7 @@ run_pass "$TEST_KEY" rose suite-clean -y -n "$NAME" --only=work
 sed -i '/\/\.cylc\//d' "$TEST_KEY.out"
 {
     echo "[INFO] delete: $SUITE_RUN_DIR/work/"
-    sort <<__OUT__
+    LANG=C sort <<__OUT__
 [INFO] delete: $JOB_HOST:cylc-run/$NAME/work
 [INFO] delete: $JOB_HOST:$JOB_HOST_WORK/cylc-run/$NAME/work
 __OUT__

--- a/t/rose-suite-log/02-update-force.t
+++ b/t/rose-suite-log/02-update-force.t
@@ -111,7 +111,7 @@ if [[ -n ${JOB_HOST:-} ]]; then
 [INFO] delete: $JOB_HOST:log/job/2013010112/
 __OUT__
     ssh -oBatchMode=yes $JOB_HOST ls "~/cylc-run/$NAME/log/job" \
-        | sort >"$TEST_KEY.ls"
+        | LANG=C sort >"$TEST_KEY.ls"
     file_cmp "$TEST_KEY.ls" "$TEST_KEY.ls" <<<'2013010200'
 else
     skip 3 "$TEST_KEY: [t]job-host not defined"

--- a/t/rose-suite-log/06-archive-star.t
+++ b/t/rose-suite-log/06-archive-star.t
@@ -79,7 +79,7 @@ log/job/2013010200/my_task_1/01/job.err||job.err
 log/job/2013010200/my_task_1/01/job.out||job.out
 __OUT__
 N_JOB_LOGS=$(wc -l "$TEST_KEY-list-job-logs-before.out" | cut -d' ' -f1)
-(cd $SUITE_RUN_DIR/log && ls job/*) | sort >foo
+(cd $SUITE_RUN_DIR/log && ls job/*) | LANG=C sort >foo
 run_pass "$TEST_KEY-command" rose suite-log -n $NAME --archive '*' --debug
 run_fail "$TEST_KEY-list-job-logs-after" ls $SUITE_RUN_DIR/log/job/*
 if [[ -n ${JOB_HOST:-} ]]; then

--- a/t/rose-suite-run/10-import-1.t
+++ b/t/rose-suite-run/10-import-1.t
@@ -32,7 +32,7 @@ NAME=$(basename $SUITE_RUN_DIR)
 TEST_KEY="$TEST_KEY_BASE-local-install"
 run_pass "$TEST_KEY" \
     rose suite-run -C $TEST_SOURCE_DIR/$TEST_KEY_BASE/hello_earth -n $NAME -l
-(cd ~/cylc-run/$NAME; find app bin -type f | sort) >"$TEST_KEY.find"
+(cd ~/cylc-run/$NAME; find app bin -type f | LANG=C sort) >"$TEST_KEY.find"
 file_cmp "$TEST_KEY.find" "$TEST_KEY.find" <<'__FIND__'
 app/hello/rose-app.conf
 bin/my-hello
@@ -67,7 +67,7 @@ else
 fi
 #-------------------------------------------------------------------------------
 TEST_KEY="$TEST_KEY_BASE-suite-run-my-hello.log"
-sort $SUITE_RUN_DIR/my-hello.log >"$TEST_KEY"
+LANG=C sort $SUITE_RUN_DIR/my-hello.log >"$TEST_KEY"
 file_cmp "$TEST_KEY" "$TEST_KEY" <<'__LOG__'
 [2013010100] Hello Earth
 [2013010100] Hello Moon

--- a/t/rose-suite-run/11-import-2.t
+++ b/t/rose-suite-run/11-import-2.t
@@ -32,7 +32,7 @@ NAME=$(basename $SUITE_RUN_DIR)
 TEST_KEY="$TEST_KEY_BASE-local-install"
 run_pass "$TEST_KEY" \
     rose suite-run -C $TEST_SOURCE_DIR/$TEST_KEY_BASE/greet_earth -n $NAME -l
-(cd ~/cylc-run/$NAME; find app bin -type f | sort) >"$TEST_KEY.find"
+(cd ~/cylc-run/$NAME; find app bin -type f | LANG=C sort) >"$TEST_KEY.find"
 file_cmp "$TEST_KEY.find" "$TEST_KEY.find" <<'__FIND__'
 app/hello/rose-app.conf
 bin/my-hello
@@ -68,7 +68,7 @@ else
 fi
 #-------------------------------------------------------------------------------
 TEST_KEY="$TEST_KEY_BASE-suite-run-my-hello.log"
-sort $SUITE_RUN_DIR/my-hello.log >"$TEST_KEY"
+LANG=C sort $SUITE_RUN_DIR/my-hello.log >"$TEST_KEY"
 file_cmp "$TEST_KEY" "$TEST_KEY" <<'__LOG__'
 [2013010100] Greet Earth
 [2013010100] Greet Moon

--- a/t/rose-suite-run/17-install-overlap.t
+++ b/t/rose-suite-run/17-install-overlap.t
@@ -36,7 +36,7 @@ run_pass "$TEST_KEY-1" rose suite-run \
     -n $NAME --no-gcontrol -C $TEST_SOURCE_DIR/$TEST_KEY_BASE -i
 run_pass "$TEST_KEY-2" rose suite-run \
     -n $NAME --no-gcontrol -C $TEST_SOURCE_DIR/$TEST_KEY_BASE -i
-(cd $SUITE_RUN_DIR/etc; find -type f) | sort >"$TEST_KEY.find"
+(cd $SUITE_RUN_DIR/etc; find -type f) | LANG=C sort >"$TEST_KEY.find"
 file_cmp "$TEST_KEY.find" "$TEST_KEY.find" <<'__FIND__'
 ./foo/bar/baz/bacon.txt
 ./foo/bar/egg/humpty.txt

--- a/t/rose-task-run/07-app-arch.t
+++ b/t/rose-task-run/07-app-arch.t
@@ -36,7 +36,7 @@ run_pass "$TEST_KEY" \
 #-------------------------------------------------------------------------------
 # Results, good ones
 TEST_KEY="$TEST_KEY_BASE-find-foo"
-(cd $SUITE_RUN_DIR; find foo -type f |sort) >"$TEST_KEY.out"
+(cd $SUITE_RUN_DIR; find foo -type f | LANG=C sort) >"$TEST_KEY.out"
 file_cmp "$TEST_KEY.out" "$TEST_SOURCE_DIR/$TEST_KEY.out" "$TEST_KEY.out"
 for CYCLE in 2013010100 2013010112 2013010200; do
     TEST_KEY="$TEST_KEY_BASE-$CYCLE.out"
@@ -46,13 +46,13 @@ for CYCLE in 2013010100 2013010112 2013010200; do
          $SUITE_RUN_DIR/log/job/$CYCLE/archive/0*/job.out >"$TEST_KEY"
     file_cmp "$TEST_KEY" "$TEST_KEY" $TEST_SOURCE_DIR/$TEST_KEY_BASE-$CYCLE.out
     TEST_KEY="$TEST_KEY_BASE-planet-n"
-    tar -tzf $SUITE_RUN_DIR/foo/$CYCLE/hello/worlds/planet-n.tar.gz | sort \
-        >"$TEST_KEY-$CYCLE.out"
+    tar -tzf $SUITE_RUN_DIR/foo/$CYCLE/hello/worlds/planet-n.tar.gz | \
+        LANG=C sort >"$TEST_KEY-$CYCLE.out"
     file_cmp "$TEST_KEY-$CYCLE.out" \
         "$TEST_KEY-$CYCLE.out" "$TEST_SOURCE_DIR/$TEST_KEY.out"
     TEST_KEY="$TEST_KEY_BASE-unknown-stuff"
-    tar -tf $SUITE_RUN_DIR/foo/$CYCLE/hello/worlds/unknown/stuff.pax | sort \
-        >"$TEST_KEY-$CYCLE.out"
+    tar -tf $SUITE_RUN_DIR/foo/$CYCLE/hello/worlds/unknown/stuff.pax | \
+        LANG=C sort >"$TEST_KEY-$CYCLE.out"
     sed "s/\\\$CYCLE/$CYCLE/" "$TEST_SOURCE_DIR/$TEST_KEY.out" \
         >"$TEST_KEY-$CYCLE.out.expected"
     file_cmp "$TEST_KEY-$CYCLE.out" \


### PR DESCRIPTION
This fixes a number of (fake) test failures when running on machines with different `LANG`
settings.

N.B. I didn't want to enforce `LANG=C` at the whole test-battery level, as it is an
antiquated setting.

@matthewrmshin, please review.