### PR TITLE
rose.variable.array_split: fix left behind escape

### DIFF
--- a/t/rose.variable/01-array-split.t
+++ b/t/rose.variable/01-array-split.t
@@ -1,0 +1,78 @@
+#!/bin/bash
+#-------------------------------------------------------------------------------
+# (C) British Crown Copyright 2012-5 Met Office.
+#
+# This file is part of Rose, a framework for meteorological suites.
+#
+# Rose is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Rose is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Rose. If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test "rose.variable" > "array_split".
+#-------------------------------------------------------------------------------
+. "$(dirname "$0")/test_header"
+tests 22
+
+if [[ -n "${PYTHONPATH:-}" ]]; then
+    export PYTHONPATH="${TEST_SOURCE_DIR}:${PYTHONPATH}"
+else
+    export PYTHONPATH="${TEST_SOURCE_DIR}"
+fi
+#-------------------------------------------------------------------------------
+TEST_KEY="${TEST_KEY_BASE}-0"
+run_pass "${TEST_KEY}" python -m 't_array_split' ''
+file_cmp "${TEST_KEY}.out" "${TEST_KEY}.out" <<<'[]'
+#-------------------------------------------------------------------------------
+TEST_KEY="${TEST_KEY_BASE}-0-space"
+run_pass "${TEST_KEY}" python -m 't_array_split' '    '
+file_cmp "${TEST_KEY}.out" "${TEST_KEY}.out" <<<'[]'
+#-------------------------------------------------------------------------------
+TEST_KEY="${TEST_KEY_BASE}-1"
+run_pass "${TEST_KEY}" python -m 't_array_split' 'foo'
+file_cmp "${TEST_KEY}.out" "${TEST_KEY}.out" <<<"['foo']"
+#-------------------------------------------------------------------------------
+TEST_KEY="${TEST_KEY_BASE}-1-space"
+run_pass "${TEST_KEY}" python -m 't_array_split' '  foo     '
+file_cmp "${TEST_KEY}.out" "${TEST_KEY}.out" <<<"['foo']"
+#-------------------------------------------------------------------------------
+TEST_KEY="${TEST_KEY_BASE}-2-null"
+run_pass "${TEST_KEY}" python -m 't_array_split' 'foo,'
+file_cmp "${TEST_KEY}.out" "${TEST_KEY}.out" <<<"['foo', '']"
+#-------------------------------------------------------------------------------
+TEST_KEY="${TEST_KEY_BASE}-2-escape"
+run_pass "${TEST_KEY}" python -m 't_array_split' 'foo\,bar, baz'
+file_cmp "${TEST_KEY}.out" "${TEST_KEY}.out" <<<"['foo\\\\,bar', 'baz']"
+#-------------------------------------------------------------------------------
+TEST_KEY="${TEST_KEY_BASE}-2-escape-remove"
+run_pass "${TEST_KEY}" python -m 't_array_split' 'foo\,bar, baz' ',' 1
+file_cmp "${TEST_KEY}.out" "${TEST_KEY}.out" <<<"['foo,bar', 'baz']"
+#-------------------------------------------------------------------------------
+TEST_KEY="${TEST_KEY_BASE}-3"
+run_pass "${TEST_KEY}" python -m 't_array_split' 'foo,bar,baz'
+file_cmp "${TEST_KEY}.out" "${TEST_KEY}.out" <<<"['foo', 'bar', 'baz']"
+#-------------------------------------------------------------------------------
+TEST_KEY="${TEST_KEY_BASE}-3-space"
+run_pass "${TEST_KEY}" python -m 't_array_split' '  foo, bar, baz'
+file_cmp "${TEST_KEY}.out" "${TEST_KEY}.out" <<<"['foo', 'bar', 'baz']"
+#-------------------------------------------------------------------------------
+TEST_KEY="${TEST_KEY_BASE}-3-only-delim-is-comma"
+run_pass "${TEST_KEY}" python -m 't_array_split' 'foo, bar, baz' ','
+file_cmp "${TEST_KEY}.out" "${TEST_KEY}.out" <<<"['foo', 'bar', 'baz']"
+#-------------------------------------------------------------------------------
+TEST_KEY="${TEST_KEY_BASE}-4-complex"
+run_pass "${TEST_KEY}" python -m 't_array_split' \
+    " \"rose's fault\", \"no, it isn't\", 'yes, it is', whatever"
+file_cmp "${TEST_KEY}.out" "${TEST_KEY}.out" <<'__OUT__'
+['"rose\'s fault"', '"no, it isn\'t"', "'yes, it is'", 'whatever']
+__OUT__
+#-------------------------------------------------------------------------------
+exit

--- a/t/rose.variable/t_array_split.py
+++ b/t/rose.variable/t_array_split.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#------------------------------------------------------------------------------
+# (C) British Crown Copyright 2012-5 Met Office.
+#
+# This file is part of Rose, a framework for meteorological suites.
+#
+# Rose is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Rose is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Rose. If not, see <http://www.gnu.org/licenses/>.
+#------------------------------------------------------------------------------
+"""Test rose.variable.array_split."""
+
+
+import sys
+from rose.variable import array_split
+
+
+def main():
+    """CLI."""
+    print array_split(*sys.argv[1:])
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
The main intention of this change is to ensure that escape characters
are removed after parsing the value.

The implementation now uses Python's standard `shlex` module, which
allows our logic to be simplified.

Fix #1363.