### PR TITLE
rose.conf example: fix underscore/dash mixup

### DIFF
--- a/etc/rose.conf.example
+++ b/etc/rose.conf.example
@@ -35,9 +35,9 @@
 ## Launch graphical text editor (default=gedit).
 #  geditor=gvim -f
 ## Launch graphical file system browser (default=nautilus).
-#  fs-browser=konqueror
+#  fs_browser=konqueror
 ## Launch image viewer (default=eog).
-#  image-viewer=eog --new-instance
+#  image_viewer=eog --new-instance
 ## The rsync command.
 #  rsync=rsync -a --exclude=.* --timeout=1800 --rsh='ssh -oBatchMode=yes'
 ## The ssh command.


### PR DESCRIPTION
This fixes a mistake in the example documentation (the names are not
actually consistent with other option names).

@matthewrmshin, please review.