### PR TITLE
Fix test fail on unset TMPDIR

### DIFF
--- a/t/rose-suite-run/12-run-dir-root.t
+++ b/t/rose-suite-run/12-run-dir-root.t
@@ -20,7 +20,7 @@
 # Test "rose suite-run", modification of the suite run root directory.
 #-------------------------------------------------------------------------------
 . $(dirname $0)/test_header
-if [[ -z $TMPDIR || -z $USER || $TMPDIR/$USER == $HOME ]]; then
+if [[ -z ${TMPDIR:-} || -z ${USER:-} || $TMPDIR/$USER == $HOME ]]; then
     skip_all "TMPDIR or USER not defined or TMPDIR/USER is HOME"
 fi
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
This fixes a failure in `t/rose-suite-run/12-run-dir-root.t` when `TMPDIR` is not set.

@kaday, please review.