### PR TITLE
rosa svn-pre-commit: fix copy with bad owner

### DIFF
--- a/lib/python/rosie/usertools/ldaptool.py
+++ b/lib/python/rosie/usertools/ldaptool.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-#-------------------------------------------------------------------------------
+#------------------------------------------------------------------------------
 # (C) British Crown Copyright 2012-5 Met Office.
 #
 # This file is part of Rose, a framework for meteorological suites.
@@ -16,7 +16,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with Rose. If not, see <http://www.gnu.org/licenses/>.
-#-------------------------------------------------------------------------------
+#------------------------------------------------------------------------------
 """User information via LDAP."""
 
 try:
@@ -25,6 +25,7 @@ except ImportError:
     pass
 import os
 from rose.resource import ResourceLocator
+
 
 class LDAPUserTool(object):
 
@@ -51,13 +52,12 @@ class LDAPUserTool(object):
     def verify_users(cls, users):
         """Verify list of users are in the LDAP directory.
 
-        Return a tuple with 2 lists (good_users, bad_users).
+        Return a list of bad users.
 
         """
         # N.B. Will they be unique?
         good_users = cls._search(users, cls.UID_IDX)
-        bad_users = [user for user in users if user not in good_users]
-        return (good_users, bad_users)
+        return [user for user in users if user not in good_users]
 
     @classmethod
     def _search(cls, users, attr_idx):

--- a/lib/python/rosie/usertools/passwdtool.py
+++ b/lib/python/rosie/usertools/passwdtool.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-#-------------------------------------------------------------------------------
+#------------------------------------------------------------------------------
 # (C) British Crown Copyright 2012-5 Met Office.
 #
 # This file is part of Rose, a framework for meteorological suites.
@@ -16,10 +16,11 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with Rose. If not, see <http://www.gnu.org/licenses/>.
-#-------------------------------------------------------------------------------
+#------------------------------------------------------------------------------
 """User information via Unix password info."""
 
 from pwd import getpwnam
+
 
 class PasswdUserTool(object):
 
@@ -37,22 +38,27 @@ class PasswdUserTool(object):
         This assumes that it is possible to email the user IDs.
 
         """
-        return cls.verify_users(users)[0]
+        good_users = []
+        for user in users:
+            try:
+                getpwnam(user)
+            except KeyError:
+                pass
+            else:
+                good_users.append(user)
+        return good_users
 
     @classmethod
     def verify_users(cls, users):
         """Verify list of users are in the Unix password file.
 
-        Return a tuple with 2 lists (good_users, bad_users).
+        Return a list of bad users.
 
         """
-        good_users = []
         bad_users = []
         for user in users:
             try:
                 getpwnam(user)
             except KeyError:
                 bad_users.append(user)
-            else:
-                good_users.append(user)
-        return (good_users, bad_users)
+        return bad_users

--- a/t/rosa-svn-pre-commit/02-passwd.t
+++ b/t/rosa-svn-pre-commit/02-passwd.t
@@ -28,7 +28,7 @@ super-users=rosie
 user-tool=passwd
 __ROSE_CONF__
 #-------------------------------------------------------------------------------
-tests 11
+tests 13
 #-------------------------------------------------------------------------------
 mkdir repos
 svnadmin create repos/foo
@@ -110,6 +110,20 @@ sed -i '/^\[FAIL\]/!d' "$TEST_KEY.err"
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" <<'__ERR__'
 [FAIL] NO SUCH USER: U   a/a/0/0/0/trunk/rose-suite.info: access-list=no-such-user-550
 [FAIL] NO SUCH USER: U   a/a/0/0/0/trunk/rose-suite.info: access-list=no-such-user-551
+__ERR__
+#-------------------------------------------------------------------------------
+TEST_KEY="${TEST_KEY_BASE}-copy-with-bad-owner"
+svn co -q "${SVN_URL}/a/a/0/0/" 'aa00'
+svn mkdir -q 'aa00/1'
+svn cp -q 'aa00/0/trunk' 'aa00/1/'
+cat >'aa00/1/trunk/rose-suite.info' <<'__ROSE_SUITE_INFO__'
+owner=no-such-user-550
+access-list=*
+__ROSE_SUITE_INFO__
+run_fail "$TEST_KEY" svn commit -q -m 't' --non-interactive 'aa00/1'
+sed -i '/^\[FAIL\]/!d' "$TEST_KEY.err"
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" <<'__ERR__'
+[FAIL] NO SUCH USER: U   a/a/0/0/1/trunk/rose-suite.info: owner=no-such-user-550
 __ERR__
 #-------------------------------------------------------------------------------
 exit 0


### PR DESCRIPTION
On suite copy, a bad user ID in `owner` or `access-list` was not being
rejected by the Rosie pre-commit hook. This change fixes the problem.

Fix #1556.