### PR TITLE
rose.suite_run: use orig cylc version on restart

### DIFF
--- a/lib/python/rose/suite_run.py
+++ b/lib/python/rose/suite_run.py
@@ -147,7 +147,7 @@ class SuiteRunner(Runner):
         jinja2_section = "jinja2:" + self.suite_engine_proc.SUITE_CONF
         my_rose_version = ResourceLocator.default().get_version()
         suite_engine_key = self.suite_engine_proc.get_version_env_name()
-        if opts.run_mode == "reload":
+        if opts.run_mode in ["reload", "restart"]:
             prev_config_path = self.suite_engine_proc.get_suite_dir(
                     suite_name, "log", "rose-suite-run.conf")
             prev_config = ConfigLoader()(prev_config_path)


### PR DESCRIPTION
`rose suite-run --restart` should now export `CYLC_VERSION` to the value used to originally start
the suite.

(N.B. The new `rose suite-restart` command should do this already.)