### PR TITLE
rose edit: fix blank ns for trailing slash section

### DIFF
--- a/demo/rose-config-edit/demo_meta/app/12-file/rose-app.conf
+++ b/demo/rose-config-edit/demo_meta/app/12-file/rose-app.conf
@@ -16,6 +16,9 @@ source=$LKSD
 [file:foo(2)]
 source=$SDFN
 
+[file:directory/]
+source=/some/directory/
+
 [file:unexpected_content]
 something=something not right
 

--- a/lib/python/rose/config_editor/data_helper.py
+++ b/lib/python/rose/config_editor/data_helper.py
@@ -309,10 +309,10 @@ class ConfigDataHelper(object):
                     else:
                         subspace = node.value + '/' + str(match.groups()[1])
                 elif section.startswith(rose.SUB_CONFIG_FILE_DIR + ":"):
-                    subspace = section.replace('/', ':')
+                    subspace = section.rstrip('/').replace('/', ':')
                     subspace = subspace.replace(':', '/', 1)
                 else:
-                    subspace = section.replace(':', '/')
+                    subspace = section.rstrip('/').replace(':', '/')
             section_ns = config_name + '/' + subspace
             if not subspace:
                 section_ns = config_name


### PR DESCRIPTION
This fixes #1527.

It fixes the example given in that issue, and the non-optimal hover-over behaviour for the related `file:directory/` problem.

@arjclark, please review.

