### PR TITLE
rose bush: jobs: hide options only if default

### DIFF
--- a/lib/html/rose-bush/jobs.html
+++ b/lib/html/rose-bush/jobs.html
@@ -91,7 +91,8 @@ role="dialog" aria-labelledby="suite-info-label" aria-hidden="true">
 <a class="accordion-toggle" data-toggle="collapse" data-parent="#accordion-0"
 href="#filter"><i class="icon-wrench"></i> Display Options</a>
 </div>
-<div id="filter" class="accordion-body collapse in">
+<div id="filter"
+class="accordion-body collapse{% if not is_option_on %} in{% endif %}">
 <div class="accordion-inner">
 <form action="{{script}}/jobs">
 <input type="hidden" name="user" value="{{user}}" />
@@ -151,7 +152,7 @@ value="{{status}}" />
 No {{status}}?</label>
 {% endfor -%}
 </div>
-<div class="span5">
+<div class="span4">
 <select name="order" title="Sort order">
 {% for k, v in [("time_desc", "new-&gt;old"),
                 ("time_asc", "old-&gt;new"),
@@ -171,8 +172,11 @@ value="{{k}}">{{v}}</option>
 {% endfor -%}
 </select>
 </div>
-<div class="span1">
+<div class="span2 btn-toolbar">
+<div class="btn-group pull-right">
+<input type="reset" class="btn" value="reset" />
 <input type="submit" class="btn btn-primary" value="update" />
+</div>
 </div>
 </div>
 </fieldset>

--- a/lib/python/rose/bush.py
+++ b/lib/python/rose/bush.py
@@ -169,6 +169,13 @@ class Root(object):
             ["rose-bush", "jobs-per-page"], self.JOBS_PER_PAGE))
         per_page_max = int(conf.get_value(
             ["rose-bush", "jobs-per-page-max"], self.JOBS_PER_PAGE_MAX))
+        is_option_on = (
+            cycles or
+            tasks or
+            no_status is not None or
+            order is not None and order != "time_desc" or
+            per_page and per_page != per_page_default
+        )
         if not isinstance(per_page, int):
             if per_page:
                 per_page = int(per_page)
@@ -186,6 +193,7 @@ class Root(object):
             "user": user,
             "suite": suite,
             "cycles": cycles,
+            "is_option_on": is_option_on,
             "tasks": tasks,
             "no_statuses": no_statuses,
             "order": order,


### PR DESCRIPTION
Only hide the *Display Options* form if all options are set as defaults.

Close #1110 and #1162.