### PR TITLE
rose test-battery: fix remaining unsorted rose-app-run output

### DIFF
--- a/t/rose-app-run/05-file.t
+++ b/t/rose-app-run/05-file.t
@@ -210,16 +210,20 @@ TEST_KEY=$TEST_KEY_BASE--install-only
 test_setup
 run_pass "$TEST_KEY" rose app-run --config=../config --install-only
 DIR=$(cd ..; pwd)
-file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<__CONTENT__
+python -c "import re, sys
+print ''.join(sorted(sys.stdin.readlines(),
+                     key=re.compile('hello(\d+)').findall)).rstrip()" \
+    <"$TEST_KEY.out" >"$TEST_KEY.sorted.out"
+file_cmp "$TEST_KEY.sorted.out" "$TEST_KEY.sorted.out" <<__CONTENT__
 [INFO] export PATH=$PATH
+[INFO] install: hello1
+[INFO]     source: $DIR/config/file/hello1
+[INFO] command: cat hello1 hello2 hello3/text
 [INFO] install: hello2
 [INFO]     source: $DIR/config/file/hello2
 [INFO] create: hello3
 [INFO] install: hello3
 [INFO]     source: $DIR/config/file/hello3
-[INFO] install: hello1
-[INFO]     source: $DIR/config/file/hello1
-[INFO] command: cat hello1 hello2 hello3/text
 __CONTENT__
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
 file_cmp "$TEST_KEY.hello1" hello1 ../config/file/hello1


### PR DESCRIPTION
Follows on from #1525.

@matthewrmshin, please review.