### PR TITLE
rose_prune: prune command uses `bash -O extglob`

### DIFF
--- a/doc/rose-configuration.html
+++ b/doc/rose-configuration.html
@@ -605,7 +605,9 @@ root-dir=hpc*=$WORKDIR
 
       <dd>Root level setting. Specify the name of a builtin application,
       instead of running a command specified in the <code>[command]</code>
-      section.</dd>
+      section. See also <a href=
+      "rose-rug-task-run.html#rose-task-run.built-in-app">Running Tasks &gt;
+      rose task-run &gt; Built-in Applications Selection</a></dd>
 
       <dt><code>[command]</code></dt>
 
@@ -741,6 +743,36 @@ delays=0,6*10s,60*1m,1h
 </pre>
       </dd>
     </dl>
+
+    <h3 id="app.conf-fcm_make">Application Configuration File: Built-in
+    Application: fcm_make</h3>
+
+    <p>See <a href=
+    "rose-rug-task-run.html#rose-task-run.built-in-app.fcm_make">Running Tasks
+    &gt; rose task-run &gt; Built-in Application: fcm_make</a>.</p>
+
+    <h3 id="app.conf-rose_ana">Application Configuration File: Built-in
+    Application: rose_ana</h3>
+
+    <p>See <a href=
+    "rose-rug-task-run.html#rose-task-run.built-in-app.rose_ana">Running Tasks
+    &gt; rose task-run &gt; Built-in Application: rose_ana</a> and <a href=
+    "rose-rug-stem.html#rose-ana">rose stem &gt; Comparing output with
+    rose_ana</a>.</p>
+
+    <h3 id="app.conf-rose_arch">Application Configuration File: Built-in
+    Application: rose_arch</h3>
+
+    <p>See <a href=
+    "rose-rug-task-run.html#rose-task-run.built-in-app.rose_arch">Running Tasks
+    &gt; rose task-run &gt; Built-in Application: rose_arch</a>.</p>
+
+    <h3 id="app.conf-rose_prune">Application Configuration File: Built-in
+    Application: rose_prune</h3>
+
+    <p>See <a href=
+    "rose-rug-task-run.html#rose-task-run.built-in-app.rose_prune">Running Tasks
+    &gt; rose task-run &gt; Built-in Application: rose_prune</a>.</p>
 
     <h2 id="meta">Configuration Metadata</h2>
 

--- a/doc/rose-rug-task-run.html
+++ b/doc/rose-rug-task-run.html
@@ -421,6 +421,9 @@ opt.jobs=8
     using the <var>method-path</var> variable in the <var>[rose-ana]</var>
     section.</p>
 
+    <p>See also <a href="rose-rug-stem.html#rose-ana">rose stem &gt; Comparing
+    output with rose_ana</a>.</p>
+
     <h2 id="rose-task-run.util.rose_arch">Built-in Application: rose_arch</h2>
 
     <p>This built-in application provides a generic solution to configure site

--- a/t/rose-task-run/15-app-prune-extglob.t
+++ b/t/rose-task-run/15-app-prune-extglob.t
@@ -1,0 +1,50 @@
+#!/bin/bash
+#-------------------------------------------------------------------------------
+# (C) British Crown Copyright 2012-5 Met Office.
+#
+# This file is part of Rose, a framework for meteorological suites.
+#
+# Rose is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Rose is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Rose. If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test "rose_prune" built-in application, with bash extglob, using not glob.
+#-------------------------------------------------------------------------------
+. $(dirname $0)/test_header
+tests 2
+
+export ROSE_CONF_PATH=
+mkdir -p "${HOME}/cylc-run"
+SUITE_RUN_DIR=$(mktemp -d --tmpdir="${HOME}/cylc-run" 'rose-test-battery.XXXXXX')
+NAME="$(basename "${SUITE_RUN_DIR}")"
+#-------------------------------------------------------------------------------
+TEST_KEY="${TEST_KEY_BASE}"
+run_pass "${TEST_KEY}" \
+    rose suite-run -C "${TEST_SOURCE_DIR}/${TEST_KEY_BASE}" --name="${NAME}" \
+    --no-gcontrol --host='localhost' -- --debug
+
+TEST_KEY="${TEST_KEY_BASE}-prune.log"
+sed '/^\[INFO\] export ROSE_TASK_CYCLE_TIME=/p;/^\[INFO\] delete: /!d' \
+    "${SUITE_RUN_DIR}/prune.log" >'edited-prune.log'
+file_cmp "${TEST_KEY}" 'edited-prune.log' <<__LOG__
+[INFO] export ROSE_TASK_CYCLE_TIME=20150101T0000Z
+[INFO] export ROSE_TASK_CYCLE_TIME=20150102T0000Z
+[INFO] delete: work/20150101T0000Z/creator/red_dwarf.nl
+[INFO] delete: work/20150101T0000Z/creator/rose-app-run.conf
+[INFO] export ROSE_TASK_CYCLE_TIME=20150103T0000Z
+[INFO] delete: work/20150101T0000Z
+[INFO] delete: work/20150102T0000Z/creator/red_dwarf.nl
+[INFO] delete: work/20150102T0000Z/creator/rose-app-run.conf
+__LOG__
+#-------------------------------------------------------------------------------
+rose suite-clean -q -y "${NAME}"
+exit 0

--- a/t/rose-task-run/15-app-prune-extglob/app/creator/rose-app.conf
+++ b/t/rose-task-run/15-app-prune-extglob/app/creator/rose-app.conf
@@ -1,0 +1,17 @@
+[command]
+default=true
+
+[file:blue_giant.nl]
+source=namelist:prop(1)
+
+[file:red_giant.nl]
+source=namelist:prop(2)
+
+[file:red_dwarf.nl]
+source=namelist:prop(2)
+
+[namelist:prop(1)]
+temperature=30000
+
+[namelist:prop(2)]
+temperature=3000

--- a/t/rose-task-run/15-app-prune-extglob/app/pruner/rose-app.conf
+++ b/t/rose-task-run/15-app-prune-extglob/app/pruner/rose-app.conf
@@ -1,0 +1,5 @@
+meta=rose_prune/HEAD
+mode=rose_prune
+
+[prune]
+prune-work-at=-P1D:creator/!(*giant*) -P2D

--- a/t/rose-task-run/15-app-prune-extglob/suite.rc
+++ b/t/rose-task-run/15-app-prune-extglob/suite.rc
@@ -1,0 +1,32 @@
+#!jinja2
+[cylc]
+    UTC mode=True
+    [[event hooks]]
+        timeout handler=rose suite-hook --shutdown
+        timeout=PT1M
+[scheduling]
+    initial cycle point=20150101T00Z
+    final cycle point=20150103T00Z
+    [[dependencies]]
+        [[[P1D]]]
+            graph="""
+creator
+creator[-P1D] => pruner
+"""
+
+[runtime]
+    [[root]]
+        [[[event hooks]]]
+            succeeded handler=rose suite-hook
+            failed handler=rose suite-hook
+            submission failed handler=rose suite-hook --shutdown
+            submission timeout handler=rose suite-hook
+            execution timeout handler=rose suite-hook
+            submission timeout=PT1M
+            execution timeout=PT1M
+    [[creator]]
+        command scripting=rose task-run
+    [[pruner]]
+        command scripting="""
+rose task-run -v -v --debug | tee -a "${CYLC_SUITE_RUN_DIR}/prune.log"
+"""


### PR DESCRIPTION
This ensures that `bash -O extglob` is used to run all pruning commands.

Resolve bullet point 3 of #1491. Close #1420.