### PR TITLE
rose test-battery: fix metadata-graph in new graphviz output 

### DIFF
--- a/t/lib/bash/test_header
+++ b/t/lib/bash/test_header
@@ -143,7 +143,7 @@ function file_cmp() {
     local TEST_KEY=$1
     local FILE_ACTUAL=$2
     local FILE_EXPECT=${3:--}
-    if diff -u "${FILE_EXPECT}" "${FILE_ACTUAL}" >&2; then
+    if xxdiff -D "${FILE_EXPECT}" "${FILE_ACTUAL}" >&2; then
         pass $TEST_KEY
         return
     fi

--- a/t/lib/bash/test_header
+++ b/t/lib/bash/test_header
@@ -143,7 +143,7 @@ function file_cmp() {
     local TEST_KEY=$1
     local FILE_ACTUAL=$2
     local FILE_EXPECT=${3:--}
-    if xxdiff -D "${FILE_EXPECT}" "${FILE_ACTUAL}" >&2; then
+    if diff -u "${FILE_EXPECT}" "${FILE_ACTUAL}" >&2; then
         pass $TEST_KEY
         return
     fi

--- a/t/rose-metadata-graph/01-data.t
+++ b/t/rose-metadata-graph/01-data.t
@@ -26,6 +26,45 @@ python -c "import pygraphviz" 2>/dev/null || \
 #-------------------------------------------------------------------------------
 tests 12
 #-------------------------------------------------------------------------------
+# Filter graphviz output.
+function filter_graphviz() {
+    FILTER_TMP_FILE=$(mktemp)
+    cat >"$FILTER_TMP_FILE"
+    # Sort and filter out non-essential properties from the output file.
+    # Get rid of line-broken newer graphviz output (replace ",\n").
+    # Append all lines to the pattern space, then substitute.
+    sed -i ':a; N; $!ba; s/,\n\s\s*/, /g' "$FILTER_TMP_FILE"
+    # Make sure the gap between name and properties is consistent.
+    sed -i 's/\s\s*\[/ \[/g' "$FILTER_TMP_FILE"
+    # Sort the file.
+    LANG=C sort "$FILTER_TMP_FILE" -o "$FILTER_TMP_FILE"
+    # Remove non-color properties and non-relevant lines.
+    python << __PYTHON__
+import re
+filename = '$FILTER_TMP_FILE'
+f = open(filename, 'r')
+lines = f.readlines()
+f.close()
+f = open(filename, 'w')
+for line in lines:
+	if '[' not in line:
+	    f.write(line + '\n')
+	    continue
+	props = dict([_.strip().split('=', 1) for _ in
+	              re.split(', ',
+	                       line.split('[', 1)[1].replace('];', ''))])
+	new_prop_string = ''
+	for key in ['arrowhead', 'color', 'label', 'rankdir', 'shape', 'style']:
+	    if key in props:
+	        new_prop_string += key + '=' + props[key] + ', '
+	new_prop_string = new_prop_string.rstrip().rstrip(',')
+	f.write(line.split('[')[0] + '[' + new_prop_string + '\n')
+__PYTHON__
+    sed -i '/^\t/!d; /^\s*\];\s*$/d; /graph \[$/d' "$FILTER_TMP_FILE"
+    cat "$FILTER_TMP_FILE"
+    rm "$FILTER_TMP_FILE"
+}
+#-------------------------------------------------------------------------------
 # Check full graphing of our example configuration & configuration metadata.
 TEST_KEY=$TEST_KEY_BASE-ok-full
 setup
@@ -33,64 +72,59 @@ init < $TEST_SOURCE_DIR/lib/rose-app.conf
 init_meta < $TEST_SOURCE_DIR/lib/rose-meta.conf
 CONFIG_PATH=$(cd ../config && pwd -P)
 run_pass "$TEST_KEY" rose metadata-graph --debug --config=../config
-# Sort and filter out non-essential properties from the output file.
-LANG=C sort "$TEST_KEY.out" -o "$TEST_KEY.out"
-sed -i -e 's/\(pos\|bb\|width\|height\|lp\)="[^"]*\("\|$\)//g;' \
-       -e 's/[, ]*\]\?;\? *$//g; /^\t/!d;' "$TEST_KEY.out"
-file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<__OUTPUT__
-		
+filter_graphviz <"$TEST_KEY.out" >"$TEST_KEY.filtered.out"
+file_cmp "$TEST_KEY.out" "$TEST_KEY.filtered.out" <<__OUTPUT__
 	"env=CONTROL" -> "env=CONTROL=None" [color=green, label=foo
 	"env=CONTROL" -> "env=CONTROL=bar" [color=red, label=foo
 	"env=CONTROL" -> "env=CONTROL=baz" [color=red, label=foo
 	"env=CONTROL" -> "env=CONTROL=foo" [color=green, label=foo
 	"env=CONTROL" [color=green
 	"env=CONTROL=None" -> "env=DEPENDENT3" [color=green
-	"env=CONTROL=None" [label=None, color=green, shape=box, style=filled
+	"env=CONTROL=None" [color=green, label=None, shape=box, style=filled
 	"env=CONTROL=bar" -> "env=DEPENDENT1" [color=red
 	"env=CONTROL=bar" -> "env=DEPENDENT2" [color=red
-	"env=CONTROL=bar" -> "env=DEPENDENT_MISSING1" [color=red, arrowhead=empty
-	"env=CONTROL=bar" [label=bar, color=red, shape=box, style=filled
+	"env=CONTROL=bar" -> "env=DEPENDENT_MISSING1" [arrowhead=empty, color=red
+	"env=CONTROL=bar" [color=red, label=bar, shape=box, style=filled
 	"env=CONTROL=baz" -> "env=DEPENDENT1" [color=red
-	"env=CONTROL=baz" [label=baz, color=red, shape=box, style=filled
+	"env=CONTROL=baz" [color=red, label=baz, shape=box, style=filled
 	"env=CONTROL=foo" -> "env=DEPENDENT_MISSING1" [color=green
-	"env=CONTROL=foo" [label=foo, color=green, shape=box, style=filled
+	"env=CONTROL=foo" [color=green, label=foo, shape=box, style=filled
 	"env=CONTROL_NAMELIST_QUX" -> "env=CONTROL_NAMELIST_QUX=bar" [color=red, label=foo
 	"env=CONTROL_NAMELIST_QUX" [color=green
 	"env=CONTROL_NAMELIST_QUX=bar" -> "namelist:qux" [color=red
-	"env=CONTROL_NAMELIST_QUX=bar" [label=bar, color=red, shape=box, style=filled
+	"env=CONTROL_NAMELIST_QUX=bar" [color=red, label=bar, shape=box, style=filled
 	"env=CONTROL_NAMELIST_WIBBLE" -> "env=CONTROL_NAMELIST_WIBBLE=bar" [color=green, label=bar
 	"env=CONTROL_NAMELIST_WIBBLE" [color=green
 	"env=CONTROL_NAMELIST_WIBBLE=bar" -> "namelist:wibble" [color=green
-	"env=CONTROL_NAMELIST_WIBBLE=bar" [label=bar, color=green, shape=box, style=filled
+	"env=CONTROL_NAMELIST_WIBBLE=bar" [color=green, label=bar, shape=box, style=filled
 	"env=CONTROL_NAMELIST_WIBBLE_WUBBLE" -> "env=CONTROL_NAMELIST_WIBBLE_WUBBLE=bar" [color=red, label=foo
 	"env=CONTROL_NAMELIST_WIBBLE_WUBBLE" [color=green
 	"env=CONTROL_NAMELIST_WIBBLE_WUBBLE=bar" -> "namelist:wibble=wubble" [color=red
-	"env=CONTROL_NAMELIST_WIBBLE_WUBBLE=bar" [label=bar, color=red, shape=box, style=filled
-	"env=DEPENDENT1" [label="!!env=DEPENDENT1", color=red
-	"env=DEPENDENT2" [label="!!env=DEPENDENT2", color=red
+	"env=CONTROL_NAMELIST_WIBBLE_WUBBLE=bar" [color=red, label=bar, shape=box, style=filled
+	"env=DEPENDENT1" [color=red, label="!!env=DEPENDENT1"
+	"env=DEPENDENT2" [color=red, label="!!env=DEPENDENT2"
 	"env=DEPENDENT3" [color=green
-	"env=DEPENDENT_DEPENDENT1" [label="!!env=DEPENDENT_DEPENDENT1", color=red
+	"env=DEPENDENT_DEPENDENT1" [color=red, label="!!env=DEPENDENT_DEPENDENT1"
 	"env=DEPENDENT_MISSING1" -> "env=DEPENDENT_MISSING1=None" [color=grey
 	"env=DEPENDENT_MISSING1" [color=grey
 	"env=DEPENDENT_MISSING1=None" -> "env=DEPENDENT_DEPENDENT1" [color=grey
-	"env=DEPENDENT_MISSING1=None" [label=None, color=grey, shape=box, style=filled
+	"env=DEPENDENT_MISSING1=None" [color=grey, label=None, shape=box, style=filled
 	"env=MISSING_VARIABLE" [color=grey
-	"env=USER_IGNORED" [label="!env=USER_IGNORED", color=orange
-	"namelist:qux" [label="!!namelist:qux", color=red, shape=octagon
+	"env=USER_IGNORED" [color=orange, label="!env=USER_IGNORED"
+	"namelist:qux" [color=red, label="!!namelist:qux", shape=octagon
 	"namelist:qux=wobble" -> "namelist:qux=wobble=.true." [color=red, label=".false."
-	"namelist:qux=wobble" [label="^namelist:qux=wobble", color=red
+	"namelist:qux=wobble" [color=red, label="^namelist:qux=wobble"
 	"namelist:qux=wobble=.true." -> "namelist:qux=wubble" [color=red
-	"namelist:qux=wobble=.true." [label=".true.", color=red, shape=box, style=filled
-	"namelist:qux=wubble" [label="^!!namelist:qux=wubble", color=red
+	"namelist:qux=wobble=.true." [color=red, label=".true.", shape=box, style=filled
+	"namelist:qux=wubble" [color=red, label="^!!namelist:qux=wubble"
 	"namelist:wibble" [color=green, shape=octagon
 	"namelist:wibble=wobble" -> "namelist:wibble=wobble=.true." [color=green, label=".true."
 	"namelist:wibble=wobble" [color=green
 	"namelist:wibble=wobble=.true." -> "namelist:wibble=wubble" [color=green
-	"namelist:wibble=wobble=.true." [label=".true.", color=green, shape=box, style=filled
-	"namelist:wibble=wubble" [label="!!namelist:wibble=wubble", color=red
+	"namelist:wibble=wobble=.true." [color=green, label=".true.", shape=box, style=filled
+	"namelist:wibble=wubble" [color=red, label="!!namelist:wibble=wubble"
 	env [color=green, shape=octagon
 	graph [label="$CONFIG_PATH", rankdir=LR
-	graph [
 	node [label="\N"
 __OUTPUT__
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
@@ -98,24 +132,19 @@ file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
 # Check specific section graphing.
 TEST_KEY=$TEST_KEY_BASE-ok-sub-section
 run_pass "$TEST_KEY" rose metadata-graph --debug --config=../config namelist:qux
-# Sort and filter out non-essential properties from the output file.
-LANG=C sort "$TEST_KEY.out" -o "$TEST_KEY.out"
-sed -i -e 's/\(pos\|bb\|width\|height\|lp\)="[^"]*\("\|$\)//g;' \
-       -e 's/[, ]*\]\?;\? *$//g; /^\t/!d;' "$TEST_KEY.out"
-file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<__OUTPUT__
-		
+filter_graphviz <"$TEST_KEY.out" >"$TEST_KEY.filtered.out"
+file_cmp "$TEST_KEY.out" "$TEST_KEY.filtered.out" <<__OUTPUT__
 	"env=CONTROL_NAMELIST_QUX" -> "env=CONTROL_NAMELIST_QUX=bar" [color=red, label=foo
 	"env=CONTROL_NAMELIST_QUX" [color=green, shape=rectangle
 	"env=CONTROL_NAMELIST_QUX=bar" -> "namelist:qux" [color=red
-	"env=CONTROL_NAMELIST_QUX=bar" [label=bar, color=red, shape=box, style=filled
-	"namelist:qux" [label="!!namelist:qux", color=red, shape=octagon
+	"env=CONTROL_NAMELIST_QUX=bar" [color=red, label=bar, shape=box, style=filled
+	"namelist:qux" [color=red, label="!!namelist:qux", shape=octagon
 	"namelist:qux=wobble" -> "namelist:qux=wobble=.true." [color=red, label=".false."
-	"namelist:qux=wobble" [label="^namelist:qux=wobble", color=red
+	"namelist:qux=wobble" [color=red, label="^namelist:qux=wobble"
 	"namelist:qux=wobble=.true." -> "namelist:qux=wubble" [color=red
-	"namelist:qux=wobble=.true." [label=".true.", color=red, shape=box, style=filled
-	"namelist:qux=wubble" [label="^!!namelist:qux=wubble", color=red
+	"namelist:qux=wobble=.true." [color=red, label=".true.", shape=box, style=filled
+	"namelist:qux=wubble" [color=red, label="^!!namelist:qux=wubble"
 	graph [label="$CONFIG_PATH: namelist:qux", rankdir=LR
-	graph [
 	node [label="\N"
 __OUTPUT__
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
@@ -124,64 +153,59 @@ file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
 TEST_KEY=$TEST_KEY_BASE-ok-property
 run_pass "$TEST_KEY" rose metadata-graph --debug --config=../config \
     --property=trigger
-# Sort and filter out non-essential properties from the output file.
-LANG=C sort "$TEST_KEY.out" -o "$TEST_KEY.out"
-sed -i -e 's/\(pos\|bb\|width\|height\|lp\)="[^"]*\("\|$\)//g;' \
-       -e 's/[, ]*\]\?;\? *$//g; /^\t/!d;' "$TEST_KEY.out"
-file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<__OUTPUT__
-		
+filter_graphviz <"$TEST_KEY.out" >"$TEST_KEY.filtered.out"
+file_cmp "$TEST_KEY.out" "$TEST_KEY.filtered.out" <<__OUTPUT__
 	"env=CONTROL" -> "env=CONTROL=None" [color=green, label=foo
 	"env=CONTROL" -> "env=CONTROL=bar" [color=red, label=foo
 	"env=CONTROL" -> "env=CONTROL=baz" [color=red, label=foo
 	"env=CONTROL" -> "env=CONTROL=foo" [color=green, label=foo
 	"env=CONTROL" [color=green
 	"env=CONTROL=None" -> "env=DEPENDENT3" [color=green
-	"env=CONTROL=None" [label=None, color=green, shape=box, style=filled
+	"env=CONTROL=None" [color=green, label=None, shape=box, style=filled
 	"env=CONTROL=bar" -> "env=DEPENDENT1" [color=red
 	"env=CONTROL=bar" -> "env=DEPENDENT2" [color=red
-	"env=CONTROL=bar" -> "env=DEPENDENT_MISSING1" [color=red, arrowhead=empty
-	"env=CONTROL=bar" [label=bar, color=red, shape=box, style=filled
+	"env=CONTROL=bar" -> "env=DEPENDENT_MISSING1" [arrowhead=empty, color=red
+	"env=CONTROL=bar" [color=red, label=bar, shape=box, style=filled
 	"env=CONTROL=baz" -> "env=DEPENDENT1" [color=red
-	"env=CONTROL=baz" [label=baz, color=red, shape=box, style=filled
+	"env=CONTROL=baz" [color=red, label=baz, shape=box, style=filled
 	"env=CONTROL=foo" -> "env=DEPENDENT_MISSING1" [color=green
-	"env=CONTROL=foo" [label=foo, color=green, shape=box, style=filled
+	"env=CONTROL=foo" [color=green, label=foo, shape=box, style=filled
 	"env=CONTROL_NAMELIST_QUX" -> "env=CONTROL_NAMELIST_QUX=bar" [color=red, label=foo
 	"env=CONTROL_NAMELIST_QUX" [color=green
 	"env=CONTROL_NAMELIST_QUX=bar" -> "namelist:qux" [color=red
-	"env=CONTROL_NAMELIST_QUX=bar" [label=bar, color=red, shape=box, style=filled
+	"env=CONTROL_NAMELIST_QUX=bar" [color=red, label=bar, shape=box, style=filled
 	"env=CONTROL_NAMELIST_WIBBLE" -> "env=CONTROL_NAMELIST_WIBBLE=bar" [color=green, label=bar
 	"env=CONTROL_NAMELIST_WIBBLE" [color=green
 	"env=CONTROL_NAMELIST_WIBBLE=bar" -> "namelist:wibble" [color=green
-	"env=CONTROL_NAMELIST_WIBBLE=bar" [label=bar, color=green, shape=box, style=filled
+	"env=CONTROL_NAMELIST_WIBBLE=bar" [color=green, label=bar, shape=box, style=filled
 	"env=CONTROL_NAMELIST_WIBBLE_WUBBLE" -> "env=CONTROL_NAMELIST_WIBBLE_WUBBLE=bar" [color=red, label=foo
 	"env=CONTROL_NAMELIST_WIBBLE_WUBBLE" [color=green
 	"env=CONTROL_NAMELIST_WIBBLE_WUBBLE=bar" -> "namelist:wibble=wubble" [color=red
-	"env=CONTROL_NAMELIST_WIBBLE_WUBBLE=bar" [label=bar, color=red, shape=box, style=filled
-	"env=DEPENDENT1" [label="!!env=DEPENDENT1", color=red
-	"env=DEPENDENT2" [label="!!env=DEPENDENT2", color=red
+	"env=CONTROL_NAMELIST_WIBBLE_WUBBLE=bar" [color=red, label=bar, shape=box, style=filled
+	"env=DEPENDENT1" [color=red, label="!!env=DEPENDENT1"
+	"env=DEPENDENT2" [color=red, label="!!env=DEPENDENT2"
 	"env=DEPENDENT3" [color=green
-	"env=DEPENDENT_DEPENDENT1" [label="!!env=DEPENDENT_DEPENDENT1", color=red
+	"env=DEPENDENT_DEPENDENT1" [color=red, label="!!env=DEPENDENT_DEPENDENT1"
 	"env=DEPENDENT_MISSING1" -> "env=DEPENDENT_MISSING1=None" [color=grey
 	"env=DEPENDENT_MISSING1" [color=grey
 	"env=DEPENDENT_MISSING1=None" -> "env=DEPENDENT_DEPENDENT1" [color=grey
-	"env=DEPENDENT_MISSING1=None" [label=None, color=grey, shape=box, style=filled
+	"env=DEPENDENT_MISSING1=None" [color=grey, label=None, shape=box, style=filled
 	"env=MISSING_VARIABLE" [color=grey
-	"env=USER_IGNORED" [label="!env=USER_IGNORED", color=orange
-	"namelist:qux" [label="!!namelist:qux", color=red, shape=octagon
+	"env=USER_IGNORED" [color=orange, label="!env=USER_IGNORED"
+	"namelist:qux" [color=red, label="!!namelist:qux", shape=octagon
 	"namelist:qux=wobble" -> "namelist:qux=wobble=.true." [color=red, label=".false."
-	"namelist:qux=wobble" [label="^namelist:qux=wobble", color=red
+	"namelist:qux=wobble" [color=red, label="^namelist:qux=wobble"
 	"namelist:qux=wobble=.true." -> "namelist:qux=wubble" [color=red
-	"namelist:qux=wobble=.true." [label=".true.", color=red, shape=box, style=filled
-	"namelist:qux=wubble" [label="^!!namelist:qux=wubble", color=red
+	"namelist:qux=wobble=.true." [color=red, label=".true.", shape=box, style=filled
+	"namelist:qux=wubble" [color=red, label="^!!namelist:qux=wubble"
 	"namelist:wibble" [color=green, shape=octagon
 	"namelist:wibble=wobble" -> "namelist:wibble=wobble=.true." [color=green, label=".true."
 	"namelist:wibble=wobble" [color=green
 	"namelist:wibble=wobble=.true." -> "namelist:wibble=wubble" [color=green
-	"namelist:wibble=wobble=.true." [label=".true.", color=green, shape=box, style=filled
-	"namelist:wibble=wubble" [label="!!namelist:wibble=wubble", color=red
+	"namelist:wibble=wobble=.true." [color=green, label=".true.", shape=box, style=filled
+	"namelist:wibble=wubble" [color=red, label="!!namelist:wibble=wubble"
 	env [color=green, shape=octagon
 	graph [label="$CONFIG_PATH (trigger)", rankdir=LR
-	graph [
 	node [label="\N"
 __OUTPUT__
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
@@ -190,55 +214,50 @@ file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
 TEST_KEY=$TEST_KEY_BASE-ok-property-sub-section
 run_pass "$TEST_KEY" rose metadata-graph --debug --config=../config \
     --property=trigger env
-# Sort and filter out non-essential properties from the output file.
-LANG=C sort "$TEST_KEY.out" -o "$TEST_KEY.out"
-sed -i -e 's/\(pos\|bb\|width\|height\|lp\)="[^"]*\("\|$\)//g;' \
-       -e 's/[, ]*\]\?;\? *$//g; /^\t/!d;' "$TEST_KEY.out"
-file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<__OUTPUT__
-		
+filter_graphviz <"$TEST_KEY.out" >"$TEST_KEY.filtered.out"
+file_cmp "$TEST_KEY.out" "$TEST_KEY.filtered.out" <<__OUTPUT__
 	"env=CONTROL" -> "env=CONTROL=None" [color=green, label=foo
 	"env=CONTROL" -> "env=CONTROL=bar" [color=red, label=foo
 	"env=CONTROL" -> "env=CONTROL=baz" [color=red, label=foo
 	"env=CONTROL" -> "env=CONTROL=foo" [color=green, label=foo
 	"env=CONTROL" [color=green
 	"env=CONTROL=None" -> "env=DEPENDENT3" [color=green
-	"env=CONTROL=None" [label=None, color=green, shape=box, style=filled
+	"env=CONTROL=None" [color=green, label=None, shape=box, style=filled
 	"env=CONTROL=bar" -> "env=DEPENDENT1" [color=red
 	"env=CONTROL=bar" -> "env=DEPENDENT2" [color=red
-	"env=CONTROL=bar" -> "env=DEPENDENT_MISSING1" [color=red, arrowhead=empty
-	"env=CONTROL=bar" [label=bar, color=red, shape=box, style=filled
+	"env=CONTROL=bar" -> "env=DEPENDENT_MISSING1" [arrowhead=empty, color=red
+	"env=CONTROL=bar" [color=red, label=bar, shape=box, style=filled
 	"env=CONTROL=baz" -> "env=DEPENDENT1" [color=red
-	"env=CONTROL=baz" [label=baz, color=red, shape=box, style=filled
+	"env=CONTROL=baz" [color=red, label=baz, shape=box, style=filled
 	"env=CONTROL=foo" -> "env=DEPENDENT_MISSING1" [color=green
-	"env=CONTROL=foo" [label=foo, color=green, shape=box, style=filled
+	"env=CONTROL=foo" [color=green, label=foo, shape=box, style=filled
 	"env=CONTROL_NAMELIST_QUX" -> "env=CONTROL_NAMELIST_QUX=bar" [color=red, label=foo
 	"env=CONTROL_NAMELIST_QUX" [color=green
 	"env=CONTROL_NAMELIST_QUX=bar" -> "namelist:qux" [color=red
-	"env=CONTROL_NAMELIST_QUX=bar" [label=bar, color=red, shape=box, style=filled
+	"env=CONTROL_NAMELIST_QUX=bar" [color=red, label=bar, shape=box, style=filled
 	"env=CONTROL_NAMELIST_WIBBLE" -> "env=CONTROL_NAMELIST_WIBBLE=bar" [color=green, label=bar
 	"env=CONTROL_NAMELIST_WIBBLE" [color=green
 	"env=CONTROL_NAMELIST_WIBBLE=bar" -> "namelist:wibble" [color=green
-	"env=CONTROL_NAMELIST_WIBBLE=bar" [label=bar, color=green, shape=box, style=filled
+	"env=CONTROL_NAMELIST_WIBBLE=bar" [color=green, label=bar, shape=box, style=filled
 	"env=CONTROL_NAMELIST_WIBBLE_WUBBLE" -> "env=CONTROL_NAMELIST_WIBBLE_WUBBLE=bar" [color=red, label=foo
 	"env=CONTROL_NAMELIST_WIBBLE_WUBBLE" [color=green
 	"env=CONTROL_NAMELIST_WIBBLE_WUBBLE=bar" -> "namelist:wibble=wubble" [color=red
-	"env=CONTROL_NAMELIST_WIBBLE_WUBBLE=bar" [label=bar, color=red, shape=box, style=filled
-	"env=DEPENDENT1" [label="!!env=DEPENDENT1", color=red
-	"env=DEPENDENT2" [label="!!env=DEPENDENT2", color=red
+	"env=CONTROL_NAMELIST_WIBBLE_WUBBLE=bar" [color=red, label=bar, shape=box, style=filled
+	"env=DEPENDENT1" [color=red, label="!!env=DEPENDENT1"
+	"env=DEPENDENT2" [color=red, label="!!env=DEPENDENT2"
 	"env=DEPENDENT3" [color=green
-	"env=DEPENDENT_DEPENDENT1" [label="!!env=DEPENDENT_DEPENDENT1", color=red
+	"env=DEPENDENT_DEPENDENT1" [color=red, label="!!env=DEPENDENT_DEPENDENT1"
 	"env=DEPENDENT_MISSING1" -> "env=DEPENDENT_MISSING1=None" [color=grey
 	"env=DEPENDENT_MISSING1" [color=grey
 	"env=DEPENDENT_MISSING1=None" -> "env=DEPENDENT_DEPENDENT1" [color=grey
-	"env=DEPENDENT_MISSING1=None" [label=None, color=grey, shape=box, style=filled
+	"env=DEPENDENT_MISSING1=None" [color=grey, label=None, shape=box, style=filled
 	"env=MISSING_VARIABLE" [color=grey
-	"env=USER_IGNORED" [label="!env=USER_IGNORED", color=orange
-	"namelist:qux" [label="!!namelist:qux", color=red, shape=rectangle
+	"env=USER_IGNORED" [color=orange, label="!env=USER_IGNORED"
+	"namelist:qux" [color=red, label="!!namelist:qux", shape=rectangle
 	"namelist:wibble" [color=green, shape=rectangle
-	"namelist:wibble=wubble" [label="!!namelist:wibble=wubble", color=red, shape=rectangle
+	"namelist:wibble=wubble" [color=red, label="!!namelist:wibble=wubble", shape=rectangle
 	env [color=green, shape=octagon
 	graph [label="$CONFIG_PATH: env (trigger)", rankdir=LR
-	graph [
 	node [label="\N"
 __OUTPUT__
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null

--- a/t/rose-metadata-graph/02-just-metadata.t
+++ b/t/rose-metadata-graph/02-just-metadata.t
@@ -27,6 +27,45 @@ python -c "import pygraphviz" 2>/dev/null || \
 #-------------------------------------------------------------------------------
 tests 3
 #-------------------------------------------------------------------------------
+# Filter graphviz output.
+function filter_graphviz() {
+    FILTER_TMP_FILE=$(mktemp)
+    cat >"$FILTER_TMP_FILE"
+    # Sort and filter out non-essential properties from the output file.
+    # Get rid of line-broken newer graphviz output (replace ",\n").
+    # Append all lines to the pattern space, then substitute.
+    sed -i ':a; N; $!ba; s/,\n\s\s*/, /g' "$FILTER_TMP_FILE"
+    # Make sure the gap between name and properties is consistent.
+    sed -i 's/\s\s*\[/ \[/g' "$FILTER_TMP_FILE"
+    # Sort the file.
+    LANG=C sort "$FILTER_TMP_FILE" -o "$FILTER_TMP_FILE"
+    # Remove non-color properties and non-relevant lines.
+    python << __PYTHON__
+import re
+filename = '$FILTER_TMP_FILE'
+f = open(filename, 'r')
+lines = f.readlines()
+f.close()
+f = open(filename, 'w')
+for line in lines:
+    if '[' not in line:
+        f.write(line + '\n')
+        continue
+    props = dict([_.strip().split('=', 1) for _ in
+                  re.split(', ',
+                           line.split('[', 1)[1].replace('];', ''))])
+    new_prop_string = ''
+    for key in ['arrowhead', 'color', 'label', 'rankdir', 'shape', 'style']:
+        if key in props:
+            new_prop_string += key + '=' + props[key] + ', '
+    new_prop_string = new_prop_string.rstrip().rstrip(',')
+    f.write(line.split('[')[0] + '[' + new_prop_string + '\n')
+__PYTHON__
+    sed -i '/^\t/!d; /^\s*\];\s*$/d; /graph \[$/d' "$FILTER_TMP_FILE"
+    cat "$FILTER_TMP_FILE"
+    rm "$FILTER_TMP_FILE"
+}
+#-------------------------------------------------------------------------------
 # Check full graphing.
 TEST_KEY=$TEST_KEY_BASE-ok-full
 setup
@@ -34,39 +73,35 @@ init < $TEST_SOURCE_DIR/lib/rose-app.conf
 init_meta < $TEST_SOURCE_DIR/lib/rose-meta.conf
 META_CONFIG_PATH=$(cd ../config/meta && pwd -P)
 run_pass "$TEST_KEY" rose metadata-graph --debug --config=../config/meta
-# Sort and filter out non-essential properties from the output file.
-LANG=C sort "$TEST_KEY.out" -o "$TEST_KEY.out"
-sed -i -e 's/\(pos\|bb\|width\|height\|lp\)="[^"]*\("\|$\)//g;' \
-       -e 's/[, ]*\]\?;\? *$//g; /^\t/!d;' "$TEST_KEY.out"
-file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<__OUTPUT__
-		
+filter_graphviz <"$TEST_KEY.out" >"$TEST_KEY.filtered.out"
+file_cmp "$TEST_KEY.filtered.out" "$TEST_KEY.filtered.out" <<__OUTPUT__
 	"env=CONTROL" -> "env=CONTROL=None" [color=grey
 	"env=CONTROL" -> "env=CONTROL=bar" [color=grey
 	"env=CONTROL" -> "env=CONTROL=baz" [color=grey
 	"env=CONTROL" -> "env=CONTROL=foo" [color=grey
 	"env=CONTROL" [
 	"env=CONTROL=None" -> "env=DEPENDENT3" [color=grey
-	"env=CONTROL=None" [label=None, shape=box, color=grey, style=filled
+	"env=CONTROL=None" [color=grey, label=None, shape=box, style=filled
 	"env=CONTROL=bar" -> "env=DEPENDENT1" [color=grey
 	"env=CONTROL=bar" -> "env=DEPENDENT2" [color=grey
 	"env=CONTROL=bar" -> "env=DEPENDENT_MISSING1" [color=grey
-	"env=CONTROL=bar" [label=bar, shape=box, color=grey, style=filled
+	"env=CONTROL=bar" [color=grey, label=bar, shape=box, style=filled
 	"env=CONTROL=baz" -> "env=DEPENDENT1" [color=grey
-	"env=CONTROL=baz" [label=baz, shape=box, color=grey, style=filled
+	"env=CONTROL=baz" [color=grey, label=baz, shape=box, style=filled
 	"env=CONTROL=foo" -> "env=DEPENDENT_MISSING1" [color=grey
-	"env=CONTROL=foo" [label=foo, shape=box, color=grey, style=filled
+	"env=CONTROL=foo" [color=grey, label=foo, shape=box, style=filled
 	"env=CONTROL_NAMELIST_QUX" -> "env=CONTROL_NAMELIST_QUX=bar" [color=grey
 	"env=CONTROL_NAMELIST_QUX" [
 	"env=CONTROL_NAMELIST_QUX=bar" -> "namelist:qux" [color=grey
-	"env=CONTROL_NAMELIST_QUX=bar" [label=bar, shape=box, color=grey, style=filled
+	"env=CONTROL_NAMELIST_QUX=bar" [color=grey, label=bar, shape=box, style=filled
 	"env=CONTROL_NAMELIST_WIBBLE" -> "env=CONTROL_NAMELIST_WIBBLE=bar" [color=grey
 	"env=CONTROL_NAMELIST_WIBBLE" [
 	"env=CONTROL_NAMELIST_WIBBLE=bar" -> "namelist:wibble" [color=grey
-	"env=CONTROL_NAMELIST_WIBBLE=bar" [label=bar, shape=box, color=grey, style=filled
+	"env=CONTROL_NAMELIST_WIBBLE=bar" [color=grey, label=bar, shape=box, style=filled
 	"env=CONTROL_NAMELIST_WIBBLE_WUBBLE" -> "env=CONTROL_NAMELIST_WIBBLE_WUBBLE=bar" [color=grey
 	"env=CONTROL_NAMELIST_WIBBLE_WUBBLE" [
 	"env=CONTROL_NAMELIST_WIBBLE_WUBBLE=bar" -> "namelist:wibble=wubble" [color=grey
-	"env=CONTROL_NAMELIST_WIBBLE_WUBBLE=bar" [label=bar, shape=box, color=grey, style=filled
+	"env=CONTROL_NAMELIST_WIBBLE_WUBBLE=bar" [color=grey, label=bar, shape=box, style=filled
 	"env=DEPENDENT1" [
 	"env=DEPENDENT2" [
 	"env=DEPENDENT3" [
@@ -74,24 +109,23 @@ file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<__OUTPUT__
 	"env=DEPENDENT_MISSING1" -> "env=DEPENDENT_MISSING1=None" [color=grey
 	"env=DEPENDENT_MISSING1" [
 	"env=DEPENDENT_MISSING1=None" -> "env=DEPENDENT_DEPENDENT1" [color=grey
-	"env=DEPENDENT_MISSING1=None" [label=None, shape=box, color=grey, style=filled
+	"env=DEPENDENT_MISSING1=None" [color=grey, label=None, shape=box, style=filled
 	"env=MISSING_VARIABLE" [
 	"env=USER_IGNORED" [
 	"namelist:qux" [shape=octagon
 	"namelist:qux=wobble" -> "namelist:qux=wobble=.true." [color=grey
 	"namelist:qux=wobble" [
 	"namelist:qux=wobble=.true." -> "namelist:qux=wubble" [color=grey
-	"namelist:qux=wobble=.true." [label=".true.", shape=box, color=grey, style=filled
+	"namelist:qux=wobble=.true." [color=grey, label=".true.", shape=box, style=filled
 	"namelist:qux=wubble" [
 	"namelist:wibble" [shape=octagon
 	"namelist:wibble=wobble" -> "namelist:wibble=wobble=.true." [color=grey
 	"namelist:wibble=wobble" [
 	"namelist:wibble=wobble=.true." -> "namelist:wibble=wubble" [color=grey
-	"namelist:wibble=wobble=.true." [label=".true.", shape=box, color=grey, style=filled
+	"namelist:wibble=wobble=.true." [color=grey, label=".true.", shape=box, style=filled
 	"namelist:wibble=wubble" [
 	env [shape=octagon
 	graph [label="$META_CONFIG_PATH", rankdir=LR
-	graph [
 	node [label="\N"
 __OUTPUT__
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null

--- a/t/rose-metadata-graph/02-just-metadata.t
+++ b/t/rose-metadata-graph/02-just-metadata.t
@@ -19,6 +19,7 @@
 #-------------------------------------------------------------------------------
 # Test "rose metadata-graph" against just configuration metadata.
 #-------------------------------------------------------------------------------
+. $(dirname $0)/test_header_extra
 . $(dirname $0)/test_header
 
 python -c "import pygraphviz" 2>/dev/null || \
@@ -26,45 +27,6 @@ python -c "import pygraphviz" 2>/dev/null || \
 
 #-------------------------------------------------------------------------------
 tests 3
-#-------------------------------------------------------------------------------
-# Filter graphviz output.
-function filter_graphviz() {
-    FILTER_TMP_FILE=$(mktemp)
-    cat >"$FILTER_TMP_FILE"
-    # Sort and filter out non-essential properties from the output file.
-    # Get rid of line-broken newer graphviz output (replace ",\n").
-    # Append all lines to the pattern space, then substitute.
-    sed -i ':a; N; $!ba; s/,\n\s\s*/, /g' "$FILTER_TMP_FILE"
-    # Make sure the gap between name and properties is consistent.
-    sed -i 's/\s\s*\[/ \[/g' "$FILTER_TMP_FILE"
-    # Sort the file.
-    LANG=C sort "$FILTER_TMP_FILE" -o "$FILTER_TMP_FILE"
-    # Remove non-color properties and non-relevant lines.
-    python << __PYTHON__
-import re
-filename = '$FILTER_TMP_FILE'
-f = open(filename, 'r')
-lines = f.readlines()
-f.close()
-f = open(filename, 'w')
-for line in lines:
-    if '[' not in line:
-        f.write(line + '\n')
-        continue
-    props = dict([_.strip().split('=', 1) for _ in
-                  re.split(', ',
-                           line.split('[', 1)[1].replace('];', ''))])
-    new_prop_string = ''
-    for key in ['arrowhead', 'color', 'label', 'rankdir', 'shape', 'style']:
-        if key in props:
-            new_prop_string += key + '=' + props[key] + ', '
-    new_prop_string = new_prop_string.rstrip().rstrip(',')
-    f.write(line.split('[')[0] + '[' + new_prop_string + '\n')
-__PYTHON__
-    sed -i '/^\t/!d; /^\s*\];\s*$/d; /graph \[$/d' "$FILTER_TMP_FILE"
-    cat "$FILTER_TMP_FILE"
-    rm "$FILTER_TMP_FILE"
-}
 #-------------------------------------------------------------------------------
 # Check full graphing.
 TEST_KEY=$TEST_KEY_BASE-ok-full
@@ -75,58 +37,58 @@ META_CONFIG_PATH=$(cd ../config/meta && pwd -P)
 run_pass "$TEST_KEY" rose metadata-graph --debug --config=../config/meta
 filter_graphviz <"$TEST_KEY.out" >"$TEST_KEY.filtered.out"
 file_cmp "$TEST_KEY.filtered.out" "$TEST_KEY.filtered.out" <<__OUTPUT__
-	"env=CONTROL" -> "env=CONTROL=None" [color=grey
-	"env=CONTROL" -> "env=CONTROL=bar" [color=grey
-	"env=CONTROL" -> "env=CONTROL=baz" [color=grey
-	"env=CONTROL" -> "env=CONTROL=foo" [color=grey
-	"env=CONTROL" [
-	"env=CONTROL=None" -> "env=DEPENDENT3" [color=grey
-	"env=CONTROL=None" [color=grey, label=None, shape=box, style=filled
-	"env=CONTROL=bar" -> "env=DEPENDENT1" [color=grey
-	"env=CONTROL=bar" -> "env=DEPENDENT2" [color=grey
-	"env=CONTROL=bar" -> "env=DEPENDENT_MISSING1" [color=grey
-	"env=CONTROL=bar" [color=grey, label=bar, shape=box, style=filled
-	"env=CONTROL=baz" -> "env=DEPENDENT1" [color=grey
-	"env=CONTROL=baz" [color=grey, label=baz, shape=box, style=filled
-	"env=CONTROL=foo" -> "env=DEPENDENT_MISSING1" [color=grey
-	"env=CONTROL=foo" [color=grey, label=foo, shape=box, style=filled
-	"env=CONTROL_NAMELIST_QUX" -> "env=CONTROL_NAMELIST_QUX=bar" [color=grey
-	"env=CONTROL_NAMELIST_QUX" [
-	"env=CONTROL_NAMELIST_QUX=bar" -> "namelist:qux" [color=grey
-	"env=CONTROL_NAMELIST_QUX=bar" [color=grey, label=bar, shape=box, style=filled
-	"env=CONTROL_NAMELIST_WIBBLE" -> "env=CONTROL_NAMELIST_WIBBLE=bar" [color=grey
-	"env=CONTROL_NAMELIST_WIBBLE" [
-	"env=CONTROL_NAMELIST_WIBBLE=bar" -> "namelist:wibble" [color=grey
-	"env=CONTROL_NAMELIST_WIBBLE=bar" [color=grey, label=bar, shape=box, style=filled
-	"env=CONTROL_NAMELIST_WIBBLE_WUBBLE" -> "env=CONTROL_NAMELIST_WIBBLE_WUBBLE=bar" [color=grey
-	"env=CONTROL_NAMELIST_WIBBLE_WUBBLE" [
-	"env=CONTROL_NAMELIST_WIBBLE_WUBBLE=bar" -> "namelist:wibble=wubble" [color=grey
-	"env=CONTROL_NAMELIST_WIBBLE_WUBBLE=bar" [color=grey, label=bar, shape=box, style=filled
-	"env=DEPENDENT1" [
-	"env=DEPENDENT2" [
-	"env=DEPENDENT3" [
-	"env=DEPENDENT_DEPENDENT1" [
-	"env=DEPENDENT_MISSING1" -> "env=DEPENDENT_MISSING1=None" [color=grey
-	"env=DEPENDENT_MISSING1" [
-	"env=DEPENDENT_MISSING1=None" -> "env=DEPENDENT_DEPENDENT1" [color=grey
-	"env=DEPENDENT_MISSING1=None" [color=grey, label=None, shape=box, style=filled
-	"env=MISSING_VARIABLE" [
-	"env=USER_IGNORED" [
-	"namelist:qux" [shape=octagon
-	"namelist:qux=wobble" -> "namelist:qux=wobble=.true." [color=grey
-	"namelist:qux=wobble" [
-	"namelist:qux=wobble=.true." -> "namelist:qux=wubble" [color=grey
-	"namelist:qux=wobble=.true." [color=grey, label=".true.", shape=box, style=filled
-	"namelist:qux=wubble" [
-	"namelist:wibble" [shape=octagon
-	"namelist:wibble=wobble" -> "namelist:wibble=wobble=.true." [color=grey
-	"namelist:wibble=wobble" [
-	"namelist:wibble=wobble=.true." -> "namelist:wibble=wubble" [color=grey
-	"namelist:wibble=wobble=.true." [color=grey, label=".true.", shape=box, style=filled
-	"namelist:wibble=wubble" [
-	env [shape=octagon
-	graph [label="$META_CONFIG_PATH", rankdir=LR
-	node [label="\N"
+"env=CONTROL" -> "env=CONTROL=None" [color=grey
+"env=CONTROL" -> "env=CONTROL=bar" [color=grey
+"env=CONTROL" -> "env=CONTROL=baz" [color=grey
+"env=CONTROL" -> "env=CONTROL=foo" [color=grey
+"env=CONTROL" [
+"env=CONTROL=None" -> "env=DEPENDENT3" [color=grey
+"env=CONTROL=None" [color=grey, label=None, shape=box, style=filled
+"env=CONTROL=bar" -> "env=DEPENDENT1" [color=grey
+"env=CONTROL=bar" -> "env=DEPENDENT2" [color=grey
+"env=CONTROL=bar" -> "env=DEPENDENT_MISSING1" [color=grey
+"env=CONTROL=bar" [color=grey, label=bar, shape=box, style=filled
+"env=CONTROL=baz" -> "env=DEPENDENT1" [color=grey
+"env=CONTROL=baz" [color=grey, label=baz, shape=box, style=filled
+"env=CONTROL=foo" -> "env=DEPENDENT_MISSING1" [color=grey
+"env=CONTROL=foo" [color=grey, label=foo, shape=box, style=filled
+"env=CONTROL_NAMELIST_QUX" -> "env=CONTROL_NAMELIST_QUX=bar" [color=grey
+"env=CONTROL_NAMELIST_QUX" [
+"env=CONTROL_NAMELIST_QUX=bar" -> "namelist:qux" [color=grey
+"env=CONTROL_NAMELIST_QUX=bar" [color=grey, label=bar, shape=box, style=filled
+"env=CONTROL_NAMELIST_WIBBLE" -> "env=CONTROL_NAMELIST_WIBBLE=bar" [color=grey
+"env=CONTROL_NAMELIST_WIBBLE" [
+"env=CONTROL_NAMELIST_WIBBLE=bar" -> "namelist:wibble" [color=grey
+"env=CONTROL_NAMELIST_WIBBLE=bar" [color=grey, label=bar, shape=box, style=filled
+"env=CONTROL_NAMELIST_WIBBLE_WUBBLE" -> "env=CONTROL_NAMELIST_WIBBLE_WUBBLE=bar" [color=grey
+"env=CONTROL_NAMELIST_WIBBLE_WUBBLE" [
+"env=CONTROL_NAMELIST_WIBBLE_WUBBLE=bar" -> "namelist:wibble=wubble" [color=grey
+"env=CONTROL_NAMELIST_WIBBLE_WUBBLE=bar" [color=grey, label=bar, shape=box, style=filled
+"env=DEPENDENT1" [
+"env=DEPENDENT2" [
+"env=DEPENDENT3" [
+"env=DEPENDENT_DEPENDENT1" [
+"env=DEPENDENT_MISSING1" -> "env=DEPENDENT_MISSING1=None" [color=grey
+"env=DEPENDENT_MISSING1" [
+"env=DEPENDENT_MISSING1=None" -> "env=DEPENDENT_DEPENDENT1" [color=grey
+"env=DEPENDENT_MISSING1=None" [color=grey, label=None, shape=box, style=filled
+"env=MISSING_VARIABLE" [
+"env=USER_IGNORED" [
+"namelist:qux" [shape=octagon
+"namelist:qux=wobble" -> "namelist:qux=wobble=.true." [color=grey
+"namelist:qux=wobble" [
+"namelist:qux=wobble=.true." -> "namelist:qux=wubble" [color=grey
+"namelist:qux=wobble=.true." [color=grey, label=".true.", shape=box, style=filled
+"namelist:qux=wubble" [
+"namelist:wibble" [shape=octagon
+"namelist:wibble=wobble" -> "namelist:wibble=wobble=.true." [color=grey
+"namelist:wibble=wobble" [
+"namelist:wibble=wobble=.true." -> "namelist:wibble=wubble" [color=grey
+"namelist:wibble=wobble=.true." [color=grey, label=".true.", shape=box, style=filled
+"namelist:wibble=wubble" [
+env [shape=octagon
+graph [label="$META_CONFIG_PATH", rankdir=LR
+node [label="\N"
 __OUTPUT__
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
 teardown

--- a/t/rose-metadata-graph/test_header_extra
+++ b/t/rose-metadata-graph/test_header_extra
@@ -1,0 +1,58 @@
+#!/bin/bash
+#-------------------------------------------------------------------------------
+# (C) British Crown Copyright 2012-5 Met Office.
+#
+# This file is part of Rose, a framework for meteorological suites.
+#
+# Rose is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Rose is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Rose. If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Provides extra functions for rose metadata-graph testing.
+#-------------------------------------------------------------------------------
+
+function filter_graphviz() {
+    FILTER_TMP_FILE=$(mktemp)
+    cat >"$FILTER_TMP_FILE"
+    # Sort and filter out non-essential properties from the output file.
+    # Get rid of line-broken newer graphviz output (replace ",\n").
+    # Sort the file.
+    python << __PYTHON__
+import re
+filename = '$FILTER_TMP_FILE'
+f = open(filename, 'r')
+text = f.read()
+f.close()
+text = text.replace(",\n", ", ")
+text = re.sub("\s+\[", " [", text)
+lines = text.splitlines()
+f = open(filename, 'w')
+for line in lines:
+    if '[' not in line:
+        if line.startswith("\t") and line.strip() != "];":
+            f.write(line.lstrip() + '\n')
+        continue
+    props = dict([_.strip().split('=', 1) for _ in
+                  re.split(', ',
+                           line.split('[', 1)[1].replace('];', ''))])
+    new_prop_string = ''
+    for key in ['arrowhead', 'color', 'label', 'rankdir', 'shape', 'style']:
+        if key in props:
+            new_prop_string += key + '=' + props[key] + ', '
+    new_prop_string = new_prop_string.rstrip().rstrip(',')
+    new_line = line.lstrip().split('[')[0] + '[' + new_prop_string + '\n'
+    if new_line.strip() != 'graph [':
+        f.write(new_line)
+__PYTHON__
+    LANG=C sort "$FILTER_TMP_FILE"
+    rm "$FILTER_TMP_FILE"
+}


### PR DESCRIPTION
This fixes the tests for rose metadata-graph under newer (quite different) graphviz output.

The principal differences of the newer format are:
 * difference in order of properties, which now have to be sorted by us
 * breaking properties across multiple lines

@arjclark, please review.