### PR TITLE
rose host-select: reinstate timeout and improve random selection logic

### DIFF
--- a/bin/rose-host-select
+++ b/bin/rose-host-select
@@ -60,6 +60,8 @@
 #         case.) "load" and "fs" must not exceed threshold while "mem"
 #         must be greater than threshold. A host not meeting a threshold
 #         condition will be excluded from the ranking list.
+#     --timeout=FLOAT
+#         Set the timeout in seconds of SSH commands to hosts.
 #     --verbose, -v
 #         Increment verbosity.
 #
@@ -75,6 +77,9 @@
 #             Declare the default ranking method for a group of hosts.
 #         thresholds{NAME} = [METHOD[:METHOD-ARG]:]VALUE ...
 #             Declare the default threshold(s) for a group of hosts.
+#         timeout = FLOAT
+#             Set the timeout in seconds of SSH commands to hosts.
+#             (default=10.0)
 #
 #     Type "rose config rose-host-select" to print settings.
 #-------------------------------------------------------------------------------

--- a/doc/rose-command.html
+++ b/doc/rose-command.html
@@ -1098,6 +1098,10 @@ rose date 19700101T000000Z 20380119T031407Z
       <var>mem</var> must be greater than threshold. A host not meeting a
       threshold condition will be excluded from the ranking list.</dd>
 
+      <dt><kbd>--timeout=FLOAT</kbd></dt>
+
+      <dd>Set the timeout in seconds of SSH commands to hosts.</dd>
+
       <dt><kbd>--verbose, -v</kbd></dt>
 
       <dd>Increment verbosity.</dd>
@@ -1126,6 +1130,11 @@ rose date 19700101T000000Z 20380119T031407Z
       <dt><kbd>thresholds{NAME}=[METHOD[:METHOD-ARG]:]VALUE</kbd></dt>
 
       <dd>Declare the default threshold(s) for a group of hosts.</dd>
+
+      <dt><kbd>timeout=FLOAT</kbd></dt>
+
+      <dd>Set the timeout in seconds of SSH commands to hosts.
+      (default=10.0)</dd>
     </dl>
 
     <p>Type <kbd>rose config rose-host-select</kbd> to print settings.</p>

--- a/etc/rose.conf.example
+++ b/etc/rose.conf.example
@@ -134,6 +134,10 @@
 ## E.g.:
 #  thresholds{hpc}=fs:/var/tmp:75 fs:/tmp:75
 #  thresholds{linux}=mem:8000
+## Set the timeout in seconds of SSH commands to hosts. (default=10.0)
+#  timeout=FLOAT
+## E.g.:
+#  timeout=5.0
 [rose-host-select]
 
 # Configuration related to "rose stem".

--- a/lib/python/rose/host_select.py
+++ b/lib/python/rose/host_select.py
@@ -273,8 +273,8 @@ class HostSelector(object):
 
         if ssh_cmd_timeout is None:
             conf = ResourceLocator.default().get_conf()
-            ssh_cmd_timeout = conf.get_value(
-                ["rose-host-select", "timeout"], self.SSH_CMD_TIMEOUT)
+            ssh_cmd_timeout = float(conf.get_value(
+                ["rose-host-select", "timeout"], self.SSH_CMD_TIMEOUT))
 
         # Random selection with no thresholds. Return the 1st available host.
         if rank_conf.method == self.RANK_METHOD_RANDOM and not threshold_confs:

--- a/lib/python/rose/opt_parse.py
+++ b/lib/python/rose/opt_parse.py
@@ -531,8 +531,8 @@ class RoseOptionParser(OptionParser):
              "help": "Specify one or more threshold."}],
         "timeout": [
             ["--timeout"],
-            {"metavar": "DELAY",
-             "help": "Set a timeout."}],
+            {"metavar": "FLOAT",
+             "help": "Set a timeout in seconds."}],
         "to_local_copy": [
             ["--to-local-copy"],
             {"action": "store_true",

--- a/t/rose-host-select/01-timeout.t
+++ b/t/rose-host-select/01-timeout.t
@@ -17,7 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with Rose. If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
-# Test "rose host-select", timeout argument passed and subprocesses killed.
+# Test "rose host-select", subprocesses killed.
 #-------------------------------------------------------------------------------
 . $(dirname $0)/test_header
 #-------------------------------------------------------------------------------
@@ -32,14 +32,14 @@ file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
 LANG=C sort "$TEST_KEY.err" -o "$TEST_KEY.sorted.err"
 file_cmp "$TEST_KEY.sorted.err" "$TEST_KEY.sorted.err" <<'__ERR__'
 [FAIL] No hosts selected.
-[WARN] sleepy1: (ssh failed)
-[WARN] sleepy2: (ssh failed)
+[WARN] sleepy1: (timed out)
+[WARN] sleepy2: (timed out)
 __ERR__
 cut -f2- mock-ssh.out | LANG=C sort >mock-ssh.out.sorted
 # N.B. Tab between 1 and sleepy?
 file_cmp "$TEST_KEY.mock-ssh.out" mock-ssh.out.sorted <<'__OUT__'
-sleepy1	bash
-sleepy2	bash
+sleepy1 bash
+sleepy2 bash
 __OUT__
 # Make sure there is no lingering processes
 run_fail "$TEST_KEY.ps" ps $(cut -f1 mock-ssh.out)

--- a/t/rose-host-select/01-timeout/bin/mock-ssh
+++ b/t/rose-host-select/01-timeout/bin/mock-ssh
@@ -1,8 +1,5 @@
 #!/bin/bash
 ME=$(basename $0)
-TIMEOUT=$1
-TIMEOUT=${TIMEOUT#*=}
-shift 1
-echo -e "$$\t$TIMEOUT\t$1" >>$ME.out
-sleep $((TIMEOUT * 2)) # A bit longer, so lingering process can be tested
-exit 255
+echo -e "$$\t$@" >>$ME.out
+sleep 10 # A bit longer, so lingering process can be tested
+exit

--- a/t/rose-host-select/01-timeout/etc/rose.conf
+++ b/t/rose-host-select/01-timeout/etc/rose.conf
@@ -2,4 +2,4 @@
 ssh=mock-ssh
 
 [rose-host-select]
-timeout=1
+timeout=1.0


### PR DESCRIPTION
Reinstate timeout logic. Kill SSH commands if they take too long to complete - treat hosts with killed SSH commands as dead hosts.

Run SSH commands in serial (to reduce system load) when selecting by random with no thresholds.