### PR TITLE
rose edit: fix variable menu when it has a macro warning.

### DIFF
--- a/lib/python/rose/config_editor/menuwidget.py
+++ b/lib/python/rose/config_editor/menuwidget.py
@@ -112,9 +112,10 @@ class MenuWidget(gtk.HBox):
             old_middle = option_ui_middle
             option_ui_middle = ''
             for warn in variable.warning:
-                option_ui_middle += "<menuitem action='Warn_" + warn + "'/>"
-                w_string = "(" + warn + ")"
-                actions.append(("Warn_" + warn, gtk.STOCK_DIALOG_INFO,
+                warn_name = warn.replace("/", "_")
+                option_ui_middle += "<menuitem action='Warn_" + warn_name + "'/>"
+                w_string = "(" + warn.replace("_", "__") + ")"
+                actions.append(("Warn_" + warn_name, gtk.STOCK_DIALOG_INFO,
                                 w_string))
             option_ui_middle += "<separator name='sepWarning'/>" + old_middle
         if variable.error:
@@ -238,12 +239,12 @@ class MenuWidget(gtk.HBox):
                                               self.my_variable.error[error],
                                               title, search_function))
         for warning in warnings:
-            action_name = "Warn_" + warning
+            action_name = "Warn_" + warning.replace("/", "_")
             if "action='" + action_name + "'" not in option_ui:
                 continue
             warn_item = uimanager.get_widget('/Options/' + action_name)
             title = rose.config_editor.DIALOG_VARIABLE_WARNING_TITLE.format(
-                                warning, self.my_variable.metadata["id"])
+                warning, self.my_variable.metadata["id"])
             warn_item.set_tooltip_text(self.my_variable.warning[warning])
             warn_item.connect("activate",
                               lambda e: dialog_func(


### PR DESCRIPTION
When a macro created a warning for a variable, the variable menu was unlaunchable.
This was due to a '/' in the generated warning name, which confused the menu
uimanager. This had been fixed for variable macro errors before, in exactly the same
way (a few lines above).

To recreate the problem, create an app with the following `rose-app.conf`:
```
[env]
FOO=bar
```
and a `meta` directory with a blank `rose-meta.conf`. The meta directory should have
a `lib/python/macros/` subdirectory with an empty `__init__.py` and a file `warning.py`
that looks like this:

```python
import rose.macro

class FooWarning(rose.macro.MacroBase):

    def validate(self, config, meta_config):
        self.add_report("env", "FOO", "bar", "Is horrible?", is_warning=True)
        return self.reports
```

After running the macro for the app in `rose edit`, clicking on the gear icon for 'FOO'
would result in a traceback like this:
```
Traceback (most recent call last):
  File "/opt/rose/lib/python/rose/config_editor/menuwidget.py", line 160, in <lambda>
    e.time))
  File "/opt/rose/lib/python/rose/config_editor/menuwidget.py", line 247, in _popup_option_menu
    warn_item.set_tooltip_text(self.my_variable.warning[warning])
AttributeError: 'NoneType' object has no attribute 'set_tooltip_text'
```

@arjclark, please review.