### PR TITLE
rose bash completion: fix use of getent for user names

### DIFF
--- a/etc/rose-bash-completion
+++ b/etc/rose-bash-completion
@@ -434,7 +434,7 @@ __rose_get_rose_dir() {
 }
 
 __rose_get_users() {
-    getent aliases | cut -f1 -d" " | sort -u
+    getent passwd | sed "s/^\([^:]\+\):.*/\1/g" | LANG=C sort -u
 }
     
 __rose_help() {

--- a/etc/rose-bash-completion
+++ b/etc/rose-bash-completion
@@ -434,7 +434,7 @@ __rose_get_rose_dir() {
 }
 
 __rose_get_users() {
-    getent passwd | sed "s/^\([^:]\+\):.*/\1/g" | LANG=C sort -u
+    getent passwd | cut -d: -f1 | LANG=C sort -u
 }
     
 __rose_help() {

--- a/t/rose-cli-bash-completion/00-static.t
+++ b/t/rose-cli-bash-completion/00-static.t
@@ -568,7 +568,7 @@ COMP_WORDS=( rose suite-hook --mail-cc = "" )
 COMP_CWORD=4
 COMPREPLY=
 run_pass "$TEST_KEY" _rose
-getent passwd | sed "s/^\([^:]\+\):.*/\1/g" | LANG=C sort | uniq > ok_users
+getent passwd | cut -d: -f1 | LANG=C sort -u > ok_users
 compreply_cmp "$TEST_KEY.reply" < ok_users
 file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
@@ -581,7 +581,7 @@ COMP_WORDS=( rose suite-log --user = "" )
 COMP_CWORD=4
 COMPREPLY=
 run_pass "$TEST_KEY" _rose
-getent passwd | sed "s/^\([^:]\+\):.*/\1/g" | LANG=C sort | uniq > ok_users
+getent passwd | cut -d: -f1 | LANG=C sort -u > ok_users
 compreply_cmp "$TEST_KEY.reply" < ok_users
 file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null

--- a/t/rose-cli-bash-completion/00-static.t
+++ b/t/rose-cli-bash-completion/00-static.t
@@ -568,7 +568,7 @@ COMP_WORDS=( rose suite-hook --mail-cc = "" )
 COMP_CWORD=4
 COMPREPLY=
 run_pass "$TEST_KEY" _rose
-getent aliases | cut -f1 -d" " | LANG=C sort | uniq > ok_users
+getent passwd | sed "s/^\([^:]\+\):.*/\1/g" | LANG=C sort | uniq > ok_users
 compreply_cmp "$TEST_KEY.reply" < ok_users
 file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
@@ -581,7 +581,7 @@ COMP_WORDS=( rose suite-log --user = "" )
 COMP_CWORD=4
 COMPREPLY=
 run_pass "$TEST_KEY" _rose
-getent aliases | cut -f1 -d" " | LANG=C sort | uniq > ok_users
+getent passwd | sed "s/^\([^:]\+\):.*/\1/g" | LANG=C sort | uniq > ok_users
 compreply_cmp "$TEST_KEY.reply" < ok_users
 file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null


### PR DESCRIPTION
This fixes the use of getent for user names - getent alias can return differently formatted results
on different systems.

@matthewrmshin, please review.