### PR TITLE
rose test-battery: add file_cmp_any test, fix sqlalchemy output variation

### DIFF
--- a/t/lib/bash/test_header
+++ b/t/lib/bash/test_header
@@ -47,10 +47,14 @@
 #     run_fail TEST_KEY COMMAND ...
 #         Run $COMMAND. pass/fail $TEST_KEY if $COMMAND returns false/true.
 #         Write STDOUT and STDERR in $TEST_KEY.out and $TEST_KEY.err.
-#     file_cmp TEST_KEY FILE_ACTUAL [$FILE_EXPECT]
+#     file_cmp TEST_KEY FILE_ACTUAL [FILE_EXPECT]
 #         Compare contents in $FILE_ACTUAL and $FILE_EXPECT. pass/fail
 #         $TEST_KEY if contents are identical/different. If $FILE_EXPECT is "-"
 #         or not defined, compare $FILE_ACTUAL with STDIN to this function.
+#     file_cmp_any TEST_KEY FILE_ACTUAL [FILE_EXPECT]
+#         As file_cmp, but FILE_EXPECT should consist of more than one
+#         contents set to compare against, separated by a line matching
+#         /^__filesep__$/. Iff any contents match, the test passes.
 #     file_test TEST_KEY FILE [OPTION]
 #         pass/fail $TEST_KEY if "test $OPTION $FILE" returns 0/1. $OPTION is
 #         -e if not specified.
@@ -143,6 +147,25 @@ function file_cmp() {
         pass $TEST_KEY
         return
     fi
+    fail $TEST_KEY
+}
+
+function file_cmp_any() {
+    local TEST_KEY=$1
+    local FILE_ACTUAL=$2
+    local FILE_EXPECT=${3:--}
+    cat $FILE_EXPECT | \
+        csplit --prefix="$TEST_KEY-cmp-any-csplit" -  /^__filesep__$/ {*}
+    for SPLIT_FILENAME in $TEST_KEY-cmp-any-csplit*; do
+        sed -i "/^__filesep__$/d" $SPLIT_FILENAME
+        if cmp -s $SPLIT_FILENAME $FILE_ACTUAL; then
+            pass $TEST_KEY
+            return
+        fi
+    done
+    for SPLIT_FILENAME in $TEST_KEY-cmp-any-csplit*; do
+        diff -u $SPLIT_FILENAME $FILE_ACTUAL >&2
+    done
     fail $TEST_KEY
 }
 

--- a/t/rosie.db/00-query.t
+++ b/t/rosie.db/00-query.t
@@ -52,8 +52,10 @@ run_pass "$TEST_KEY" $TEST_PARSER \
     '[["and", "description", "eq", "shiny"],
       ["or", "title", "eq", "Something"],
       ["and", "simulation", "contains", "Matrix"]]'
-file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<'__CONTENT__'
+file_cmp_any "$TEST_KEY.out" "$TEST_KEY.out" <<'__CONTENT__'
 optional.name = :name_1 AND optional.value = :value_1 OR main.title = :title_1 AND optional.name = :name_2 AND optional.value LIKE '%%' || :value_2 || '%%'
+__filesep__
+optional.name = :name_1 AND optional.value = :value_1 OR main.title = :title_1 AND optional.name = :name_2 AND (optional.value LIKE '%%' || :value_2 || '%%')
 __CONTENT__
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
 #-------------------------------------------------------------------------------
@@ -74,8 +76,10 @@ run_pass "$TEST_KEY" $TEST_PARSER \
     '[["and", "(", "description", "eq", "shiny"],
       ["or", "title", "eq", "Something", ")"],
       ["and", "simulation", "contains", "Matrix"]]'
-file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<'__CONTENT__'
+file_cmp_any "$TEST_KEY.out" "$TEST_KEY.out" <<'__CONTENT__'
 (optional.name = :name_1 AND optional.value = :value_1 OR main.title = :title_1) AND optional.name = :name_2 AND optional.value LIKE '%%' || :value_2 || '%%'
+__filesep__
+(optional.name = :name_1 AND optional.value = :value_1 OR main.title = :title_1) AND optional.name = :name_2 AND (optional.value LIKE '%%' || :value_2 || '%%')
 __CONTENT__
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
 #-------------------------------------------------------------------------------
@@ -90,8 +94,10 @@ run_pass "$TEST_KEY" $TEST_PARSER \
       ["or", "((", "author", "contains", "fr"],
       ["or", "revision", "lt", "100", ")"],
       ["or", "title", "contains", "x", ")"]]'
-file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<'__CONTENT__'
+file_cmp_any "$TEST_KEY.out" "$TEST_KEY.out" <<'__CONTENT__'
 optional.name = :name_1 AND optional.value = :value_1 OR main.title = :title_1 AND (main.owner = :owner_1 OR main.owner = :owner_2) OR main.author LIKE '%%' || :author_1 || '%%' OR latest.revision < :revision_1 OR main.title LIKE '%%' || :title_2 || '%%'
+__filesep__
+optional.name = :name_1 AND optional.value = :value_1 OR main.title = :title_1 AND (main.owner = :owner_1 OR main.owner = :owner_2) OR (main.author LIKE '%%' || :author_1 || '%%') OR latest.revision < :revision_1 OR (main.title LIKE '%%' || :title_2 || '%%')
 __CONTENT__
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
 #-------------------------------------------------------------------------------
@@ -107,8 +113,10 @@ run_pass "$TEST_KEY" $TEST_PARSER \
       ["or", "((", "author", "contains", "fr"],
       ["or", "revision", "lt", "100", ")"],
       ["and", "title", "eq", "x", ")"]]'
-file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<'__CONTENT__'
+file_cmp_any "$TEST_KEY.out" "$TEST_KEY.out" <<'__CONTENT__'
 (optional.name = :name_1 AND optional.value = :value_1 OR main.title = :title_1 OR main.title = :title_2) AND (main.owner = :owner_1 OR main.owner = :owner_2) OR (main.author LIKE '%%' || :author_1 || '%%' OR latest.revision < :revision_1) AND main.title = :title_3
+__filesep__
+(optional.name = :name_1 AND optional.value = :value_1 OR main.title = :title_1 OR main.title = :title_2) AND (main.owner = :owner_1 OR main.owner = :owner_2) OR ((main.author LIKE '%%' || :author_1 || '%%') OR latest.revision < :revision_1) AND main.title = :title_3
 __CONTENT__
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
This fixes a test problem with slightly differing (but functionally equal) output from later
versions of SQLAlchemy. This introduces a 'either this content or this content or this content'
kind of test.

@arjclark, please review.