### PR TITLE
rose edit, rose app-upgrade: allow category packages

### DIFF
--- a/doc/rose-api.html
+++ b/doc/rose-api.html
@@ -864,6 +864,16 @@ class Upgrade272to273(rose.upgrade.MacroUpgrade):
     <samp>versions.py</samp> file -
     <samp>rose-meta/CATEGORY/versions.py</samp>.</p>
 
+    <p>If you have many upgrade macros, you may want to separate them into
+    different modules in the same directory. You can then import from those in
+    <samp>versions.py</samp>, so that they are still exposed in that module.
+    You'll need to make your directory a package by creating an
+    <samp>__init__.py</samp> file, which should contain the line <samp>import
+    versions</samp>. To avoid conflict with other <samp>CATEGORY</samp> upgrade
+    modules (or other Python modules), please name these very modules carefully
+    or use absolute or package level imports like this: <samp>from
+    .versionXX_YY import FooBar</samp>.</p>
+
     <p>Upgrade macros are subclasses of <code>rose.upgrade.MacroUpgrade</code>.
     They have all the functionality of the transform macros documented above.
     <code>rose.upgrade.MacroUpgrade</code> also has some additional convenience

--- a/t/rose-app-upgrade/08-category-is-package.t
+++ b/t/rose-app-upgrade/08-category-is-package.t
@@ -1,0 +1,84 @@
+#!/bin/bash
+#-------------------------------------------------------------------------------
+# (C) British Crown Copyright 2012-5 Met Office.
+#
+# This file is part of Rose, a framework for meteorological suites.
+#
+# Rose is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Rose is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Rose. If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test "rose app-upgrade" when the versions.py file is in a package.
+#-------------------------------------------------------------------------------
+. $(dirname $0)/test_header
+#-------------------------------------------------------------------------------
+tests 4
+#-------------------------------------------------------------------------------
+init <<'__CONFIG__'
+meta=defence/blaster
+__CONFIG__
+setup
+init_meta defence blaster lightsaber HEAD
+init_macro defence <<'__MACRO__'
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from .jedi import *
+__MACRO__
+cat >$TEST_DIR/rose-meta/$category/__init__.py <<'__MODULE__'
+import versions
+__MODULE__
+cat >$TEST_DIR/rose-meta/$category/jedi.py <<'__MACRO__'
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+
+import rose.upgrade
+
+
+class UpgradeAddLightSaber(rose.upgrade.MacroUpgrade):
+
+    """'An elegant weapon, for a more civilized age.'
+
+    (Star Wars: A New Hope)
+
+    """
+
+    BEFORE_TAG = "blaster"
+    AFTER_TAG = "lightsaber"
+
+    def upgrade(self, config, meta_config=None):
+        self.add_setting(config, ['env', 'COLOUR'], 'blue')
+        return config, self.reports
+__MACRO__
+#-----------------------------------------------------------------------------
+TEST_KEY=$TEST_KEY_BASE-simple
+run_pass "$TEST_KEY" rose app-upgrade --non-interactive \
+ --meta-path=../rose-meta/ -C ../config lightsaber
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<'__OUTPUT__'
+[U] Upgrade_blaster-lightsaber: changes: 3
+    env=None=None
+        Added
+    env=COLOUR=blue
+        Added with value 'blue'
+    =meta=defence/lightsaber
+        Upgraded from blaster to lightsaber
+__OUTPUT__
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+file_cmp "$TEST_KEY.file" ../config/rose-app.conf <<'__CONFIG__'
+meta=defence/lightsaber
+
+[env]
+COLOUR=blue
+__CONFIG__
+#-----------------------------------------------------------------------------
+teardown


### PR DESCRIPTION
This fixes #1554. The root cause of this problem is that different `versions.py` files in different
metadata categories can attempt to import exactly the same named submodules.

For example, both `versions.py` files might look like this:
```
from versionX_Y import * 
from versionY_Z import *
```
where `X`, `Y`, `Z` are some common tags between the two categories.

Python will attempt to use the first `versionX_Y` module it imports for both categories.
This happens in a `rose edit` suite editing context.

This fix allows a workaround for the problem by allowing the `versions.py` parent directory
to look like a Python package (add an `__init__.py`). The `__init__.py` must `import versions`
at least in the way I've currently implemented it.

The `versions.py` file can then look like this:
```
from .versionX_Y import * 
from .versionY_Z import *
```
where the leading `.` denotes "from this package".

@matthewrmshin, please review.