### PR TITLE
rose edit: catch fs browser launch exception

### DIFF
--- a/lib/python/rose/config_editor/menu.py
+++ b/lib/python/rose/config_editor/menu.py
@@ -988,10 +988,14 @@ class MainMenuHandler(object):
         self.mainwindow.launch_prefs()
 
     def launch_browser(self):
+        start_directory = self.data.top_level_directory
         if self.data.top_level_directory is None:
-            rose.external.launch_fs_browser(os.getcwd())
-        else:
-            rose.external.launch_fs_browser(self.data.top_level_directory)
+            start_directory = os.getcwd()
+        try:
+            rose.external.launch_fs_browser(start_directory)
+        except rose.popen.RosePopenError as exc:
+            rose.gtk.dialog.run_exception_dialog(exc)
+
 
     def launch_graph(self, namespace, allowed_sections=None):
         try:
@@ -1013,7 +1017,10 @@ class MainMenuHandler(object):
                     self.data.helper.get_sections_from_namespace(namespace))
         cmd = (shlex.split(rose.config_editor.LAUNCH_COMMAND_GRAPH) +
                [config_data.directory] + allowed_sections)
-        rose.popen.RosePopener().run_bg(*cmd)
+        try:
+            rose.popen.RosePopener().run_bg(*cmd)
+        except rose.popen.RosePopenError as exc:
+            rose.gtk.dialog.run_exception_dialog(exc)
 
     def launch_scheduler(self, *args):
         """Run the scheduler for a suite open in config edit."""
@@ -1033,11 +1040,8 @@ class MainMenuHandler(object):
         # Handle a launch terminal request.
         try:
             rose.external.launch_terminal()
-        except rose.popen.RosePopenError as e:
-            rose.gtk.dialog.run_dialog(
-                                rose.gtk.dialog.DIALOG_TYPE_ERROR,
-                                str(e),
-                                rose.config_editor.DIALOG_TITLE_ERROR)
+        except rose.popen.RosePopenError as exc:
+            rose.gtk.dialog.run_exception_dialog(exc)
 
     def launch_output_viewer(self):
         """View a suite's output, if any."""

--- a/lib/python/rose/config_editor/menu.py
+++ b/lib/python/rose/config_editor/menu.py
@@ -996,7 +996,6 @@ class MainMenuHandler(object):
         except rose.popen.RosePopenError as exc:
             rose.gtk.dialog.run_exception_dialog(exc)
 
-
     def launch_graph(self, namespace, allowed_sections=None):
         try:
             import pygraphviz

--- a/lib/python/rose/config_editor/panelwidget/filesystem.py
+++ b/lib/python/rose/config_editor/panelwidget/filesystem.py
@@ -95,10 +95,8 @@ class FileSystemPanel(gtk.ScrolledWindow):
                 target_func = rose.external.launch_geditor
         try:
             target_func(target)
-        except Exception as e:
-            title = rose.config_editor.DIALOG_TITLE_CRITICAL_ERROR
-            rose.gtk.dialog.run_dialog(rose.gtk.dialog.DIALOG_TYPE_ERROR,
-                                       str(e), title)
+        except Exception as exc:
+            rose.gtk.dialog.run_exception_dialog(exc)
 
     def _handle_click(self, view, event):
         pathinfo = view.get_path_at_pos(int(event.x), int(event.y))

--- a/lib/python/rose/gtk/dialog.py
+++ b/lib/python/rose/gtk/dialog.py
@@ -55,6 +55,7 @@ DIALOG_TEXT_SHUTDOWN_ASAP = "Shutdown ASAP."
 DIALOG_TEXT_SHUTTING_DOWN = "Shutting down."
 DIALOG_TEXT_UNCAUGHT_EXCEPTION = ("{0} has crashed. {1}" +
                                   "\n\n<b>{2}</b>: {3}\n{4}")
+DIALOG_TITLE_ERROR = "Error"
 DIALOG_TITLE_UNCAUGHT_EXCEPTION = "Critical error"
 DIALOG_TITLE_EXTRA_INFO = "Further information"
 DIALOG_TYPE_ERROR = gtk.MESSAGE_ERROR
@@ -421,6 +422,12 @@ def run_dialog(dialog_type, text, title=None, modal=True,
     else:
         ok_button.connect("clicked", lambda b: dialog.destroy())
         dialog.show()
+
+
+def run_exception_dialog(exception):
+    """Run a dialog displaying an exception."""
+    text = type(exception).__name__ + ": " + str(exception)
+    return run_dialog(DIALOG_TYPE_ERROR, text, DIALOG_TITLE_ERROR)
 
 
 def run_hyperlink_dialog(stock_id=None, text="", title=None,


### PR DESCRIPTION
This catches an exception thrown when a bad `[external]fs_browser` setting is defined and a file
browser is launched through `rose edit`.

@arjclark, please review.