### PR TITLE
Fix link for image of ECOX.

### DIFF
--- a/doc/rose-rug-suites-I.html
+++ b/doc/rose-rug-suites-I.html
@@ -142,7 +142,7 @@
 
     <div class="slide">
     <h3>Background - ECOX</h3><img src=
-    "http://www.niwa.co.nz/sites/default/files/imagecache/PhotoGallery_ImageNodeFull/images/ecox-suite.png"
+    "http://cylc.github.io/cylc/screenshots/ecox-1.png"
     alt="ECOX" width="80%" /></div>
 
     <div class="slide">


### PR DESCRIPTION
NIWA have moved their ECOX suite image. This links against the image in the cylc user guide which should be a bit more stable.

@benfitzpatrick - please review.