### PR TITLE
rose test-battery: increase reliability of task-run extglob test.

### DIFF
--- a/t/rose-task-run/15-app-prune-extglob/suite.rc
+++ b/t/rose-task-run/15-app-prune-extglob/suite.rc
@@ -10,8 +10,7 @@
     [[dependencies]]
         [[[P1D]]]
             graph="""
-creator
-creator[-P1D] => pruner
+creator[-P1D] => pruner => creator
 """
 
 [runtime]


### PR DESCRIPTION
On some platforms, this test sometimes fails due to reporting an extra pruning of
`share/data/20150101T0000Z`.

The current test suite has an undefined order of precedence for the tasks - changing
this seems to fix it.