### PR TITLE
 rose macro, app-upgrade: handle opt confs.

### DIFF
--- a/bin/rose-app-upgrade
+++ b/bin/rose-app-upgrade
@@ -15,6 +15,10 @@
 #         "=" indicates the current version.
 #         "*" indicates the default version to change to.
 #
+#     If an application contains optional configurations, loop through
+#     each one, combine with the main, upgrade it, and re-create it as
+#     a diff vs the upgraded main configuration.
+#
 # OPTIONS
 #     --all-versions, -a
 #         Use all tagged versions.

--- a/bin/rose-macro
+++ b/bin/rose-macro
@@ -26,6 +26,13 @@
 # DESCRIPTION
 #     List or run macros associated with a suite or application.
 #
+#     If a configuration contains optional configurations:
+#       * For validator macros, validate the main configuration, then
+#         validate each main + optional configuration in turn.
+#       * For transform macros, transform the main configuration, then
+#         transform each main + optional configuration, recreating each
+#         optional configuration as the diff vs the transformed main.
+#
 # OPTIONS
 #     --config=DIR, -C DIR
 #         Use configuration in DIR instead of $PWD.

--- a/doc/rose-command.html
+++ b/doc/rose-command.html
@@ -401,6 +401,10 @@ rosie UTIL [OPTS] [ARG ...]
       <li><code>*</code> indicates the default version to change to.</li>
     </ul>
 
+    <p>If an application contains optional configurations, loop through each
+    one, combine with the main, upgrade it, and re-create it as a diff vs the
+    upgraded main configuration.</p>
+
     <h3>OPTIONS</h3>
 
     <dl>
@@ -671,10 +675,10 @@ rosie UTIL [OPTS] [ARG ...]
       <dt><kbd>--ignore=PATTERN, -i PATTERN</kbd></dt>
 
       <dd>
-        <p>Ignore settings that contain the regular expression <var>PATTERN</var> in their
-        id. Can be specified more than once. <var>PATTERN</var> may also be a key used in
-        site or user configuration which expands to a list of patterns. See
-        CONFIGURATION below.</p>
+        <p>Ignore settings that contain the regular expression
+        <var>PATTERN</var> in their id. Can be specified more than once.
+        <var>PATTERN</var> may also be a key used in site or user configuration
+        which expands to a list of patterns. See CONFIGURATION below.</p>
       </dd>
 
       <dt><kbd>--meta-path=PATH, -M PATH</kbd></dt>
@@ -890,7 +894,6 @@ ignore{foo}=namelist:bar,namelist:baz
     <p><kbd>rose-date</kbd></p>
 
     <h3>SYNOPSIS</h3>
-
     <pre class="shell">
 # 1. Print date time point
 # 1.1 Current date time with an optional offset
@@ -930,8 +933,7 @@ rose date 19700101T000000Z 20380119T031407Z
       <li>With 0 or 1 argument. Print the current or the specified date time
       point with an optional offset.</li>
 
-      <li>With 2 arguments. Print the duration between the 2
-      arguments.</li>
+      <li>With 2 arguments. Print the duration between the 2 arguments.</li>
     </ol>
 
     <h3>OPTIONS</h3>
@@ -939,29 +941,29 @@ rose date 19700101T000000Z 20380119T031407Z
     <dl>
       <dt><kbd>--calendar=gregorian|360day|365day|366day</kbd></dt>
 
-      <dd>Specify the calendar mode.
-      See <a href="#rose-date-calendar-mode">CALENDER MODE</a> below.</dd>
+      <dd>Specify the calendar mode. See <a href=
+      "#rose-date-calendar-mode">CALENDER MODE</a> below.</dd>
 
-      <dt><kbd>--offset1=OFFSET</kbd>, <kbd>--offset=OFFSET</kbd>,
-      <kbd>-s OFFSET</kbd>, <kbd>-1 OFFSET</kbd></dt>
+      <dt><kbd>--offset1=OFFSET</kbd>, <kbd>--offset=OFFSET</kbd>, <kbd>-s
+      OFFSET</kbd>, <kbd>-1 OFFSET</kbd></dt>
 
       <dd>Specify 1 or more offsets to add to argument 1 or the current time.
       See <a href="#rose-date-offset-format">OFFSET FORMAT</a> below.</dd>
 
       <dt><kbd>--offset2=OFFSET</kbd>, <kbd>-2 OFFSET</kbd></dt>
 
-      <dd>Specify 1 or more offsets to add to argument 2.
-      See <a href="#rose-date-offset-format">OFFSET FORMAT</a> below.</dd>
+      <dd>Specify 1 or more offsets to add to argument 2. See <a href=
+      "#rose-date-offset-format">OFFSET FORMAT</a> below.</dd>
 
       <dt><kbd>--parse-format=FORMAT</kbd>, <kbd>-p FORMAT</kbd></dt>
 
-      <dd>Specify a format for parsing <var>DATE-TIME</var>. See
-      <a href="#rose-date-parse-format">PARSE FORMAT</a> below.</dd>
+      <dd>Specify a format for parsing <var>DATE-TIME</var>. See <a href=
+      "#rose-date-parse-format">PARSE FORMAT</a> below.</dd>
 
       <dt><kbd>--print-format=FORMAT</kbd>, <kbd>-f FORMAT</kbd></dt>
 
-      <dd>Specify a format for print the result. See
-      <a href="#rose-date-print-format">PRINT FORMAT</a> below.</dd>
+      <dd>Specify a format for print the result. See <a href=
+      "#rose-date-print-format">PRINT FORMAT</a> below.</dd>
 
       <dt><kbd>--use-task-cycle-time, -c</kbd></dt>
 
@@ -992,48 +994,48 @@ rose date 19700101T000000Z 20380119T031407Z
     <var>nU</var> where <var>U</var> is the unit (Y, M, D, H, M, S) and
     <var>n</var> is a positive integer, where T delimits the date series from
     the time series if any time units are used. <var>n</var> may also have a
-    decimal (e.g. <samp>PT5.5M</samp>) part for a unit provided no smaller units
-    are supplied. It is not necessary to specify zero values for units. If
-    <var>OFFSET</var> is negative, prefix a <samp>-</samp>. For example:</p>
+    decimal (e.g. <samp>PT5.5M</samp>) part for a unit provided no smaller
+    units are supplied. It is not necessary to specify zero values for units.
+    If <var>OFFSET</var> is negative, prefix a <samp>-</samp>. For example:</p>
 
     <dl>
       <dt>P6D</dt>
-    
+
       <dd>6 day offset</dd>
 
       <dt>PT6H</dt>
-      
+
       <dd>6 hour offset</dd>
 
       <dt>PT1M</dt>
-      
+
       <dd>1 minute offset</dd>
 
       <dt>-PT1M</dt>
-      
+
       <dd>(negative) 1 minute offset</dd>
 
       <dt>P3M</dt>
-      
+
       <dd>3 month offset</dd>
 
       <dt>P2W</dt>
-      
+
       <dd>2 week offset (note no other units may be combined with weeks)</dd>
 
       <dt>P2DT5.5H</dt>
-      
+
       <dd>2 day, 5.5 hour offset</dd>
 
       <dt>-P2YT4S</dt>
-      
+
       <dd>(negative) 2 year, 4 second offset</dd>
     </dl>
 
     <p>The following deprecated syntax is supported: <var>OFFSET</var> in the
     form <var>nU</var> where <var>U</var> is the unit (w for weeks, d for days,
-    h for hours, m for minutes and s for seconds) and <var>n</var> is a positive
-    or negative integer.</p>
+    h for hours, m for minutes and s for seconds) and <var>n</var> is a
+    positive or negative integer.</p>
 
     <h3 id="rose-date-parse-format">PARSE FORMAT</h3>
 
@@ -1041,26 +1043,28 @@ rose date 19700101T000000Z 20380119T031407Z
     POSIX strptime template format (see the strptime command help), with the
     following subset supported across all date/time ranges:</p>
 
-    <blockquote><kbd>%F, %H, %M, %S, %Y, %d, %j, %m, %s, %z</kbd></blockquote>
+    <blockquote>
+      <kbd>%F, %H, %M, %S, %Y, %d, %j, %m, %s, %z</kbd>
+    </blockquote>
 
     <p>If not specified, the system will attempt to parse <var>DATE-TIME</var>
     using the following formats:</p>
 
     <dl>
       <dt>ctime</dt>
-      
+
       <dd><var>%a %b %d %H:%M:%S %Y</var></dd>
 
       <dt>Unix date</dt>
-      
+
       <dd><var>%a %b %d %H:%M:%S %Z %Y</var></dd>
 
       <dt>Basic ISO8601</dt>
-      
+
       <dd><var>%Y-%m-%dT%H:%M:%S</var>, <var>%Y%m%dT%H%M%S</var></dd>
 
       <dt>Cylc (deprecated mode)</dt>
-      
+
       <dd><var>%Y%m%d%H</var></dd>
     </dl>
 
@@ -1069,11 +1073,10 @@ rose date 19700101T000000Z 20380119T031407Z
 
     <h3 id="rose-date-print-format">PRINT FORMAT</h3>
 
-    <p>For printing a date time point, the print format will default to the same
-    format as the parse format. Also supports the isodatetime library dump
+    <p>For printing a date time point, the print format will default to the
+    same format as the parse format. Also supports the isodatetime library dump
     syntax for these operations which follows ISO 8601 example syntax - for
     example:</p>
-
     <pre>
 'CCYY-MM-DDThh:mm:ss' -&gt; '1955-11-05T09:28:00',
 'CCYY' -&gt; '1955',
@@ -1081,8 +1084,8 @@ rose date 19700101T000000Z 20380119T031407Z
 'CCYY-Www-D' -&gt; '1955-W44-6'.
 </pre>
 
-    <p>Usage of this ISO 8601-like syntax should be as ISO 8601-compliant
-    as possible.</p>
+    <p>Usage of this ISO 8601-like syntax should be as ISO 8601-compliant as
+    possible.</p>
 
     <p>Note that specifying an explicit timezone in this format (e.g.
     <var>CCYY-MM-DDThh:mm:ss+0100</var> or <var>CCYYDDDThhmmZ</var> will
@@ -1094,15 +1097,19 @@ rose date 19700101T000000Z 20380119T031407Z
 
     <ul>
       <li>y: years</li>
+
       <li>m: months</li>
+
       <li>d: days</li>
+
       <li>h: hours</li>
+
       <li>M: minutes</li>
+
       <li>s: seconds</li>
     </ul>
 
     <p>For example, for a duration <samp>P57DT12H</samp>:</p>
-
     <pre>
 'y,m,d,h' -&gt; '0,0,57,12'
 </pre>
@@ -1297,6 +1304,17 @@ rose date 19700101T000000Z 20380119T031407Z
     <h3>DESCRIPTION</h3>
 
     <p>List or run macros associated with a suite or application.</p>
+
+    <p>If a configuration contains optional configurations:</p>
+
+    <ul>
+      <li>For validation macros, validate the main configuration, then validate
+      each main + optional configuration in turn.</li>
+
+      <li>For transform macros, transform the main configuration, then
+      transform each main + optional configuration, recreating each optional
+      configuration as the diff vs the transformed main.</li>
+    </ul>
 
     <h3>OPTIONS</h3>
 
@@ -1783,7 +1801,8 @@ launcher-preopts.mpiexec=-n $NPROC
 
     <h3>DESCRIPTION</h3>
 
-    <p>Remove items created by <a href="#rose-suite-run">rose suite-run</a>.</p>
+    <p>Remove items created by <a href="#rose-suite-run">rose
+    suite-run</a>.</p>
 
     <p>If no argument is specified, use the base-name of <var>$PWD</var> as the
     suite name.</p>
@@ -2352,7 +2371,8 @@ launcher-preopts.mpiexec=-n $NPROC
 
       <dt><kbd>-- --EXTRA-ARGS</kbd></dt>
 
-      <dd>See the cylc documentation, cylc shutdown for options and details on EXTRA-ARGS.</dd>
+      <dd>See the cylc documentation, cylc shutdown for options and details on
+      EXTRA-ARGS.</dd>
 
       <dt><kbd>--quiet, -q</kbd></dt>
 
@@ -2859,23 +2879,24 @@ environment scripting = "eval $(rose task-env)"
 
     <p>Launch the Rosie client GTK+ GUI.</p>
 
-    <p>If arguments are specified, rosie go will perform an initial lookup based
-    on the arguments, which can be an address, a query, or search words. See
-    <a href="#rosie-lookup">rosie lookup</a> for detail.</p>
+    <p>If arguments are specified, rosie go will perform an initial lookup
+    based on the arguments, which can be an address, a query, or search words.
+    See <a href="#rosie-lookup">rosie lookup</a> for detail.</p>
 
     <p>Unless an option is used to specify the initial search type the argument
     is interpreted as follows:</p>
 
     <ul>
       <li>A string beginning with <em>http</em> - an address</li>
+
       <li>A string not beginning with <em>http</em> - search words</li>
     </ul>
 
     <p>An address URL may contain shell meta characters, so remember to put it
     in quotes.</p>
 
-    <p>If no argument is specified, <code>rosie go</code> will display a list of
-    all your locally checked out suites.</p>
+    <p>If no argument is specified, <code>rosie go</code> will display a list
+    of all your locally checked out suites.</p>
 
     <h3>OPTIONS</h3>
 
@@ -2933,8 +2954,8 @@ environment scripting = "eval $(rose task-env)"
     <dl>
       <dt><kbd>--prefix=PREFIX</kbd></dt>
 
-      <dd>Specify the name of one or more Rosie web service servers to use. This
-      option can be used multiple times.</dd>
+      <dd>Specify the name of one or more Rosie web service servers to use.
+      This option can be used multiple times.</dd>
     </dl>
 
     <h2 id="rosie-id">rosie id</h2>
@@ -3041,6 +3062,7 @@ environment scripting = "eval $(rose task-env)"
 
     <ul>
       <li>A string beginning with <em>http</em> - an address</li>
+
       <li>A string not beginning with <em>http</em> - search words</li>
     </ul>
 
@@ -3175,8 +3197,8 @@ abc01 from daisy
       column names or properties preceded by <kbd>%</kbd>.</dd>
 
       <dd>
-        For example: <kbd>rosie ls --format="%idx from %owner"</kbd>
-        might give:
+        For example: <kbd>rosie ls --format="%idx from %owner"</kbd> might
+        give:
         <pre>
 abc01 from daisy
 </pre>

--- a/doc/rose-command.html
+++ b/doc/rose-command.html
@@ -890,6 +890,7 @@ ignore{foo}=namelist:bar,namelist:baz
     <p><kbd>rose-date</kbd></p>
 
     <h3>SYNOPSIS</h3>
+
     <pre class="shell">
 # 1. Print date time point
 # 1.1 Current date time with an optional offset
@@ -929,7 +930,8 @@ rose date 19700101T000000Z 20380119T031407Z
       <li>With 0 or 1 argument. Print the current or the specified date time
       point with an optional offset.</li>
 
-      <li>With 2 arguments. Print the duration between the 2 arguments.</li>
+      <li>With 2 arguments. Print the duration between the 2
+      arguments.</li>
     </ol>
 
     <h3>OPTIONS</h3>
@@ -937,29 +939,29 @@ rose date 19700101T000000Z 20380119T031407Z
     <dl>
       <dt><kbd>--calendar=gregorian|360day|365day|366day</kbd></dt>
 
-      <dd>Specify the calendar mode. See <a href=
-      "#rose-date-calendar-mode">CALENDER MODE</a> below.</dd>
+      <dd>Specify the calendar mode.
+      See <a href="#rose-date-calendar-mode">CALENDER MODE</a> below.</dd>
 
-      <dt><kbd>--offset1=OFFSET</kbd>, <kbd>--offset=OFFSET</kbd>, <kbd>-s
-      OFFSET</kbd>, <kbd>-1 OFFSET</kbd></dt>
+      <dt><kbd>--offset1=OFFSET</kbd>, <kbd>--offset=OFFSET</kbd>,
+      <kbd>-s OFFSET</kbd>, <kbd>-1 OFFSET</kbd></dt>
 
       <dd>Specify 1 or more offsets to add to argument 1 or the current time.
       See <a href="#rose-date-offset-format">OFFSET FORMAT</a> below.</dd>
 
       <dt><kbd>--offset2=OFFSET</kbd>, <kbd>-2 OFFSET</kbd></dt>
 
-      <dd>Specify 1 or more offsets to add to argument 2. See <a href=
-      "#rose-date-offset-format">OFFSET FORMAT</a> below.</dd>
+      <dd>Specify 1 or more offsets to add to argument 2.
+      See <a href="#rose-date-offset-format">OFFSET FORMAT</a> below.</dd>
 
       <dt><kbd>--parse-format=FORMAT</kbd>, <kbd>-p FORMAT</kbd></dt>
 
-      <dd>Specify a format for parsing <var>DATE-TIME</var>. See <a href=
-      "#rose-date-parse-format">PARSE FORMAT</a> below.</dd>
+      <dd>Specify a format for parsing <var>DATE-TIME</var>. See
+      <a href="#rose-date-parse-format">PARSE FORMAT</a> below.</dd>
 
       <dt><kbd>--print-format=FORMAT</kbd>, <kbd>-f FORMAT</kbd></dt>
 
-      <dd>Specify a format for print the result. See <a href=
-      "#rose-date-print-format">PRINT FORMAT</a> below.</dd>
+      <dd>Specify a format for print the result. See
+      <a href="#rose-date-print-format">PRINT FORMAT</a> below.</dd>
 
       <dt><kbd>--use-task-cycle-time, -c</kbd></dt>
 
@@ -990,48 +992,48 @@ rose date 19700101T000000Z 20380119T031407Z
     <var>nU</var> where <var>U</var> is the unit (Y, M, D, H, M, S) and
     <var>n</var> is a positive integer, where T delimits the date series from
     the time series if any time units are used. <var>n</var> may also have a
-    decimal (e.g. <samp>PT5.5M</samp>) part for a unit provided no smaller
-    units are supplied. It is not necessary to specify zero values for units.
-    If <var>OFFSET</var> is negative, prefix a <samp>-</samp>. For example:</p>
+    decimal (e.g. <samp>PT5.5M</samp>) part for a unit provided no smaller units
+    are supplied. It is not necessary to specify zero values for units. If
+    <var>OFFSET</var> is negative, prefix a <samp>-</samp>. For example:</p>
 
     <dl>
       <dt>P6D</dt>
-
+    
       <dd>6 day offset</dd>
 
       <dt>PT6H</dt>
-
+      
       <dd>6 hour offset</dd>
 
       <dt>PT1M</dt>
-
+      
       <dd>1 minute offset</dd>
 
       <dt>-PT1M</dt>
-
+      
       <dd>(negative) 1 minute offset</dd>
 
       <dt>P3M</dt>
-
+      
       <dd>3 month offset</dd>
 
       <dt>P2W</dt>
-
+      
       <dd>2 week offset (note no other units may be combined with weeks)</dd>
 
       <dt>P2DT5.5H</dt>
-
+      
       <dd>2 day, 5.5 hour offset</dd>
 
       <dt>-P2YT4S</dt>
-
+      
       <dd>(negative) 2 year, 4 second offset</dd>
     </dl>
 
     <p>The following deprecated syntax is supported: <var>OFFSET</var> in the
     form <var>nU</var> where <var>U</var> is the unit (w for weeks, d for days,
-    h for hours, m for minutes and s for seconds) and <var>n</var> is a
-    positive or negative integer.</p>
+    h for hours, m for minutes and s for seconds) and <var>n</var> is a positive
+    or negative integer.</p>
 
     <h3 id="rose-date-parse-format">PARSE FORMAT</h3>
 
@@ -1039,28 +1041,26 @@ rose date 19700101T000000Z 20380119T031407Z
     POSIX strptime template format (see the strptime command help), with the
     following subset supported across all date/time ranges:</p>
 
-    <blockquote>
-      <kbd>%F, %H, %M, %S, %Y, %d, %j, %m, %s, %z</kbd>
-    </blockquote>
+    <blockquote><kbd>%F, %H, %M, %S, %Y, %d, %j, %m, %s, %z</kbd></blockquote>
 
     <p>If not specified, the system will attempt to parse <var>DATE-TIME</var>
     using the following formats:</p>
 
     <dl>
       <dt>ctime</dt>
-
+      
       <dd><var>%a %b %d %H:%M:%S %Y</var></dd>
 
       <dt>Unix date</dt>
-
+      
       <dd><var>%a %b %d %H:%M:%S %Z %Y</var></dd>
 
       <dt>Basic ISO8601</dt>
-
+      
       <dd><var>%Y-%m-%dT%H:%M:%S</var>, <var>%Y%m%dT%H%M%S</var></dd>
 
       <dt>Cylc (deprecated mode)</dt>
-
+      
       <dd><var>%Y%m%d%H</var></dd>
     </dl>
 
@@ -1069,10 +1069,11 @@ rose date 19700101T000000Z 20380119T031407Z
 
     <h3 id="rose-date-print-format">PRINT FORMAT</h3>
 
-    <p>For printing a date time point, the print format will default to the
-    same format as the parse format. Also supports the isodatetime library dump
+    <p>For printing a date time point, the print format will default to the same
+    format as the parse format. Also supports the isodatetime library dump
     syntax for these operations which follows ISO 8601 example syntax - for
     example:</p>
+
     <pre>
 'CCYY-MM-DDThh:mm:ss' -&gt; '1955-11-05T09:28:00',
 'CCYY' -&gt; '1955',
@@ -1080,8 +1081,8 @@ rose date 19700101T000000Z 20380119T031407Z
 'CCYY-Www-D' -&gt; '1955-W44-6'.
 </pre>
 
-    <p>Usage of this ISO 8601-like syntax should be as ISO 8601-compliant as
-    possible.</p>
+    <p>Usage of this ISO 8601-like syntax should be as ISO 8601-compliant
+    as possible.</p>
 
     <p>Note that specifying an explicit timezone in this format (e.g.
     <var>CCYY-MM-DDThh:mm:ss+0100</var> or <var>CCYYDDDThhmmZ</var> will
@@ -1093,19 +1094,15 @@ rose date 19700101T000000Z 20380119T031407Z
 
     <ul>
       <li>y: years</li>
-
       <li>m: months</li>
-
       <li>d: days</li>
-
       <li>h: hours</li>
-
       <li>M: minutes</li>
-
       <li>s: seconds</li>
     </ul>
 
     <p>For example, for a duration <samp>P57DT12H</samp>:</p>
+
     <pre>
 'y,m,d,h' -&gt; '0,0,57,12'
 </pre>
@@ -2862,24 +2859,23 @@ environment scripting = "eval $(rose task-env)"
 
     <p>Launch the Rosie client GTK+ GUI.</p>
 
-    <p>If arguments are specified, rosie go will perform an initial lookup
-    based on the arguments, which can be an address, a query, or search words.
-    See <a href="#rosie-lookup">rosie lookup</a> for detail.</p>
+    <p>If arguments are specified, rosie go will perform an initial lookup based
+    on the arguments, which can be an address, a query, or search words. See
+    <a href="#rosie-lookup">rosie lookup</a> for detail.</p>
 
     <p>Unless an option is used to specify the initial search type the argument
     is interpreted as follows:</p>
 
     <ul>
       <li>A string beginning with <em>http</em> - an address</li>
-
       <li>A string not beginning with <em>http</em> - search words</li>
     </ul>
 
     <p>An address URL may contain shell meta characters, so remember to put it
     in quotes.</p>
 
-    <p>If no argument is specified, <code>rosie go</code> will display a list
-    of all your locally checked out suites.</p>
+    <p>If no argument is specified, <code>rosie go</code> will display a list of
+    all your locally checked out suites.</p>
 
     <h3>OPTIONS</h3>
 
@@ -2937,8 +2933,8 @@ environment scripting = "eval $(rose task-env)"
     <dl>
       <dt><kbd>--prefix=PREFIX</kbd></dt>
 
-      <dd>Specify the name of one or more Rosie web service servers to use.
-      This option can be used multiple times.</dd>
+      <dd>Specify the name of one or more Rosie web service servers to use. This
+      option can be used multiple times.</dd>
     </dl>
 
     <h2 id="rosie-id">rosie id</h2>
@@ -3045,7 +3041,6 @@ environment scripting = "eval $(rose task-env)"
 
     <ul>
       <li>A string beginning with <em>http</em> - an address</li>
-
       <li>A string not beginning with <em>http</em> - search words</li>
     </ul>
 
@@ -3180,8 +3175,8 @@ abc01 from daisy
       column names or properties preceded by <kbd>%</kbd>.</dd>
 
       <dd>
-        For example: <kbd>rosie ls --format="%idx from %owner"</kbd> might
-        give:
+        For example: <kbd>rosie ls --format="%idx from %owner"</kbd>
+        might give:
         <pre>
 abc01 from daisy
 </pre>

--- a/doc/rose-configuration.html
+++ b/doc/rose-configuration.html
@@ -273,6 +273,29 @@ opts=ketchup (mayonnaise)
       KEY</code>.</li>
     </ol>
 
+    <h3 id="opts-meta">Optional Configurations and Metadata</h3>
+
+    <p>Metadata utilities such as <code>rose app-upgrade</code> and <code>rose
+    macro</code> treat each main + optional configuration as a separate entity
+    to be transformed, upgraded, or validated. Use cases with more than one
+    optional configuration are not handled.</p>
+
+    <p>When transforming or upgrading, each optional configuration is treated
+    separately and re-created after the transform as a functional difference
+    from the main upgraded configuration.</p>
+
+    <p>The logic for transforming or upgrading a main configuration
+    <var>C</var> with optional configurations <var>O1</var> and <var>O2</var>
+    into a new main configuration <var>Ct</var> and new optional configurations
+    <var>O1t</var> and <var>O2t</var> can be represented like this:</p>
+    <pre>
+C =&gt; Ct
+C + O1 =&gt; C1t
+C + O2 =&gt; C2t
+O1t = C1t - Ct
+O2t = C2t - Ct
+</pre>
+
     <h2 id="import">Import Configuration</h2>
 
     <p>A root level <var>import=PATH1 PATH2...</var> setting in the main
@@ -369,8 +392,8 @@ accel-find-next=F3
       <li><samp>opt/</samp> directory. For detail, see <a href="#opts">Optional
       Configuration</a>.</li>
 
-      <li>Other items, as long as they do not clash with the scheduler's working
-      directories. E.g. for a cylc suite, <samp>log*/</samp>,
+      <li>Other items, as long as they do not clash with the scheduler's
+      working directories. E.g. for a cylc suite, <samp>log*/</samp>,
       <samp>share/</samp>, <samp>state/</samp> and <samp>work/</samp> should be
       avoided.</li>
     </ul>
@@ -786,8 +809,8 @@ delays=0,6*10s,60*1m,1h
     Application: rose_prune</h3>
 
     <p>See <a href=
-    "rose-rug-task-run.html#rose-task-run.built-in-app.rose_prune">Running Tasks
-    &gt; rose task-run &gt; Built-in Application: rose_prune</a>.</p>
+    "rose-rug-task-run.html#rose-task-run.built-in-app.rose_prune">Running
+    Tasks &gt; rose task-run &gt; Built-in Application: rose_prune</a>.</p>
 
     <h2 id="meta">Configuration Metadata</h2>
 

--- a/lib/python/rose/config.py
+++ b/lib/python/rose/config.py
@@ -35,6 +35,7 @@ Synopsis:
 
 Classes:
     ConfigNode - represents an individual node (setting or section).
+    ConfigNodeDiff - represent differences between ConfigNode instances.
     ConfigDumper - dumps a configuration to stdout or a file.
     ConfigLoader - loads a configuration into a Config instance.
 
@@ -54,7 +55,7 @@ What about the standard library ConfigParser? Well, it is problematic:
 
 """
 
-import errno
+import copy
 import os.path
 import re
 from rose.env import env_var_escape
@@ -278,6 +279,138 @@ class ConfigNode(object):
         except (KeyError, AttributeError):
             return None
 
+    def add(self, config_diff):
+        """Apply a config node diff object to self."""
+        for added_key, added_data in config_diff.get_added():
+            value, state, comments = added_data
+            self.set(keys=added_key, value=value, state=state,
+                     comments=comments)
+        for modified_key, modified_data in config_diff.get_modified():
+            # Should we check that the original data matches what we have?
+            orig_value = modified_data[0][0]
+            value, state, comments = modified_data[1]
+            if orig_value is None and value is None:
+                # A section - be careful not to change an existing node value.
+                subnode = self.get(keys=modified_key)
+                if subnode is None:
+                    self.set(
+                        keys=modified_key, state=state, comments=comments)
+                else:
+                    subnode.state = state
+                    subnode.comments = comments
+            else:
+                self.set(keys=modified_key, value=value, state=state,
+                         comments=comments)
+        for removed_key, removed_data in config_diff.get_removed():
+            self.unset(keys=removed_key)
+
+    def __add__(self, config_diff):
+        """Return a new node by applying a config node diff object to self."""
+        new_node = copy.deepcopy(self)
+        new_node.add(config_diff)
+        return new_node
+
+    def __sub__(self, other_config_node):
+        """Produce a diff from another node."""
+        diff = ConfigNodeDiff()
+        diff.set_from_configs(other_config_node, self)
+        return diff
+
+
+class ConfigNodeDiff(object):
+
+    """Represent differences between two ConfigNode instances."""
+
+    def __init__(self):
+        self._data = {"added": {}, "removed": {}, "modified": {}}
+
+    def set_from_configs(self, config_node_1, config_node_2):
+        """Create diff data from two ConfigNode instances."""
+        first_settings = {}
+        second_settings = {}
+        for config_node, settings in [(config_node_1, first_settings),
+                                      (config_node_2, second_settings)]:
+            for keys, node in config_node.walk():
+                value = node.value
+                if type(node.value) is dict:
+                    value = None
+                settings[tuple(keys)] = (value, node.state, node.comments)
+        for keys in set(second_settings) - set(first_settings):
+            self.set_added_setting(keys, second_settings[keys])
+        for keys in set(first_settings) - set(second_settings):
+            self.set_removed_setting(keys, first_settings[keys])
+        for keys in set(first_settings).intersection(set(second_settings)):
+            if first_settings[keys] != second_settings[keys]:
+                self.set_modified_setting(keys, first_settings[keys],
+                                          second_settings[keys])
+
+    def get_as_opt_config(self):
+        """Return a ConfigNode such that main + new_node = main + diff.
+
+        Add all the added settings, add all the modified settings,
+        add all the removed settings as user-ignored.
+
+        """
+        node = ConfigNode()
+        for keys, info in self.get_added():
+            value, state, comments = info
+            node.set(keys, value=value, state=state, comments=comments)
+        for keys, old_and_new_info in self.get_modified():
+            old_info, info = old_and_new_info
+            value, state, comments = info
+            node.set(keys, value=value, state=state, comments=comments)
+        for keys, info in self.get_removed():
+            # Need to add as user-ignored.
+            value, state, comments = info
+            node.set(keys, value=value, state=node.STATE_USER_IGNORED,
+                     comments=comments)
+        return node
+
+    def set_added_setting(self, keys, data):
+        """Set a setting to be "added"."""
+        self._data["added"][keys] = data
+
+    def set_modified_setting(self, keys, old_data, data):
+        """Set a setting to be "modified"."""
+        self._data["modified"][keys] = (old_data, data)
+
+    def set_removed_setting(self, keys, data):
+        """Set a setting to be "removed"."""
+        self._data["removed"][keys] = data
+
+    def get_added(self):
+        """Return a list of tuples of added keys with their data.
+
+        The data is a tuple of value, state, comments, where value is
+        set to None for sections.
+
+        """
+        return sorted(self._data["added"].items())
+
+    def get_modified(self):
+        """Return a dict of altered keys with before and after data.
+
+        The data is a list of two tuples (before and after) of value,
+        state, comments, where value is set to None for sections.
+
+        """
+        return sorted(self._data["modified"].items())
+
+    def get_removed(self):
+        """Return a dict of removed keys with their data.
+
+        The data is a tuple of value, state, comments, where value is
+        set to None for sections.
+
+        """
+        return sorted(self._data["removed"].items())
+
+    def get_all_keys(self):
+        """Return all changed keys."""
+        return sorted(
+            set(self._data["added"]) | set(self._data["modified"]) |
+            set(self._data["removed"]))
+
 
 class ConfigDumper(object):
 
@@ -430,7 +563,7 @@ class ConfigLoader(object):
             + r"\s*(?P<value>.*)$")
 
     def load_with_opts(self, source, node=None, more_keys=None,
-                       used_keys=None):
+                       used_keys=None, return_config_map=False):
         """Read a source configuration file with optional configurations.
 
         Arguments:
@@ -446,11 +579,19 @@ class ConfigLoader(object):
                      that are specified in more_keys will not raise an error.
                      If not defined, any missing optional configuration will
                      trigger an OSError.
+        return_config_map -- (default False) if True, construct and return a
+                              dict (config_map) containing config names vs
+                              their uncombined nodes. Optional configurations
+                              use their opt keys as keys, and the main
+                              configuration uses 'None'.
 
-        Return node.
+        Return node if return_config_map is False (default).
+        Return node, config_map if return_config_map is True.
 
         """
         node = self.load(source, node)
+        if return_config_map:
+            config_map = {None: copy.deepcopy(node)}
         opt_conf_keys_node = node.unset(["opts"])
         if opt_conf_keys_node is None or opt_conf_keys_node.is_ignored():
             opt_conf_keys = []
@@ -459,6 +600,8 @@ class ConfigLoader(object):
         if more_keys:
             opt_conf_keys += more_keys
         if not opt_conf_keys:
+            if return_config_map:
+                return node, config_map
             return node
         source_dir = os.path.dirname(source)
         source_root, source_ext = os.path.splitext(os.path.basename(source))
@@ -480,6 +623,10 @@ class ConfigLoader(object):
             else:
                 if used_keys is not None and key not in used_keys:
                     used_keys.append(key)
+                if return_config_map:
+                    config_map[key] = self.load(opt_conf_file_name)
+        if return_config_map:
+            return node, config_map
         return node
 
     def load(self, source, node=None):

--- a/lib/python/rose/config_editor/data.py
+++ b/lib/python/rose/config_editor/data.py
@@ -854,8 +854,9 @@ class ConfigDataManager(object):
             text = rose.config_editor.ERROR_METADATA_CHECKER_TEXT.format(
                                             len(reports), meta_dir_path)
             self._bad_meta_dir_paths.append(meta_dir_path)
+            reports_map = {None: reports}
             reports_text = rose.macro.get_reports_as_text(
-                                      reports,
+                                      reports_map,
                                       "rose.metadata_check.MetadataChecker")
             rose.gtk.dialog.run_dialog(rose.gtk.dialog.DIALOG_TYPE_ERROR,
                                        text, title, modal=False,

--- a/lib/python/rose/metadata_check.py
+++ b/lib/python/rose/metadata_check.py
@@ -366,9 +366,8 @@ def main():
     macro_id = rose.macro.MACRO_OUTPUT_ID.format(
                                 rose.macro.VALIDATE_METHOD.upper()[0],
                                 "rose.metadata_check.MetadataChecker")
-    text = rose.macro.get_reports_as_text(
-                                    reports,
-                                    macro_id)
+    reports_map = {None: reports}
+    text = rose.macro.get_reports_as_text(reports_map, macro_id)
     if reports:
         reporter(text, kind=reporter.KIND_ERR, level=reporter.FAIL, prefix="")
         sys.exit(1)

--- a/t/rose-app-upgrade/09-opt.t
+++ b/t/rose-app-upgrade/09-opt.t
@@ -1,0 +1,93 @@
+#!/bin/bash
+#-------------------------------------------------------------------------------
+# (C) British Crown Copyright 2012-5 Met Office.
+#
+# This file is part of Rose, a framework for meteorological suites.
+#
+# Rose is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Rose is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Rose. If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test "rose app-upgrade" for real macros.
+#-------------------------------------------------------------------------------
+. $(dirname $0)/test_header
+#-------------------------------------------------------------------------------
+tests 5
+#-------------------------------------------------------------------------------
+# Check upgrading with optional configurations.
+init <<'__CONFIG__'
+meta=test-app-upgrade/0.1
+
+[env]
+A=4
+__CONFIG__
+init_opt foo<<'__CONFIG__'
+[env]
+A=1
+D=2
+__CONFIG__
+setup
+init_meta test-app-upgrade 0.1 0.2
+init_macro test-app-upgrade <<'__MACRO__'
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+
+import rose.upgrade
+
+
+class Upgrade01to02(rose.upgrade.MacroUpgrade):
+
+    """Upgrade from 0.1 to 0.2."""
+
+    BEFORE_TAG = "0.1"
+    AFTER_TAG = "0.2"
+
+    def upgrade(self, config, meta_config=None):
+        self.add_setting(config, ["env", "Z"], "1",
+                         info="only one Z")
+        if config.get(["env", "D"]) is not None:
+            self.change_setting_value(
+                config, ["env", "D"], "56")
+        self.remove_setting(config, ["env", "A"])
+        return config, self.reports
+__MACRO__
+#-----------------------------------------------------------------------------
+TEST_KEY=$TEST_KEY_BASE-upgrade-add
+# Check adding
+run_pass "$TEST_KEY" rose app-upgrade --non-interactive \
+ --meta-path=../rose-meta/ -C ../config 0.2
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<'__OUTPUT__'
+[U] Upgrade_0.1-0.2: changes: 4
+    env=Z=1
+        only one Z
+    env=A=None
+        Removed
+    =meta=test-app-upgrade/0.2
+        Upgraded from 0.1 to 0.2
+    (opts=foo)env=D=56
+        Value: '2' -> '56'
+__OUTPUT__
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+file_cmp "$TEST_KEY.file" ../config/rose-app.conf <<'__CONFIG__'
+meta=test-app-upgrade/0.2
+
+[env]
+Z=1
+__CONFIG__
+file_cmp "$TEST_KEY.opt-config" ../config/opt/rose-app-foo.conf <<'__CONFIG__'
+[env]
+D=56
+__CONFIG__
+teardown
+#-------------------------------------------------------------------------------
+exit

--- a/t/rose-app-upgrade/test_header
+++ b/t/rose-app-upgrade/test_header
@@ -26,6 +26,12 @@ function init() {
     cat >$TEST_DIR/config/rose-app.conf
 }
 
+function init_opt() {
+    local opt_key=$1
+    mkdir -p $TEST_DIR/config/opt/
+    cat >$TEST_DIR/config/opt/rose-app-$opt_key.conf
+}
+
 function init_meta() {
     category=$1
     mkdir -p $TEST_DIR/rose-meta/$category/

--- a/t/rose-cli-bash-completion/00-static.t
+++ b/t/rose-cli-bash-completion/00-static.t
@@ -258,7 +258,7 @@ file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
 teardown
 #-------------------------------------------------------------------------------
-# List option arguments for "rose app-upgrade ".
+# List arguments for "rose app-upgrade ".
 TEST_KEY=$TEST_KEY_BASE-rose-app-upgrade
 setup
 init <<'__CONFIG__'

--- a/t/rose-macro/18-opt-conf-check.t
+++ b/t/rose-macro/18-opt-conf-check.t
@@ -1,0 +1,104 @@
+#!/bin/bash
+#-------------------------------------------------------------------------------
+# (C) British Crown Copyright 2012-5 Met Office.
+#
+# This file is part of Rose, a framework for meteorological suites.
+#
+# Rose is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Rose is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Rose. If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test "rose macro" for optional configuration validating.
+#-------------------------------------------------------------------------------
+. $(dirname $0)/test_header
+#-------------------------------------------------------------------------------
+tests 15
+#-------------------------------------------------------------------------------
+setup
+init <<'__CONFIG__'
+[car]
+budget=1000
+paint_job=standard
+__CONFIG__
+init_meta <<'__META_CONFIG__'
+[car=paint_job]
+fail-if=this != 'standard' and car=budget < 1500
+__META_CONFIG__
+#-------------------------------------------------------------------------------
+TEST_KEY=$TEST_KEY_BASE-ok-no-opts
+run_pass "$TEST_KEY" rose macro --config=../config -V
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+#-------------------------------------------------------------------------------
+init_opt colour <<'__OPT_CONFIG__'
+[car]
+paint_job=sparkly
+__OPT_CONFIG__
+TEST_KEY=$TEST_KEY_BASE-bad-single-opt
+run_fail "$TEST_KEY" rose macro --config=../config -V 
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" <<'__ERR__'
+[V] rose.macros.DefaultValidators: issues: 1
+    (opts=colour)car=paint_job=sparkly
+        failed because: this != 'standard' and car=budget < 1500
+__ERR__
+#-------------------------------------------------------------------------------
+TEST_KEY=$TEST_KEY_BASE-bad-opt-incl
+init <<'__CONFIG__'
+opts=colour
+
+[car]
+budget=1000
+paint_job=standard
+wheels=4
+__CONFIG__
+run_fail "$TEST_KEY" rose macro --config=../config -V
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" <<'__ERR__'
+[V] rose.macros.DefaultValidators: issues: 1
+    (opts=colour)car=paint_job=sparkly
+        failed because: this != 'standard' and car=budget < 1500
+__ERR__
+#-------------------------------------------------------------------------------
+init_opt deluxe <<'__OPT_CONFIG__'
+[car]
+paint_job=invisible
+__OPT_CONFIG__
+TEST_KEY=$TEST_KEY_BASE-bad-two-opts
+run_fail "$TEST_KEY" rose macro --config=../config -V
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" <<'__ERR__'
+[V] rose.macros.DefaultValidators: issues: 2
+    (opts=colour)car=paint_job=sparkly
+        failed because: this != 'standard' and car=budget < 1500
+    (opts=deluxe)car=paint_job=invisible
+        failed because: this != 'standard' and car=budget < 1500
+__ERR__
+#-------------------------------------------------------------------------------
+init_meta <<'__META_CONFIG__'
+[car=paint_job]
+warn-if=this != 'standard' and car=budget < 1500
+__META_CONFIG__
+TEST_KEY=$TEST_KEY_BASE-warn-bad-opt
+run_fail "$TEST_KEY" rose macro --config=../config -V
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" <<'__ERR__'
+[V] rose.macros.DefaultValidators: issues: 0
+[V] rose.macros.DefaultValidators: warnings: 2
+    (opts=colour)car=paint_job=sparkly
+        warn because: this != 'standard' and car=budget < 1500
+    (opts=deluxe)car=paint_job=invisible
+        warn because: this != 'standard' and car=budget < 1500
+__ERR__
+teardown
+#-------------------------------------------------------------------------------
+exit

--- a/t/rose-macro/19-opt-conf-change-add.t
+++ b/t/rose-macro/19-opt-conf-change-add.t
@@ -1,0 +1,192 @@
+#!/bin/bash
+#-------------------------------------------------------------------------------
+# (C) British Crown Copyright 2012-5 Met Office.
+#
+# This file is part of Rose, a framework for meteorological suites.
+#
+# Rose is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Rose is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Rose. If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test "rose macro" for optional configuration validating.
+#-------------------------------------------------------------------------------
+. $(dirname $0)/test_header
+#-------------------------------------------------------------------------------
+tests 15
+#-------------------------------------------------------------------------------
+setup
+#-------------------------------------------------------------------------------
+# Test adding sections and options via macros.
+#-------------------------------------------------------------------------------
+init <<'__CONFIG__'
+[car]
+budget=1000
+paint_job=standard
+wheels=4
+__CONFIG__
+init_opt colour <<'__CONFIG__'
+[car]
+paint_job=sparkly
+
+[garage]
+door_paint_job=boring
+__CONFIG__
+init_meta </dev/null
+init_macro add.py <<'__MACRO__'
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#-----------------------------------------------------------------------------
+# (C) Crown copyright Met Office. All rights reserved.
+#-----------------------------------------------------------------------------
+
+import rose.macro
+
+
+class AddSpoiler(rose.macro.MacroBase):
+
+    """Add a spoiler."""
+
+    def transform(self, config, meta_config=None):
+        """Spoilers are cool."""
+        self.reports = []
+        config.set(["car", "spoilers"], "1")
+        info = "Added a spoiler, woohoo!"
+        self.add_report("car", "spoilers", "1", info)
+        return config, self.reports
+
+
+class AddGarageRoof(rose.macro.MacroBase):
+
+    """Add garage roof."""
+
+    def transform(self, config, meta_config=None):
+        """Now with fewer puddles."""
+        self.reports = []
+        config.set(["garage", "roof"], "flat")
+        info = "Added garage roof!"
+        self.add_report("garage", "roof", "flat", info)
+        return config, self.reports
+
+
+class AddElectricBike(rose.macro.MacroBase):
+
+    """Add an electric bike!"""
+
+    def transform(self, config, meta_config=None):
+        """'If you're exerting yourself, you're doing it wrong.'"""
+        self.reports = []
+        config.set(["electric_bike"])
+        info = "Added electric bike!"
+        self.add_report("bike", None, None, info)
+        return config, self.reports
+__MACRO__
+#-------------------------------------------------------------------------------
+TEST_KEY=$TEST_KEY_BASE-add-option-to-main
+run_pass "$TEST_KEY" rose macro -y --config=../config add.AddSpoiler
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<'__OUT__'
+[T] add.AddSpoiler: changes: 1
+    car=spoilers=1
+        Added a spoiler, woohoo!
+__OUT__
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+file_cmp "$TEST_KEY.config" ../config/rose-app.conf <<'__CONFIG__'
+[car]
+budget=1000
+paint_job=standard
+spoilers=1
+wheels=4
+__CONFIG__
+file_cmp "$TEST_KEY.opt-config" ../config/opt/rose-app-colour.conf <<'__CONFIG__'
+[car]
+paint_job=sparkly
+
+[garage]
+door_paint_job=boring
+__CONFIG__
+#-------------------------------------------------------------------------------
+TEST_KEY=$TEST_KEY_BASE-add-option-to-section-from-opt-conf
+init <<'__CONFIG__'
+[car]
+budget=1000
+paint_job=standard
+wheels=4
+__CONFIG__
+init_opt colour <<'__CONFIG__'
+[car]
+paint_job=sparkly
+
+[garage]
+door_paint_job=boring
+__CONFIG__
+run_pass "$TEST_KEY" rose macro -y --config=../config add.AddGarageRoof
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<'__OUT__'
+[T] add.AddGarageRoof: changes: 1
+    garage=roof=flat
+        Added garage roof!
+__OUT__
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+file_cmp "$TEST_KEY.config" ../config/rose-app.conf <<'__CONFIG__'
+[car]
+budget=1000
+paint_job=standard
+wheels=4
+
+[garage]
+roof=flat
+__CONFIG__
+file_cmp "$TEST_KEY.opt-config" ../config/opt/rose-app-colour.conf <<'__CONFIG__'
+[car]
+paint_job=sparkly
+
+[garage]
+door_paint_job=boring
+__CONFIG__
+#-------------------------------------------------------------------------------
+TEST_KEY=$TEST_KEY_BASE-add-section-to-main
+init <<'__CONFIG__'
+[car]
+budget=1000
+paint_job=standard
+wheels=4
+__CONFIG__
+init_opt colour <<'__OPT_CONFIG__'
+[car]
+paint_job=sparkly
+
+[garage]
+door_paint_job=boring
+__OPT_CONFIG__
+run_pass "$TEST_KEY" rose macro -y --config=../config add.AddElectricBike
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<'__OUT__'
+[T] add.AddElectricBike: changes: 1
+    bike=None=None
+        Added electric bike!
+__OUT__
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+file_cmp "$TEST_KEY.config" ../config/rose-app.conf <<'__CONFIG__'
+[car]
+budget=1000
+paint_job=standard
+wheels=4
+
+[electric_bike]
+__CONFIG__
+file_cmp "$TEST_KEY.opt-config" ../config/opt/rose-app-colour.conf <<'__CONFIG__'
+[car]
+paint_job=sparkly
+
+[garage]
+door_paint_job=boring
+__CONFIG__
+teardown
+#-------------------------------------------------------------------------------
+exit

--- a/t/rose-macro/20-opt-conf-change-modify.t
+++ b/t/rose-macro/20-opt-conf-change-modify.t
@@ -1,0 +1,257 @@
+#!/bin/bash
+#-------------------------------------------------------------------------------
+# (C) British Crown Copyright 2012-5 Met Office.
+#
+# This file is part of Rose, a framework for meteorological suites.
+#
+# Rose is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Rose is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Rose. If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test "rose macro" for optional configuration validating.
+#-------------------------------------------------------------------------------
+. $(dirname $0)/test_header
+#-------------------------------------------------------------------------------
+tests 20
+#-------------------------------------------------------------------------------
+setup
+#-------------------------------------------------------------------------------
+# Test modifying sections and options via macros.
+#-------------------------------------------------------------------------------
+init <<'__CONFIG__'
+[car]
+budget=1000
+paint_job=standard
+wheels=4
+
+# In the middle of our
+[our_house]
+__CONFIG__
+init_opt colour <<'__OPT_CONFIG__'
+[car]
+paint_job=sparkly
+
+[garage]
+door_paint_job=boring
+__OPT_CONFIG__
+init_meta </dev/null
+init_macro modify.py <<'__MACRO__'
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#-----------------------------------------------------------------------------
+# (C) Crown copyright Met Office. All rights reserved.
+#-----------------------------------------------------------------------------
+
+import rose.macro
+
+
+class InvisibleCarPaint(rose.macro.MacroBase):
+
+    """The coolest colour is... invisible."""
+
+    def transform(self, config, meta_config=None):
+        """Check paint can isn't empty."""
+        self.reports = []
+        config.set(["car", "paint_job"], "invisible")
+        info = "Where did I park?"
+        self.add_report("car", "paint_job", "invisible", info)
+        return config, self.reports
+
+
+class ExtraWheels(rose.macro.MacroBase):
+
+    """Add some more wheels."""
+
+    def transform(self, config, meta_config=None):
+        """Make the car a 6x6."""
+        self.reports = []
+        config.set(["car", "wheels"], "6")
+        info = "Added 2 more wheels"
+        self.add_report("car", "wheels", "6", info)
+        return config, self.reports
+
+
+class ChangeHouseComments(rose.macro.MacroBase):
+
+    """Change comments for our house."""
+
+    def transform(self, config, meta_config=None):
+        """Complete the lyric."""
+        self.reports = []
+        config.set(["our_house"], comments=[" In the middle of our street"])
+        info = "Much better now."
+        self.add_report("our_house", None, None, info)
+        return config, self.reports
+
+
+class IgnoreGarage(rose.macro.MacroBase):
+
+    """Park outside."""
+
+    def transform(self, config, meta_config=None):
+        """Garages are for boxes and junk."""
+        self.reports = []
+        node = config.get(["garage"])
+        if node is not None:
+            config.get(["garage"]).state = config.STATE_USER_IGNORED
+            info = "Ignore garage"
+            self.add_report("garage", None, None, info)
+        return config, self.reports
+__MACRO__
+#-------------------------------------------------------------------------------
+TEST_KEY=$TEST_KEY_BASE-modify-option-in-opt
+run_pass "$TEST_KEY" rose macro -y --config=../config modify.InvisibleCarPaint
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<'__OUT__'
+[T] modify.InvisibleCarPaint: changes: 1
+    car=paint_job=invisible
+        Where did I park?
+__OUT__
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+file_cmp "$TEST_KEY.config" ../config/rose-app.conf <<'__CONFIG__'
+[car]
+budget=1000
+paint_job=invisible
+wheels=4
+
+# In the middle of our
+[our_house]
+__CONFIG__
+file_cmp "$TEST_KEY.opt-config" ../config/opt/rose-app-colour.conf <<'__CONFIG__'
+[garage]
+door_paint_job=boring
+__CONFIG__
+#-------------------------------------------------------------------------------
+TEST_KEY=$TEST_KEY_BASE-modify-option-in-main
+init <<'__CONFIG__'
+[car]
+budget=1000
+paint_job=standard
+wheels=4
+
+# In the middle of our
+[our_house]
+__CONFIG__
+init_opt colour <<'__OPT_CONFIG__'
+[car]
+paint_job=sparkly
+
+[garage]
+door_paint_job=boring
+__OPT_CONFIG__
+run_pass "$TEST_KEY" rose macro -y --config=../config modify.ExtraWheels
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<'__OUT__'
+[T] modify.ExtraWheels: changes: 1
+    car=wheels=6
+        Added 2 more wheels
+__OUT__
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+file_cmp "$TEST_KEY.config" ../config/rose-app.conf <<'__CONFIG__'
+[car]
+budget=1000
+paint_job=standard
+wheels=6
+
+# In the middle of our
+[our_house]
+__CONFIG__
+file_cmp "$TEST_KEY.opt-config" ../config/opt/rose-app-colour.conf <<'__CONFIG__'
+[car]
+paint_job=sparkly
+
+[garage]
+door_paint_job=boring
+__CONFIG__
+#-------------------------------------------------------------------------------
+TEST_KEY=$TEST_KEY_BASE-modify-comments-in-main
+init <<'__CONFIG__'
+[car]
+budget=1000
+paint_job=standard
+wheels=4
+
+# In the middle of our
+[our_house]
+__CONFIG__
+init_opt colour <<'__OPT_CONFIG__'
+[car]
+paint_job=sparkly
+
+[garage]
+door_paint_job=boring
+__OPT_CONFIG__
+run_pass "$TEST_KEY" rose macro -y --config=../config modify.ChangeHouseComments
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<'__OUT__'
+[T] modify.ChangeHouseComments: changes: 1
+    our_house=None=None
+        Much better now.
+__OUT__
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+file_cmp "$TEST_KEY.config" ../config/rose-app.conf <<'__CONFIG__'
+[car]
+budget=1000
+paint_job=standard
+wheels=4
+
+# In the middle of our street
+[our_house]
+__CONFIG__
+file_cmp "$TEST_KEY.opt-config" ../config/opt/rose-app-colour.conf <<'__CONFIG__'
+[car]
+paint_job=sparkly
+
+[garage]
+door_paint_job=boring
+__CONFIG__
+#-------------------------------------------------------------------------------
+TEST_KEY=$TEST_KEY_BASE-ignore-section-in-opt
+init <<'__CONFIG__'
+[car]
+budget=1000
+paint_job=standard
+wheels=4
+
+# In the middle of our
+[our_house]
+__CONFIG__
+init_opt colour <<'__OPT_CONFIG__'
+[car]
+paint_job=sparkly
+
+[garage]
+door_paint_job=boring
+__OPT_CONFIG__
+run_pass "$TEST_KEY" rose macro -y --config=../config modify.IgnoreGarage
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<'__OUT__'
+[T] modify.IgnoreGarage: changes: 1
+    (opts=colour)garage=None=None
+        Ignore garage
+__OUT__
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+file_cmp "$TEST_KEY.config" ../config/rose-app.conf <<'__CONFIG__'
+[car]
+budget=1000
+paint_job=standard
+wheels=4
+
+# In the middle of our
+[our_house]
+__CONFIG__
+file_cmp "$TEST_KEY.opt-config" ../config/opt/rose-app-colour.conf <<'__CONFIG__'
+[car]
+paint_job=sparkly
+
+[!garage]
+door_paint_job=boring
+__CONFIG__
+teardown
+#-------------------------------------------------------------------------------
+exit

--- a/t/rose-macro/21-opt-conf-change-remove.t
+++ b/t/rose-macro/21-opt-conf-change-remove.t
@@ -1,0 +1,119 @@
+#!/bin/bash
+#-------------------------------------------------------------------------------
+# (C) British Crown Copyright 2012-5 Met Office.
+#
+# This file is part of Rose, a framework for meteorological suites.
+#
+# Rose is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Rose is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Rose. If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test "rose macro" for optional configuration validating.
+#-------------------------------------------------------------------------------
+. $(dirname $0)/test_header
+#-------------------------------------------------------------------------------
+tests 5
+#-------------------------------------------------------------------------------
+setup
+#-------------------------------------------------------------------------------
+# Test adding sections and options via macros.
+#-------------------------------------------------------------------------------
+init <<'__CONFIG__'
+[car]
+budget=1000
+paint_job=standard
+wheels=4
+
+[electric_bike]
+__CONFIG__
+init_opt colour <<'__OPT_CONFIG__'
+[car]
+motor=electric
+paint_job=sparkly
+
+[garage]
+door_paint_job=boring
+
+[skateboard]
+__OPT_CONFIG__
+init_meta </dev/null
+init_macro remove.py <<'__MACRO__'
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#-----------------------------------------------------------------------------
+# (C) Crown copyright Met Office. All rights reserved.
+#-----------------------------------------------------------------------------
+
+import rose.macro
+
+
+class RemoveLotsOfStuff(rose.macro.MacroBase):
+
+    """Remove many things."""
+
+    def transform(self, config, meta_config=None):
+        """Get rid of selected stuff."""
+        self.reports = []
+        if config.get_value(["car", "motor"]) == "electric":
+            if config.get(["electric_bike"]) is not None:
+                config.unset(["electric_bike"])
+                self.add_report("electric_bike", None, None, "No bike")
+        if config.get(["car", "motor"]) is not None:
+            config.unset(["car", "motor"])
+            self.add_report("car", "motor", None, "No motor")
+        if config.get(["car", "wheels"]) is not None:
+            config.unset(["car", "wheels"])
+            self.add_report("car", "wheels", "4", "No wheels")
+        if config.get(["garage", "door_paint_job"]) is not None:
+            config.unset(["garage", "door_paint_job"])
+            self.add_report("garage", "door_paint_job", "boring", "No door")
+        if config.get(["car", "paint_job"]) is not None:
+            config.unset(["car", "paint_job"])
+            self.add_report("car", "paint_job", None, "No paint")
+        if config.get(["skateboard"]) is not None:
+            config.unset(["skateboard"])
+            self.add_report("skateboard", None, None, "No skateboard")
+        return config, self.reports
+__MACRO__
+#-------------------------------------------------------------------------------
+TEST_KEY=$TEST_KEY_BASE-remove-lots-of-stuff
+run_pass "$TEST_KEY" rose macro -y --config=../config remove.RemoveLotsOfStuff
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<'__OUT__'
+[T] remove.RemoveLotsOfStuff: changes: 6
+    car=wheels=4
+        No wheels
+    car=paint_job=None
+        No paint
+    (opts=colour)electric_bike=None=None
+        No bike
+    (opts=colour)car=motor=None
+        No motor
+    (opts=colour)garage=door_paint_job=boring
+        No door
+    (opts=colour)skateboard=None=None
+        No skateboard
+__OUT__
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+file_cmp "$TEST_KEY.config" ../config/rose-app.conf <<'__CONFIG__'
+[car]
+budget=1000
+
+[electric_bike]
+__CONFIG__
+file_cmp "$TEST_KEY.opt-config" ../config/opt/rose-app-colour.conf <<'__CONFIG__'
+[!electric_bike]
+
+[garage]
+__CONFIG__
+teardown
+#-------------------------------------------------------------------------------
+exit

--- a/t/rose-macro/test_header
+++ b/t/rose-macro/test_header
@@ -26,6 +26,12 @@ function init() {
     cat >$TEST_DIR/config/rose-app.conf
 }
 
+function init_opt() {
+    local opt_key=$1
+    mkdir -p $TEST_DIR/config/opt/
+    cat >$TEST_DIR/config/opt/rose-app-$opt_key.conf
+}
+
 function init_meta() {
     mkdir -p $TEST_DIR/config/meta
     cat >$TEST_DIR/config/meta/rose-meta.conf


### PR DESCRIPTION
We can now handle validation and macro transformation of
optional configurations in rose macro and rose app-upgrade.

The commands now support `-O` and `--opt-conf-key` options.
The old `output_dir` option has been changed to use `-o` rather
than `-O`.

This closes #1334.

Validation is easy.

Transforms are hard. It is difficult to know what to apply
where. It currently works like this:
 * add setting in macro => add settings to the main configuration, unless
 their parent section only exists in an optional configuration
 * modify setting in macro => modify setting only in the last applied
 configuration containing that setting (so e.g. in the optional
 configuration rather than the main one, which would get overwritten).
 * remove setting in macro => remove setting from all configurations

In the case of modification, this may leave the main configuration
in an 'un-upgraded' state if the setting was present in the optional
configuration as well. However, it's difficult to get these things
right - arguably, the best thing for the user to do is to upgrade with
optional configurations, revert the main configuration, and then just
upgrade the main configuration.

@matthewrmshin, please review.
@dpmatthews, I know you have suggestions for the desired mechanics.