### PR TITLE
rose.job_runner: correctly handle exceptions

### DIFF
--- a/t/rose-app-run/06-namelist.t
+++ b/t/rose-app-run/06-namelist.t
@@ -230,6 +230,7 @@ run_fail "$TEST_KEY" rose app-run --config=../config -q \
 file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" <<'__CONTENT__'
 [FAIL] namelist:hello=greeting: NO_SUCH_VARIABLE: unbound variable
+[FAIL] source: namelist:hello
 __CONTENT__
 test_teardown
 #-------------------------------------------------------------------------------

--- a/t/rose-app-run/15-file-permission.t
+++ b/t/rose-app-run/15-file-permission.t
@@ -43,6 +43,8 @@ file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<'__OUT__'
 __OUT__
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" <<'__ERR__'
 [FAIL] [Errno 13] Permission denied: 'read_only_dest/foo.nl'
+[FAIL] install: read_only_dest/foo.nl
+[FAIL]     source: namelist:foo
 __ERR__
 chmod u+w read_only_dest
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
Should fix #1526. Failed jobs are now properly recorded and reported. Not obvious how to write a dedicated automated test.