### PR TITLE
documentation: fix wrong command links in rose-variables.html

### DIFF
--- a/doc/rose-variables.html
+++ b/doc/rose-variables.html
@@ -62,7 +62,7 @@
     <ul>
       <li><a href="rose-command.html#rose-app-run">rose app-run</a></li>
 
-      <li><a href="rose-command.html#rose-app-run">rose task-run</a></li>
+      <li><a href="rose-command.html#rose-task-run">rose task-run</a></li>
     </ul>
 
     <h2 id="ROSE_CONF_PATH"><var>ROSE_CONF_PATH</var></h2>
@@ -182,7 +182,7 @@
     <ul>
       <li><a href="rose-command.html#rose-app-run">rose app-run</a></li>
 
-      <li><a href="rose-command.html#rose-app-run">rose task-run</a></li>
+      <li><a href="rose-command.html#rose-task-run">rose task-run</a></li>
     </ul>
 
     <h2 id="ROSE_HOME"><var>ROSE_HOME</var></h2>
@@ -378,9 +378,7 @@
     <h3>Used By</h3>
 
     <ul>
-      <li><a href="rose-command.html#rose-app-run">rose app-run</a></li>
-
-      <li><a href="rose-command.html#rose-app-run">rose task-run</a></li>
+      <li><a href="rose-command.html#rose-suite-run">rose suite-run</a></li>
     </ul>
 
     <h2 id="ROSE_TASK_APP"><var>ROSE_TASK_APP</var></h2>


### PR DESCRIPTION
This fixes some incorrect links in the variables documentation.

@arjclark, please review.