### PR TITLE
rose edit: report errors from metadata-graph

### DIFF
--- a/lib/python/rose/config_editor/menu.py
+++ b/lib/python/rose/config_editor/menu.py
@@ -1003,6 +1003,7 @@ class MainMenuHandler(object):
             title = rose.config_editor.WARNING_CANNOT_GRAPH
             rose.gtk.dialog.run_dialog(rose.gtk.dialog.DIALOG_TYPE_ERROR,
                                        str(e), title)
+            return
         config_name, subsp = self.util.split_full_ns(self.data, namespace)
         self.update_config(config_name)
         config_data = self.data.config[config_name]
@@ -1017,7 +1018,8 @@ class MainMenuHandler(object):
         cmd = (shlex.split(rose.config_editor.LAUNCH_COMMAND_GRAPH) +
                [config_data.directory] + allowed_sections)
         try:
-            rose.popen.RosePopener().run_bg(*cmd)
+            rose.popen.RosePopener().run_bg(
+                *cmd, stdout=sys.stdout, stderr=sys.stderr)
         except rose.popen.RosePopenError as exc:
             rose.gtk.dialog.run_exception_dialog(exc)
 


### PR DESCRIPTION
`rose edit` did not report any failures or errors from an internal launch of `rose metadata-graph`.

Failures can be caused by:
 * apps with no metadata
 * invalid site/user `[external]image_viewer` configuration

@matthewrmshin, please review.