### PR TITLE
rose test-battery: fix arbitrarily-ordered test output

### DIFF
--- a/t/rose-app-run/05-file.t
+++ b/t/rose-app-run/05-file.t
@@ -79,17 +79,21 @@ TEST_KEY=$TEST_KEY_BASE-v1
 test_setup
 run_pass "$TEST_KEY" rose app-run --config=../config
 DIR=$(cd ..; pwd)
-file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<__CONTENT__
+python -c "import re, sys
+print ''.join(sorted(sys.stdin.readlines(),
+                     key=re.compile('hello(\d+)').findall)).rstrip()" \
+    <"$TEST_KEY.out" >"$TEST_KEY.sorted.out"
+file_cmp "$TEST_KEY.sorted.out" "$TEST_KEY.sorted.out" <<__CONTENT__
 [INFO] export PATH=$PATH
+$OUT
+[INFO] install: hello1
+[INFO]     source: $DIR/config/file/hello1
+[INFO] command: cat hello1 hello2 hello3/text
 [INFO] install: hello2
 [INFO]     source: $DIR/config/file/hello2
 [INFO] create: hello3
 [INFO] install: hello3
 [INFO]     source: $DIR/config/file/hello3
-[INFO] install: hello1
-[INFO]     source: $DIR/config/file/hello1
-[INFO] command: cat hello1 hello2 hello3/text
-$OUT
 __CONTENT__
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
 # ... and in incremental mode

--- a/t/rose-suite-clean/03-only-2.t
+++ b/t/rose-suite-clean/03-only-2.t
@@ -57,8 +57,10 @@ TEST_KEY="$TEST_KEY_BASE-share-tens"
 run_pass "$TEST_KEY" \
     rose suite-clean -y -n "$NAME" --only=share/data/20?00101T0000Z
 sed -i '/\/\.cylc\//d' "$TEST_KEY.out"
+LANG=C sort "$TEST_KEY.out" >"$TEST_KEY.sorted.out"
 if [[ -n "$JOB_HOST" ]]; then
-    file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<__OUT__
+    # We do not know the relative sort order of $SUITE_RUN_DIR and $JOB_HOST.
+    LANG=C sort >"$TEST_KEY.expected.out" <<__OUT__
 [INFO] delete: $SUITE_RUN_DIR/share/data/20000101T0000Z/
 [INFO] delete: $SUITE_RUN_DIR/share/data/20100101T0000Z/
 [INFO] delete: $SUITE_RUN_DIR/share/data/20200101T0000Z/
@@ -67,13 +69,13 @@ if [[ -n "$JOB_HOST" ]]; then
 [INFO] delete: $JOB_HOST:cylc-run/$NAME/share/data/20200101T0000Z
 __OUT__
 else
-    file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<__OUT__
-[INFO] delete: $SUITE_RUN_DIR/share/data/20100101T0000Z/
+    cat >"$TEST_KEY.expected.out" <<__OUT__
 [INFO] delete: $SUITE_RUN_DIR/share/data/20000101T0000Z/
+[INFO] delete: $SUITE_RUN_DIR/share/data/20100101T0000Z/
 [INFO] delete: $SUITE_RUN_DIR/share/data/20200101T0000Z/
 __OUT__
 fi
-
+file_cmp "$TEST_KEY.sorted.out" "$TEST_KEY.sorted.out" "$TEST_KEY.expected.out"
 TEST_KEY="$TEST_KEY_BASE-multiples"
 run_pass "$TEST_KEY" \
     rose suite-clean -y -n "$NAME" \


### PR DESCRIPTION
This fixes some timing-dependent ordering in two of our test-battery tests.

@matthewrmshin, please review.