### PR TITLE
rose config: remove --has from docs

### DIFF
--- a/bin/rose-config
+++ b/bin/rose-config
@@ -43,10 +43,10 @@
 #     rose config --keys
 #
 #     # Exit with 0 if OPTION exists in SECTION, or 1 otherwise.
-#     rose config --has SECTION OPTION
+#     rose config -q SECTION OPTION
 #
 #     # Exit with 0 if SECTION exists, or 1 otherwise.
-#     rose config --has SECTION
+#     rose config -q SECTION
 #
 #     # Combine the configurations in FILE1 and FILE2, and dump the result.
 #     rose config --file=FILE1 --file=FILE2
@@ -73,9 +73,6 @@
 #         Each of these specifies a configuration file. If none specified, read
 #         from $THIS/../etc/rose.conf and $HOME/.metomi/rose.conf (where $THIS
 #         is the location of this command).
-#     --has, --quiet, -q
-#         Exit with 0 if the specified SECTION and/or OPTION exist in the
-#         configuration, or 1 otherwise.
 #     --keys, -k
 #         If specified, only print the SECTION keys in the configuration file or
 #         the OPTION keys in a SECTION.
@@ -94,6 +91,9 @@
 #     --print-ignored, -i
 #         If specified, the program will print ignored !OPTION=VALUE where
 #         relevant.
+#     --quiet, -q
+#         Exit with 0 if the specified SECTION and/or OPTION exist in the
+#         configuration, or 1 otherwise.
 #
 # ENVIRONMENT VARIABLES
 #     optional ROSE_META_PATH

--- a/doc/rose-command.html
+++ b/doc/rose-command.html
@@ -518,12 +518,12 @@ rosie UTIL [OPTS] [ARG ...]
 
       <dd>Print the <var>SECTION</var> keys.</dd>
 
-      <dt><kbd>rose config --has SECTION OPTION</kbd></dt>
+      <dt><kbd>rose config -q SECTION OPTION</kbd></dt>
 
       <dd>Exit with 0 if <var>OPTION</var> exists in <var>SECTION</var>, or 1
       otherwise.</dd>
 
-      <dt><kbd>rose config --has SECTION</kbd></dt>
+      <dt><kbd>rose config -q SECTION</kbd></dt>
 
       <dd>Exit with 0 if <var>SECTION</var> exists, or 1 otherwise.</dd>
 
@@ -568,11 +568,6 @@ rosie UTIL [OPTS] [ARG ...]
       <var>$HOME/.metomi/rose.conf</var> (where <var>$THIS</var> is the
       location of this command).</dd>
 
-      <dt><kbd>--has, --quiet, -q</kbd></dt>
-
-      <dd>Exit with 0 if the specified <var>SECTION</var> and/or
-      <var>OPTION</var> exist in the configuration, or 1 otherwise.</dd>
-
       <dt><kbd>--keys, -k</kbd></dt>
 
       <dd>If specified, only print the <var>SECTION</var> keys in the
@@ -604,6 +599,11 @@ rosie UTIL [OPTS] [ARG ...]
 
       <dd>If specified, the program will print ignored <var>!OPTION=VALUE</var>
       where relevant.</dd>
+
+      <dt><kbd>--quiet, -q</kbd></dt>
+
+      <dd>Exit with 0 if the specified <var>SECTION</var> and/or
+      <var>OPTION</var> exist in the configuration, or 1 otherwise.</dd>
     </dl>
 
     <h3>ENVIRONMENT VARIABLES</h3>


### PR DESCRIPTION
Option is no longer supported by the logic.

Close #1546.