### PR TITLE
rose test-battery: fix debug output for stdin cmp

### DIFF
--- a/t/lib/bash/test_header
+++ b/t/lib/bash/test_header
@@ -139,16 +139,11 @@ function file_cmp() {
     local TEST_KEY=$1
     local FILE_ACTUAL=$2
     local FILE_EXPECT=${3:--}
-    local FILE_EXPECT_DISK=$(mktemp)
-    cat "${FILE_EXPECT}" >"${FILE_EXPECT_DISK}"
-    if cmp -s "${FILE_EXPECT_DISK}" "${FILE_ACTUAL}"; then
+    if diff -u "${FILE_EXPECT}" "${FILE_ACTUAL}" >&2; then
         pass $TEST_KEY
-        rm "${FILE_EXPECT_DISK}"
         return
     fi
     fail $TEST_KEY
-    ${DIFFTOOL} "${FILE_EXPECT_DISK}" "${FILE_ACTUAL}" >&2
-    rm "${FILE_EXPECT_DISK}"
 }
 
 function file_test() {

--- a/t/lib/bash/test_header
+++ b/t/lib/bash/test_header
@@ -143,10 +143,12 @@ function file_cmp() {
     cat "${FILE_EXPECT}" >"${FILE_EXPECT_DISK}"
     if cmp -s "${FILE_EXPECT_DISK}" "${FILE_ACTUAL}"; then
         pass $TEST_KEY
+        rm "${FILE_EXPECT_DISK}"
         return
     fi
     fail $TEST_KEY
     ${DIFFTOOL} "${FILE_EXPECT_DISK}" "${FILE_ACTUAL}" >&2
+    rm "${FILE_EXPECT_DISK}"
 }
 
 function file_test() {

--- a/t/lib/bash/test_header
+++ b/t/lib/bash/test_header
@@ -139,12 +139,14 @@ function file_cmp() {
     local TEST_KEY=$1
     local FILE_ACTUAL=$2
     local FILE_EXPECT=${3:--}
-    if cmp -s $FILE_EXPECT $FILE_ACTUAL; then
+    local FILE_EXPECT_DISK=$(mktemp)
+    cat "${FILE_EXPECT}" >"${FILE_EXPECT_DISK}"
+    if cmp -s "${FILE_EXPECT_DISK}" "${FILE_ACTUAL}"; then
         pass $TEST_KEY
         return
     fi
     fail $TEST_KEY
-    ${DIFFTOOL} "${FILE_EXPECT}" "${FILE_ACTUAL}" >&2
+    ${DIFFTOOL} "${FILE_EXPECT_DISK}" "${FILE_ACTUAL}" >&2
 }
 
 function file_test() {


### PR DESCRIPTION
This fixes a bug in the file comparison failure reporting for `rose test-battery`.

@matthewrmshin, please review.