### PR TITLE
Improve output from rose-ana and fix a bug

### DIFF
--- a/lib/python/rose/apps/comparisons/output_grepper.py
+++ b/lib/python/rose/apps/comparisons/output_grepper.py
@@ -23,7 +23,7 @@ from rose.apps.rose_ana import DataLengthError, data_from_regexp
 import re
 
 REGEXPS = {
-  'um_wallclock' : r"Total Elapsed CPU Time:\s*(\S+)",
+  'um_wallclock' : r"Maximum Elapsed Wallclock Time:\s*(\S+)",
   'um_initial_norms' : r"initial\s*Absolute\s*Norm\s*:\s*(\S+)",
   'um_final_norms' : r"Final\s*Absolute\s*Norm\s*:\s*(\S+)", }
 


### PR DESCRIPTION
A user has said it would be nice if, where numbers differ, the values were printed. This change alters the "Within" comparison so that if two values are compared, it prints the numerical values if they differ as well as a percentage difference. If two lists of values are compared only the percentage difference is printed (as before), but now together with the position in the list of that value. So you can now tell that, for example, the fourth value in the list was the first different one and it was different by 6%, say.

This also fixes a bug where a test was meant to be on wallclock time, but it was accidentally testing CPU time instead.