### PR TITLE
rose config-diff: metadata-annotated config diffs.

### DIFF
--- a/bin/rose-config-diff
+++ b/bin/rose-config-diff
@@ -21,8 +21,11 @@
 #     rose config-diff
 #
 # SYNOPSIS
-#     # Display the metadata-annotated difference between two Rose configs.
+#     # Display the metadata-annotated diff between two Rose config files.
 #     rose config-diff FILE1 FILE2
+#
+#     # Display the metadata-annotated diff between two Rose config dirs.
+#     rose config-diff DIR1 DIR2
 #
 #     # Display the diff, ignoring particular setting patterns
 #     rose config-diff --ignore=namelist:foo FILE1 FILE2
@@ -44,9 +47,8 @@
 #     --ignore=PATTERN, -i PATTERN
 #         Ignore settings that contain the regular expression PATTERN in their
 #         id. Can be specified more than once. PATTERN may also be a key used
-#         in site or user configuration which expands to a list of patterns:
-#         [rose-config-diff]
-#         ignore{PATTERN}=PATTERN1,PATTERN2,...
+#         in site or user configuration which expands to a list of patterns.
+#         See CONFIGURATION below.
 #     --meta-path=PATH, -M PATH
 #         Prepend PATH to the metadata search path (look here first).
 #         This option can be used repeatedly to load multiple paths.
@@ -59,11 +61,35 @@
 #         Prepend $ROSE_META_PATH to the metadata search path.
 #
 # ARGUMENTS
-#     FILE1, FILE2
-#         Two Rose configuration files (e.g. two rose-app.conf files) to
-#         compare. '-' for FILE1 or FILE2 denotes read in from standard input.
+#     PATH1, PATH2
+#         Two Rose configuration files or directories to compare.
+#         If the path is a directory, look underneath for a Rose configuration
+#         file.
+#         '-' for PATH1 or PATH2 denotes read in from standard input.
 #     --
 #         Options and arguments after a -- token are passed directly to the
 #         diff tool.
+#
+# CONFIGURATION
+#     [external]diff-tool, [external]gdiff-tool
+#         You can override the default non-graphical and graphical diff tools
+#         by setting e.g.:
+#         [external]
+#         diff-tool=diff3
+#         gdiff-tool=kompare
+#         in your site or user Rose configuration (rose.conf).
+#     [rose-config-diff]properties, [rose-config-diff]ignore{...}
+#         You can override the default metadata properties to display by
+#         setting e.g.:
+#         [rose-config-diff]
+#         properties=title,ns,description,help
+#         in your site or user Rose configuration (rose.conf).
+#         You can also set shorthand ignore patterns by setting e.g.:
+#         [rose-config-diff]
+#         ignore{foo}=namelist:bar,namelist:baz
+#         in the same location. This will allow you to run:
+#         rose config-diff --ignore=foo ...
+#         instead of:
+#         rose config-diff --ignore=namelist:bar --ignore=namelist:baz ...
 #-------------------------------------------------------------------------------
 exec python -m rose.config_diff "$@"

--- a/bin/rose-config-diff
+++ b/bin/rose-config-diff
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+#-------------------------------------------------------------------------------
+# (C) British Crown Copyright 2012-5 Met Office.
+#
+# This file is part of Rose, a framework for meteorological suites.
+#
+# Rose is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Rose is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Rose. If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# NAME
+#     rose config-diff
+#
+# SYNOPSIS
+#     # Display the metadata-annotated difference between two Rose configs.
+#     rose config-diff FILE1 FILE2
+#
+#     # Display the diff, ignoring particular setting patterns
+#     rose config-diff --ignore=namelist:foo FILE1 FILE2
+#
+#     # Display the diff with a particular diff tool
+#     rose config-diff --diff-tool=kdiff3 FILE1 FILE2
+#
+#     # Display the diff with some diff tool specific options/arguments
+#     rose config-diff FILE1 FILE2 -- [DIFF_OPTIONS] [DIFF_ARGUMENTS]
+#
+# DESCRIPTION
+#     Display the metadata-annotated difference between two Rose config files.
+#
+# OPTIONS
+#     --diff-tool=TOOL
+#         Specify an alternate diff tool like diffuse or kompare.
+#     --graphical, -g
+#         Use a graphical diff tool.
+#     --ignore=PATTERN, -i PATTERN
+#         Ignore settings that contain the regular expression PATTERN in their
+#         id. Can be specified more than once. PATTERN may also be a key used
+#         in site or user configuration which expands to a list of patterns:
+#         [rose-config-diff]
+#         ignore{PATTERN}=PATTERN1,PATTERN2,...
+#     --meta-path=PATH, -M PATH
+#         Prepend PATH to the metadata search path (look here first).
+#         This option can be used repeatedly to load multiple paths.
+#     --properties=PROPERTIES, -p PROPERTIES
+#         Only display these metadata properties. This should be a comma
+#         separated list of metadata options, such as title,description,help.
+#
+# ENVIRONMENT VARIABLES
+#     optional ROSE_META_PATH
+#         Prepend $ROSE_META_PATH to the metadata search path.
+#
+# ARGUMENTS
+#     FILE1, FILE2
+#         Two Rose configuration files (e.g. two rose-app.conf files) to
+#         compare. '-' for FILE1 or FILE2 denotes read in from standard input.
+#     --
+#         Options and arguments after a -- token are passed directly to the
+#         diff tool.
+#-------------------------------------------------------------------------------
+exec python -m rose.config_diff "$@"

--- a/doc/rose-command.html
+++ b/doc/rose-command.html
@@ -70,6 +70,10 @@
 
       <dd>Parse a set of rose configuration files.</dd>
 
+      <dt><a href="#rose-config-diff">rose config-diff</a></dt>
+
+      <dd>Display the metadata-annotated difference between two Rose config files.</dd>
+
       <dt><a href="#rose-config-dump">rose config-dump</a></dt>
 
       <dd>Re-dump Rose configuration files in the common format.</dd>
@@ -613,6 +617,85 @@ rosie UTIL [OPTS] [ARG ...]
       <dt><kbd>optional ROSE_META_PATH</kbd></dt>
 
       <dd>Prepend <var>$ROSE_META_PATH</var> to the metadata search path.</dd>
+    </dl>
+
+    <h2 id="rose-config-diff">rose config-diff</h2>
+
+    <h3>NAME</h3><kbd>rose config-diff</kbd>
+
+    <h3>SYNOPSIS</h3>
+
+    <dl>
+      <dt><kbd>rose config-diff</kbd></dt>
+
+      <dd>Display the metadata-annotated difference between two Rose configs.</dd>
+
+      <dt><kbd>rose config-diff --ignore=namelist:foo FILE1 FILE2</kbd></dt>
+
+      <dd>Display the diff, ignoring particular setting patterns.</dd>
+
+      <dt><kbd>rose config-diff --diff-tool=kdiff3 FILE1 FILE2</kbd></dt>
+
+      <dd>Display the diff with a particular diff tool.</dd>
+
+      <dt><kbd>rose config-diff FILE1 FILE2 -- [DIFF_OPTIONS] [DIFF_ARGUMENTS]</kbd></dt>
+
+      <dd>Display the diff with some diff tool specific options/arguments.</dd>
+    </dl>
+
+    <h3>DESCRIPTION</h3>
+
+    <p>Display the metadata-annotated difference between two Rose config files.</p>
+
+    <h3>OPTIONS</h3>
+
+    <dl>
+      <dt><kbd>--diff-tool=TOOL</kbd></dt>
+
+      <dd>Specify an alternate diff tool like diffuse or kompare.</dd>
+
+      <dt><kbd>--graphical, -g</kbd></dt>
+
+      <dd>Use a graphical diff tool.</dd>
+
+      <dt><kbd>--ignore=PATTERN, -i PATTERN</kbd></dt>
+
+      <dd><p>Ignore settings that contain the regular expression PATTERN in their
+        id. Can be specified more than once. PATTERN may also be a key used
+        in site or user configuration which expands to a list of patterns:</p>
+        <pre>
+        [rose-config-diff]
+        ignore{PATTERN}=PATTERN1,PATTERN2,...</pre></dd>
+
+      <dt><kbd>--meta-path=PATH, -M PATH</kbd></dt>
+
+      <dd>Prepend <var>PATH</var> to the metadata search path (look here first).
+        This option can be used repeatedly to load multiple paths.</dd>
+
+      <dt><kbd>--properties=PROPERTIES, -p PROPERTIES</kbd></dt>
+
+      <dd>Only display these metadata properties. This should be a comma separated list such as <samp>title,description,help</samp>.</dd>
+    
+    </dl>
+
+    <h3>ENVIRONMENT VARIABLES</h3>
+
+    <dl>
+      <dt><kbd>optional ROSE_META_PATH</kbd></dt>
+
+      <dd>Prepend <var>$ROSE_META_PATH</var> to the metadata search path.</dd>
+    </dl>
+
+    <h3>ARGUMENTS</h3>
+
+    <dl>
+      <dt><kbd>FILE1, FILE2</kbd></dt>
+
+      <dd>Two Rose configuration files (e.g. two rose-app.conf files) to compare. '-' for FILE1 or FILE2 denotes read in from standard input.</dd>
+    
+      <dt><kbd>--</kbd></dt>
+
+      <dd>Options and arguments after a -- token are passed directly to the diff tool. 
     </dl>
 
     <h2 id="rose-config-dump">rose config-dump</h2>

--- a/doc/rose-command.html
+++ b/doc/rose-command.html
@@ -1,5 +1,5 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
-    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
@@ -33,7 +33,8 @@
       "http://www.nationalarchives.gov.uk/doc/open-government-licence/" rel=
       "license">Open Government Licence</a>.<br />
       <span id="rose-version"></span>
-    </address><img id="rose-icon" src="rose-icon.png" alt="Rose" />
+    </address><img id="rose-icon" src="rose-icon.png" alt="Rose" name=
+    "rose-icon" />
 
     <p><a href=".">Rose Documentation</a></p>
   </div>
@@ -72,7 +73,8 @@
 
       <dt><a href="#rose-config-diff">rose config-diff</a></dt>
 
-      <dd>Display the metadata-annotated difference between two Rose config files.</dd>
+      <dd>Display the metadata-annotated difference between two Rose config
+      files.</dd>
 
       <dt><a href="#rose-config-dump">rose config-dump</a></dt>
 
@@ -626,9 +628,15 @@ rosie UTIL [OPTS] [ARG ...]
     <h3>SYNOPSIS</h3>
 
     <dl>
-      <dt><kbd>rose config-diff</kbd></dt>
+      <dt><kbd>rose config-diff FILE1 FILE2</kbd></dt>
 
-      <dd>Display the metadata-annotated difference between two Rose configs.</dd>
+      <dd>Display the metadata-annotated diff between two Rose config
+      files.</dd>
+
+      <dt><kbd>rose config-diff DIR1 DIR2</kbd></dt>
+
+      <dd>Display the metadata-annotated diff between two Rose config files in
+      these directories.</dd>
 
       <dt><kbd>rose config-diff --ignore=namelist:foo FILE1 FILE2</kbd></dt>
 
@@ -638,14 +646,16 @@ rosie UTIL [OPTS] [ARG ...]
 
       <dd>Display the diff with a particular diff tool.</dd>
 
-      <dt><kbd>rose config-diff FILE1 FILE2 -- [DIFF_OPTIONS] [DIFF_ARGUMENTS]</kbd></dt>
+      <dt><kbd>rose config-diff FILE1 FILE2 -- [DIFF_OPTIONS]
+      [DIFF_ARGUMENTS]</kbd></dt>
 
       <dd>Display the diff with some diff tool specific options/arguments.</dd>
     </dl>
 
     <h3>DESCRIPTION</h3>
 
-    <p>Display the metadata-annotated difference between two Rose config files.</p>
+    <p>Display the metadata-annotated difference between two Rose config
+    files.</p>
 
     <h3>OPTIONS</h3>
 
@@ -660,22 +670,22 @@ rosie UTIL [OPTS] [ARG ...]
 
       <dt><kbd>--ignore=PATTERN, -i PATTERN</kbd></dt>
 
-      <dd><p>Ignore settings that contain the regular expression PATTERN in their
-        id. Can be specified more than once. PATTERN may also be a key used
-        in site or user configuration which expands to a list of patterns:</p>
-        <pre>
-        [rose-config-diff]
-        ignore{PATTERN}=PATTERN1,PATTERN2,...</pre></dd>
+      <dd>
+        <p>Ignore settings that contain the regular expression <var>PATTERN</var> in their
+        id. Can be specified more than once. <var>PATTERN</var> may also be a key used in
+        site or user configuration which expands to a list of patterns. See
+        CONFIGURATION below.</p>
+      </dd>
 
       <dt><kbd>--meta-path=PATH, -M PATH</kbd></dt>
 
-      <dd>Prepend <var>PATH</var> to the metadata search path (look here first).
-        This option can be used repeatedly to load multiple paths.</dd>
+      <dd>Prepend <var>PATH</var> to the metadata search path (look here
+      first). This option can be used repeatedly to load multiple paths.</dd>
 
       <dt><kbd>--properties=PROPERTIES, -p PROPERTIES</kbd></dt>
 
-      <dd>Only display these metadata properties. This should be a comma separated list such as <samp>title,description,help</samp>.</dd>
-    
+      <dd>Only display these metadata properties. This should be a comma
+      separated list such as <samp>title,description,help</samp>.</dd>
     </dl>
 
     <h3>ENVIRONMENT VARIABLES</h3>
@@ -689,13 +699,65 @@ rosie UTIL [OPTS] [ARG ...]
     <h3>ARGUMENTS</h3>
 
     <dl>
-      <dt><kbd>FILE1, FILE2</kbd></dt>
+      <dt><kbd>PATH1, PATH2</kbd></dt>
 
-      <dd>Two Rose configuration files (e.g. two rose-app.conf files) to compare. '-' for FILE1 or FILE2 denotes read in from standard input.</dd>
-    
+      <dd>Two Rose configuration files or directories to compare. If the path
+      is a directory, look underneath for a Rose configuration file. '-' for
+      FILE1 or FILE2 denotes read in from standard input.</dd>
+
       <dt><kbd>--</kbd></dt>
 
-      <dd>Options and arguments after a -- token are passed directly to the diff tool. 
+      <dd>Options and arguments after a -- token are passed directly to the
+      diff tool.</dd>
+    </dl>
+
+    <h3>CONFIGURATION</h3>
+
+    <dl>
+      <dt><kbd>[external]diff-tool, [external]gdiff-tool</kbd></dt>
+
+      <dd>
+        <p>You can override the default non-graphical and graphical diff tools
+        by setting e.g.:</p>
+        <pre>
+[external]
+diff-tool=diff3
+gdiff-tool=kompare
+</pre>
+
+        <p>in your site or user Rose configuration
+        (<samp>rose.conf</samp>).</p>
+      </dd>
+
+      <dt><kbd>[rose-config-diff]properties,
+      [rose-config-diff]ignore{...}</kbd></dt>
+
+      <dd>
+        <p>You can override the default metadata properties to display by
+        setting e.g.:</p>
+        <pre>
+[rose-config-diff]
+properties=title,ns,description,help
+</pre>
+
+        <p>in your site or user Rose configuration
+        (<samp>rose.conf</samp>).</p>
+
+        <p>You can also set shorthand ignore patterns by setting e.g.:</p>
+        <pre>
+[rose-config-diff]
+ignore{foo}=namelist:bar,namelist:baz
+</pre>
+
+        <p>in the same location. This will allow you to run:<samp>rose
+        config-diff --ignore=foo ...</samp> instead of <samp>rose config-diff
+        --ignore=namelist:bar --ignore=namelist:baz</samp>.</p>
+      </dd>
+
+      <dt><kbd>--</kbd></dt>
+
+      <dd>Options and arguments after a -- token are passed directly to the
+      diff tool.</dd>
     </dl>
 
     <h2 id="rose-config-dump">rose config-dump</h2>
@@ -828,7 +890,6 @@ rosie UTIL [OPTS] [ARG ...]
     <p><kbd>rose-date</kbd></p>
 
     <h3>SYNOPSIS</h3>
-
     <pre class="shell">
 # 1. Print date time point
 # 1.1 Current date time with an optional offset
@@ -868,8 +929,7 @@ rose date 19700101T000000Z 20380119T031407Z
       <li>With 0 or 1 argument. Print the current or the specified date time
       point with an optional offset.</li>
 
-      <li>With 2 arguments. Print the duration between the 2
-      arguments.</li>
+      <li>With 2 arguments. Print the duration between the 2 arguments.</li>
     </ol>
 
     <h3>OPTIONS</h3>
@@ -877,29 +937,29 @@ rose date 19700101T000000Z 20380119T031407Z
     <dl>
       <dt><kbd>--calendar=gregorian|360day|365day|366day</kbd></dt>
 
-      <dd>Specify the calendar mode.
-      See <a href="#rose-date-calendar-mode">CALENDER MODE</a> below.</dd>
+      <dd>Specify the calendar mode. See <a href=
+      "#rose-date-calendar-mode">CALENDER MODE</a> below.</dd>
 
-      <dt><kbd>--offset1=OFFSET</kbd>, <kbd>--offset=OFFSET</kbd>,
-      <kbd>-s OFFSET</kbd>, <kbd>-1 OFFSET</kbd></dt>
+      <dt><kbd>--offset1=OFFSET</kbd>, <kbd>--offset=OFFSET</kbd>, <kbd>-s
+      OFFSET</kbd>, <kbd>-1 OFFSET</kbd></dt>
 
       <dd>Specify 1 or more offsets to add to argument 1 or the current time.
       See <a href="#rose-date-offset-format">OFFSET FORMAT</a> below.</dd>
 
       <dt><kbd>--offset2=OFFSET</kbd>, <kbd>-2 OFFSET</kbd></dt>
 
-      <dd>Specify 1 or more offsets to add to argument 2.
-      See <a href="#rose-date-offset-format">OFFSET FORMAT</a> below.</dd>
+      <dd>Specify 1 or more offsets to add to argument 2. See <a href=
+      "#rose-date-offset-format">OFFSET FORMAT</a> below.</dd>
 
       <dt><kbd>--parse-format=FORMAT</kbd>, <kbd>-p FORMAT</kbd></dt>
 
-      <dd>Specify a format for parsing <var>DATE-TIME</var>. See
-      <a href="#rose-date-parse-format">PARSE FORMAT</a> below.</dd>
+      <dd>Specify a format for parsing <var>DATE-TIME</var>. See <a href=
+      "#rose-date-parse-format">PARSE FORMAT</a> below.</dd>
 
       <dt><kbd>--print-format=FORMAT</kbd>, <kbd>-f FORMAT</kbd></dt>
 
-      <dd>Specify a format for print the result. See
-      <a href="#rose-date-print-format">PRINT FORMAT</a> below.</dd>
+      <dd>Specify a format for print the result. See <a href=
+      "#rose-date-print-format">PRINT FORMAT</a> below.</dd>
 
       <dt><kbd>--use-task-cycle-time, -c</kbd></dt>
 
@@ -930,48 +990,48 @@ rose date 19700101T000000Z 20380119T031407Z
     <var>nU</var> where <var>U</var> is the unit (Y, M, D, H, M, S) and
     <var>n</var> is a positive integer, where T delimits the date series from
     the time series if any time units are used. <var>n</var> may also have a
-    decimal (e.g. <samp>PT5.5M</samp>) part for a unit provided no smaller units
-    are supplied. It is not necessary to specify zero values for units. If
-    <var>OFFSET</var> is negative, prefix a <samp>-</samp>. For example:</p>
+    decimal (e.g. <samp>PT5.5M</samp>) part for a unit provided no smaller
+    units are supplied. It is not necessary to specify zero values for units.
+    If <var>OFFSET</var> is negative, prefix a <samp>-</samp>. For example:</p>
 
     <dl>
       <dt>P6D</dt>
-    
+
       <dd>6 day offset</dd>
 
       <dt>PT6H</dt>
-      
+
       <dd>6 hour offset</dd>
 
       <dt>PT1M</dt>
-      
+
       <dd>1 minute offset</dd>
 
       <dt>-PT1M</dt>
-      
+
       <dd>(negative) 1 minute offset</dd>
 
       <dt>P3M</dt>
-      
+
       <dd>3 month offset</dd>
 
       <dt>P2W</dt>
-      
+
       <dd>2 week offset (note no other units may be combined with weeks)</dd>
 
       <dt>P2DT5.5H</dt>
-      
+
       <dd>2 day, 5.5 hour offset</dd>
 
       <dt>-P2YT4S</dt>
-      
+
       <dd>(negative) 2 year, 4 second offset</dd>
     </dl>
 
     <p>The following deprecated syntax is supported: <var>OFFSET</var> in the
     form <var>nU</var> where <var>U</var> is the unit (w for weeks, d for days,
-    h for hours, m for minutes and s for seconds) and <var>n</var> is a positive
-    or negative integer.</p>
+    h for hours, m for minutes and s for seconds) and <var>n</var> is a
+    positive or negative integer.</p>
 
     <h3 id="rose-date-parse-format">PARSE FORMAT</h3>
 
@@ -979,26 +1039,28 @@ rose date 19700101T000000Z 20380119T031407Z
     POSIX strptime template format (see the strptime command help), with the
     following subset supported across all date/time ranges:</p>
 
-    <blockquote><kbd>%F, %H, %M, %S, %Y, %d, %j, %m, %s, %z</kbd></blockquote>
+    <blockquote>
+      <kbd>%F, %H, %M, %S, %Y, %d, %j, %m, %s, %z</kbd>
+    </blockquote>
 
     <p>If not specified, the system will attempt to parse <var>DATE-TIME</var>
     using the following formats:</p>
 
     <dl>
       <dt>ctime</dt>
-      
+
       <dd><var>%a %b %d %H:%M:%S %Y</var></dd>
 
       <dt>Unix date</dt>
-      
+
       <dd><var>%a %b %d %H:%M:%S %Z %Y</var></dd>
 
       <dt>Basic ISO8601</dt>
-      
+
       <dd><var>%Y-%m-%dT%H:%M:%S</var>, <var>%Y%m%dT%H%M%S</var></dd>
 
       <dt>Cylc (deprecated mode)</dt>
-      
+
       <dd><var>%Y%m%d%H</var></dd>
     </dl>
 
@@ -1007,11 +1069,10 @@ rose date 19700101T000000Z 20380119T031407Z
 
     <h3 id="rose-date-print-format">PRINT FORMAT</h3>
 
-    <p>For printing a date time point, the print format will default to the same
-    format as the parse format. Also supports the isodatetime library dump
+    <p>For printing a date time point, the print format will default to the
+    same format as the parse format. Also supports the isodatetime library dump
     syntax for these operations which follows ISO 8601 example syntax - for
     example:</p>
-
     <pre>
 'CCYY-MM-DDThh:mm:ss' -&gt; '1955-11-05T09:28:00',
 'CCYY' -&gt; '1955',
@@ -1019,8 +1080,8 @@ rose date 19700101T000000Z 20380119T031407Z
 'CCYY-Www-D' -&gt; '1955-W44-6'.
 </pre>
 
-    <p>Usage of this ISO 8601-like syntax should be as ISO 8601-compliant
-    as possible.</p>
+    <p>Usage of this ISO 8601-like syntax should be as ISO 8601-compliant as
+    possible.</p>
 
     <p>Note that specifying an explicit timezone in this format (e.g.
     <var>CCYY-MM-DDThh:mm:ss+0100</var> or <var>CCYYDDDThhmmZ</var> will
@@ -1032,15 +1093,19 @@ rose date 19700101T000000Z 20380119T031407Z
 
     <ul>
       <li>y: years</li>
+
       <li>m: months</li>
+
       <li>d: days</li>
+
       <li>h: hours</li>
+
       <li>M: minutes</li>
+
       <li>s: seconds</li>
     </ul>
 
     <p>For example, for a duration <samp>P57DT12H</samp>:</p>
-
     <pre>
 'y,m,d,h' -&gt; '0,0,57,12'
 </pre>
@@ -2784,23 +2849,24 @@ environment scripting = "eval $(rose task-env)"
 
     <p>Launch the Rosie client GTK+ GUI.</p>
 
-    <p>If arguments are specified, rosie go will perform an initial lookup based
-    on the arguments, which can be an address, a query, or search words. See
-    <a href="#rosie-lookup">rosie lookup</a> for detail.</p>
+    <p>If arguments are specified, rosie go will perform an initial lookup
+    based on the arguments, which can be an address, a query, or search words.
+    See <a href="#rosie-lookup">rosie lookup</a> for detail.</p>
 
     <p>Unless an option is used to specify the initial search type the argument
     is interpreted as follows:</p>
 
     <ul>
       <li>A string beginning with <em>http</em> - an address</li>
+
       <li>A string not beginning with <em>http</em> - search words</li>
     </ul>
 
     <p>An address URL may contain shell meta characters, so remember to put it
     in quotes.</p>
 
-    <p>If no argument is specified, <code>rosie go</code> will display a list of
-    all your locally checked out suites.</p>
+    <p>If no argument is specified, <code>rosie go</code> will display a list
+    of all your locally checked out suites.</p>
 
     <h3>OPTIONS</h3>
 
@@ -2858,8 +2924,8 @@ environment scripting = "eval $(rose task-env)"
     <dl>
       <dt><kbd>--prefix=PREFIX</kbd></dt>
 
-      <dd>Specify the name of one or more Rosie web service servers to use. This
-      option can be used multiple times.</dd>
+      <dd>Specify the name of one or more Rosie web service servers to use.
+      This option can be used multiple times.</dd>
     </dl>
 
     <h2 id="rosie-id">rosie id</h2>
@@ -2966,6 +3032,7 @@ environment scripting = "eval $(rose task-env)"
 
     <ul>
       <li>A string beginning with <em>http</em> - an address</li>
+
       <li>A string not beginning with <em>http</em> - search words</li>
     </ul>
 
@@ -3100,8 +3167,8 @@ abc01 from daisy
       column names or properties preceded by <kbd>%</kbd>.</dd>
 
       <dd>
-        For example: <kbd>rosie ls --format="%idx from %owner"</kbd>
-        might give:
+        For example: <kbd>rosie ls --format="%idx from %owner"</kbd> might
+        give:
         <pre>
 abc01 from daisy
 </pre>

--- a/etc/rose.conf.example
+++ b/etc/rose.conf.example
@@ -34,10 +34,10 @@
 #  diff_tool=diff -y
 ## Launch text editor (default=vi).
 #  editor=gvim -f
-## Launch graphical text editor (default=gedit).
-#  geditor=gvim -f
 ## Launch graphical diff tool (default=gvimdiff).
 #  gdiff_tool=meld
+## Launch graphical text editor (default=gedit).
+#  geditor=gvim -f
 ## Launch graphical file system browser (default=nautilus).
 #  fs_browser=konqueror
 ## Launch image viewer (default=eog).

--- a/etc/rose.conf.example
+++ b/etc/rose.conf.example
@@ -103,6 +103,13 @@
 #  view-size-max=10485760
 [rose-bush]
 
+# Configuration specific to "rose config-diff".
+## Metadata properties to use (default='title,ns,description,help')
+# properties=title,ns,description,help
+## Shorthand expressions for ignore-setting regexes
+# ignore{foo}=^baz,bar,w[ib]ble
+[rose-config-diff]
+
 # Configuration specific to "rose config-edit".
 # See the $ROSE_HOME/lib/python/rose/config_editor/__init__.py for detail.
 #

--- a/etc/rose.conf.example
+++ b/etc/rose.conf.example
@@ -30,10 +30,14 @@
 
 # Configuration of external commands.
 #
+## Launch diff tool (default='diff -u')
+#  diff_tool=diff -y
 ## Launch text editor (default=vi).
 #  editor=gvim -f
 ## Launch graphical text editor (default=gedit).
 #  geditor=gvim -f
+## Launch graphical diff tool (default=gvimdiff).
+#  gdiff_tool=meld
 ## Launch graphical file system browser (default=nautilus).
 #  fs_browser=konqueror
 ## Launch image viewer (default=eog).

--- a/lib/python/rose/__init__.py
+++ b/lib/python/rose/__init__.py
@@ -29,6 +29,7 @@ CONFIG_DELIMITER = "="
 # Filenames and directory names
 CONFIG_NAMES = ["rose-app.conf", "rose-meta.conf",
                 "rose-suite.conf", "rose-suite.info"]
+GLOB_CONFIG_FILE = "rose*.conf"
 META_CONFIG_NAME = "rose-meta.conf"
 CONFIG_META_DIR = "meta"
 SUB_CONFIG_NAME = "rose-app.conf"

--- a/lib/python/rose/config_diff.py
+++ b/lib/python/rose/config_diff.py
@@ -207,8 +207,9 @@ def main():
         diff_cmd = shlex.split(opts.diff_tool) + cmd_opts_args
     return_code = 1
     try:
-        return_code, stdout, stderr = popener.run(
-            *diff_cmd, stdout=sys.stdout, stderr=sys.stderr)
+        return_code, stdout, stderr = popener.run(*diff_cmd)
+        sys.stdout.write(stdout)
+        sys.stderr.write(stderr)
     finally:
         fs_util = rose.fs_util.FileSystemUtil()
         for path in output_filenames:

--- a/lib/python/rose/config_diff.py
+++ b/lib/python/rose/config_diff.py
@@ -1,0 +1,234 @@
+# -*- coding: utf-8 -*-
+# ----------------------------------------------------------------------------
+# (C) British Crown Copyright 2012-5 Met Office.
+#
+# This file is part of Rose, a framework for meteorological suites.
+#
+# Rose is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Rose is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Rose. If not, see <http://www.gnu.org/licenses/>.
+# ----------------------------------------------------------------------------
+"""Implements the "rose config-diff" command."""
+
+import ast
+import re
+import os
+import shlex
+import shutil
+import StringIO
+import sys
+import tempfile
+
+import rose.config
+import rose.opt_parse
+import rose.popen
+import rose.resource
+import rose.macro
+
+
+class ConfigDiffDefaults(object):
+
+    """Store default settings for the rose config-diff command."""
+
+    PROPERTIES = ",".join(
+        [rose.META_PROP_TITLE, rose.META_PROP_NS,
+         rose.META_PROP_DESCRIPTION, rose.META_PROP_HELP]
+    )
+    SHORTHAND = []
+
+
+_DEFAULTS = ConfigDiffDefaults()
+
+
+def annotate_config_with_metadata(config, meta_config, ignore_regexes=None,
+                                  metadata_properties=None):
+    """Add metadata to the rose.config.ConfigNode.comments attribute.
+
+    config -- a rose.config.ConfigNode instance, containing app or
+              suite data.
+    meta_config -- a rose.config.ConfigNode instance, containing
+                   metadata for config.
+    ignore_regexes -- (default None) a list of uncompiled regular
+                      expressions - if a setting contains any of these,
+                      don't include it in the annotated output.
+
+    """
+
+    if ignore_regexes is None:
+        ignore_regexes = []
+    ignore_recs = [re.compile(_) for _ in ignore_regexes]
+    unset_keys = []
+    for keylist, node in config.walk():
+        section = keylist[0]
+        option = None
+        if len(keylist) > 1:
+            option = keylist[1]
+        id_ = rose.macro.get_id_from_section_option(section, option)
+        if any([_.search(id_) for _ in ignore_recs]):
+            unset_keys.append(keylist)
+            continue
+        metadata = rose.macro.get_metadata_for_config_id(id_, meta_config)
+        metadata_text = format_metadata_as_text(
+            metadata, only_these_options=metadata_properties)
+        metadata_lines = [" " + line for line in metadata_text.splitlines()]
+        node.comments = metadata_lines + node.comments
+    for keylist in unset_keys:
+        config.unset(keylist)
+    return config
+
+
+def expand_shorthand_in_ignore_regexes(ignore_regexes_in):
+    """Expand any shorthand patterns in ignore_regexes."""
+    if ignore_regexes_in is None:
+        return None
+    ignore_regexes_in = list(ignore_regexes_in)
+    ignore_regexes = []
+    while ignore_regexes_in:
+        regex = ignore_regexes_in.pop(0)
+        is_shorthand = False
+        for shorthand, regexes in _DEFAULTS.SHORTHAND:
+            if shorthand == regex:
+                ignore_regexes_in.extend(regexes)
+                is_shorthand = True
+        if not is_shorthand:
+            ignore_regexes.append(regex)
+    return ignore_regexes
+
+
+def format_metadata_as_text(metadata, only_these_options=None):
+    """Convert a metadata dictionary to a block of text.
+
+    metadata -- a dictionary with metadata keys and values.
+    only_these_options -- (default None) if given, only output these
+    metadata keys. Otherwise, output all metadata keys.
+
+    """
+    id_node = rose.config.ConfigNode()
+    if only_these_options is None:
+        # Default to every option.
+        only_these_options = sorted(metadata.keys())
+    for property_ in only_these_options:
+        value = metadata.get(property_)
+        if value is None:
+            continue
+        id_node.set([property_], value=value)
+    string_file = StringIO.StringIO()
+    rose.config.dump(id_node, target=string_file)
+    string_file.seek(0)
+    return string_file.read()
+
+
+def main():
+    """Implement the "rose config-diff" command."""
+    opt_parser = rose.opt_parse.RoseOptionParser()
+    opt_parser.add_my_options("diff_tool", "graphical",
+                              "ignore", "meta_path", "properties")
+    my_sys_args = list(sys.argv)
+    if "--" in sys.argv:
+        my_sys_args = sys.argv[:sys.argv.index("--")]
+        diff_args = sys.argv[sys.argv.index("--") + 1:]
+    else:
+        diff_args = []
+
+    opts, args = opt_parser.parse_args(my_sys_args[1:])
+    rose.macro.add_site_meta_paths()
+    rose.macro.add_env_meta_paths()
+    rose.macro.add_opt_meta_paths(opts.meta_path)
+
+    if len(args) != 2:
+        sys.exit(opt_parser.get_usage())
+
+    config_loader = rose.config.ConfigLoader()
+
+    if opts.properties is None:
+        properties = _DEFAULTS.PROPERTIES.split(",")
+    else:
+        properties = opts.properties.split(",")
+
+    ignore_regexes = expand_shorthand_in_ignore_regexes(
+        opts.ignore_patterns)
+
+    output_filenames = []
+    config_type = rose.SUB_CONFIG_NAME
+    for path in args:
+        if path == "-":
+            continue
+        config_type = path.split(os.sep)[-1]
+    for path in args:
+        if path == "-":
+            path = sys.stdin
+            filename = config_type
+            directory = None
+        else:
+            filename = path.split(os.sep)[-1]
+            directory = path.rsplit(os.sep, 1)[0]
+        config = config_loader.load_with_opts(path)
+        meta_config_tree = rose.macro.load_meta_config_tree(
+            config, directory=directory, config_type=filename)
+        if meta_config_tree is None:
+            meta_config = rose.config.ConfigNode()
+        else:
+            meta_config = meta_config_tree.node
+        annotated_config = annotate_config_with_metadata(
+            config, meta_config, ignore_regexes=ignore_regexes,
+            metadata_properties=properties
+        )
+        output_dir = tempfile.mkdtemp()
+        output_path = os.path.join(output_dir, filename)
+        rose.config.dump(annotated_config, target=output_path)
+        output_filenames.append(output_path)
+    popener = rose.popen.RosePopener()
+    cmd_opts_args = diff_args + output_filenames
+    if opts.diff_tool is None:
+        if opts.graphical_mode:
+            diff_cmd = popener.get_cmd("gdiff_tool", *cmd_opts_args)
+        else:
+            diff_cmd = popener.get_cmd("diff_tool", *cmd_opts_args)
+    else:
+        diff_cmd = shlex.split(opts.diff_tool) + cmd_opts_args
+    return_code = 1
+    try:
+        return_code, stdout, stderr = popener.run(*diff_cmd)
+        sys.stdout.write(stdout)
+        sys.stderr.write(stderr)
+    finally:
+        for path in output_filenames:
+            shutil.rmtree(os.path.dirname(path))
+    sys.exit(return_code)
+
+
+def load_override_config():
+    """Load user or site options for the config_diff command."""
+    conf = rose.resource.ResourceLocator.default().get_conf().get(
+        ["rose-config-diff"])
+    if conf is None:
+        return
+    for key, node in conf.value.items():
+        if node.is_ignored():
+            continue
+        try:
+            cast_value = ast.literal_eval(node.value)
+        except Exception:
+            cast_value = node.value
+        var_key = key.replace("-", "_").upper()
+        if hasattr(_DEFAULTS, var_key):
+            setattr(_DEFAULTS, var_key, cast_value)
+        elif key.startswith("ignore{"):
+            key = key.replace("ignore{", "").rstrip("}")
+            _DEFAULTS.SHORTHAND.append((key, node.value.split(",")))
+
+
+load_override_config()
+
+
+if __name__ == "__main__":
+    main()

--- a/lib/python/rose/opt_parse.py
+++ b/lib/python/rose/opt_parse.py
@@ -149,6 +149,12 @@ class RoseOptionParser(OptionParser):
              "dest": "diff",
              "default": None,
              "help": "Set a datetime to subtract from DATE-TIME."}],
+        "diff_tool": [
+            ["--diff-tool"],
+            {"action": "store",
+             "dest": "diff_tool",
+             "default": None,
+             "help": "Specify an alternate diff tool like diffuse."}],
         "downgrade": [
             ["--downgrade", "-d"],
             {"action": "store_true",
@@ -175,6 +181,12 @@ class RoseOptionParser(OptionParser):
             {"action": "store_true",
              "dest": "force_mode",
              "help": "Switch on force mode."}],
+        "graphical": [
+            ["--graphical", "-g"],
+            {"action": "store_true",
+             "dest": "graphical_mode",
+             "default": False,
+             "help": "Run in graphical mode (X windows, etc.)"}],
         "gcontrol_mode": [
             ["--no-gcontrol"],
             {"action": "store_false",
@@ -190,6 +202,12 @@ class RoseOptionParser(OptionParser):
             ["--host"],
             {"metavar": "HOST",
              "help": "Specify a host"}],
+        "ignore": [
+            ["--ignore", "-i"],
+            {"action": "append",
+             "dest": "ignore_patterns",
+             "metavar": "PATTERN",
+             "help": "Ignore setting ids that contain (regex) PATTERN."}],
         "info_file": [
             ["--info-file"],
             {"metavar": "FILE",
@@ -431,6 +449,11 @@ class RoseOptionParser(OptionParser):
             {"action": "append",
              "metavar": "PROPERTY",
              "help": "Specify a property."}],
+        "properties": [
+            ["--properties", "-p"],
+            {"action": "store",
+             "metavar": "PROPERTIES",
+             "help": "Specify a comma-separated list of properties."}],
         "prune_remote_mode": [
             ["--prune-remote", "--tidy-remote"],
             {"action": "store_true",

--- a/lib/python/rose/popen.py
+++ b/lib/python/rose/popen.py
@@ -85,8 +85,10 @@ class RosePopener(object):
     """Wrap Python's subprocess.Popen."""
 
     CMDS = {
+        "diff_tool": ["diff", "-u"],
         "editor": ["vi"],
         "fs_browser": ["nautilus"],
+        "gdiff_tool": ["gvimdiff"],
         "geditor": ["gedit"],
         "image_viewer": ["eog", "--new-instance"],
         "rsync": ["rsync", "-a", "--exclude=.*", "--timeout=1800",

--- a/t/rose-config-diff/00-basic.t
+++ b/t/rose-config-diff/00-basic.t
@@ -1,0 +1,270 @@
+#!/bin/bash
+#-------------------------------------------------------------------------------
+# (C) British Crown Copyright 2012-5 Met Office.
+#
+# This file is part of Rose, a framework for meteorological suites.
+#
+# Rose is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Rose is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Rose. If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test "rose config", basic usage.
+#-------------------------------------------------------------------------------
+. $(dirname $0)/test_header
+#-------------------------------------------------------------------------------
+tests 27
+#-------------------------------------------------------------------------------
+init app 1 <<'__APP__'
+[env]
+# 1 reverse, 5 forward
+GEARBOX_GEARS=6
+GEARSTICK_DECORATION=golfball
+__APP__
+init_meta app 1 <<'__META__'
+[env=GEARBOX_GEARS]
+description=The number of gears available.
+title=Gearbox Gears
+trigger=env=GEARSTICK_DECORATION: this > 1;
+
+[env=GEARSTICK_DECORATION]
+help=1  3  5
+    =|  |  |
+    =-------
+    =|  |  |
+    =2  4  R
+__META__
+init app 2 <<'__APP__'
+[env]
+GEARSTICK_DECORATION=golfball
+
+[namelist:locking]
+air_locking=.false.
+__APP__
+init_meta app 2 <<'__META__'
+[namelist:locking]
+description=Different choices of locking methods, if available.
+
+[namelist:locking=air_locking]
+title=Air Locking?
+__META__
+export ROSE_CONF_PATH=$PWD
+#-------------------------------------------------------------------------------
+TEST_KEY=$TEST_KEY_BASE
+setup
+run_fail "$TEST_KEY" rose config-diff $TEST_DIR/app{1,2}/rose-app.conf
+sed -i "/rose-app.conf/d" "$TEST_KEY.out"
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<'__DIFF__'
+@@ -1,12 +1,8 @@
+ # description=Environment variable configuration
+ [env]
+-# description=The number of gears available.
+-# title=Gearbox Gears
+-# 1 reverse, 5 forward
+-GEARBOX_GEARS=6
+-# help=1  3  5
+-#     =|  |  |
+-#     =-------
+-#     =|  |  |
+-#     =2  4  R
+ GEARSTICK_DECORATION=golfball
++
++# description=Different choices of locking methods, if available.
++[namelist:locking]
++# title=Air Locking?
++air_locking=.false.
+__DIFF__
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+#-------------------------------------------------------------------------------
+TEST_KEY=$TEST_KEY_BASE-extra-args
+run_fail "$TEST_KEY" rose config-diff $TEST_DIR/app{1,2}/rose-app.conf \
+    -- --label=app1 --label=app2
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<'__DIFF__'
+--- app1
++++ app2
+@@ -1,12 +1,8 @@
+ # description=Environment variable configuration
+ [env]
+-# description=The number of gears available.
+-# title=Gearbox Gears
+-# 1 reverse, 5 forward
+-GEARBOX_GEARS=6
+-# help=1  3  5
+-#     =|  |  |
+-#     =-------
+-#     =|  |  |
+-#     =2  4  R
+ GEARSTICK_DECORATION=golfball
++
++# description=Different choices of locking methods, if available.
++[namelist:locking]
++# title=Air Locking?
++air_locking=.false.
+__DIFF__
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+#-------------------------------------------------------------------------------
+TEST_KEY=$TEST_KEY_BASE-ignore
+run_fail "$TEST_KEY" rose config-diff --ignore=env $TEST_DIR/app{1,2}/rose-app.conf
+sed -i "/rose-app.conf/d" "$TEST_KEY.out"
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<'__DIFF__'
+@@ -0,0 +1,4 @@
++# description=Different choices of locking methods, if available.
++[namelist:locking]
++# title=Air Locking?
++air_locking=.false.
+__DIFF__
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+#-------------------------------------------------------------------------------
+TEST_KEY=$TEST_KEY_BASE-ignore-shorthand
+mkdir conf
+cat >conf/rose.conf <<__ROSE_CONF__
+[rose-config-diff]
+ignore{everything}=GEAR,locking
+__ROSE_CONF__
+export ROSE_CONF_PATH=$PWD/conf
+run_pass "$TEST_KEY" rose config-diff --ignore=everything $TEST_DIR/app{1,2}/rose-app.conf
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+#-------------------------------------------------------------------------------
+TEST_KEY=$TEST_KEY_BASE-custom-properties
+echo >conf/rose.conf
+run_fail "$TEST_KEY" rose config-diff --properties=title,description \
+    $TEST_DIR/app{1,2}/rose-app.conf
+sed -i "/rose-app.conf/d" "$TEST_KEY.out"
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<'__DIFF__'
+@@ -1,7 +1,8 @@
+ # description=Environment variable configuration
+ [env]
+-# description=The number of gears available.
+-# title=Gearbox Gears
+-# 1 reverse, 5 forward
+-GEARBOX_GEARS=6
+ GEARSTICK_DECORATION=golfball
++
++# description=Different choices of locking methods, if available.
++[namelist:locking]
++# title=Air Locking?
++air_locking=.false.
+__DIFF__
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+#-------------------------------------------------------------------------------
+TEST_KEY=$TEST_KEY_BASE-custom-properties-config
+cat >conf/rose.conf <<__ROSE_CONF__
+[rose-config-diff]
+properties=title,description
+__ROSE_CONF__
+run_fail "$TEST_KEY" rose config-diff $TEST_DIR/app{1,2}/rose-app.conf
+sed -i "/rose-app.conf/d" "$TEST_KEY.out"
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<'__DIFF__'
+@@ -1,7 +1,8 @@
+ # description=Environment variable configuration
+ [env]
+-# description=The number of gears available.
+-# title=Gearbox Gears
+-# 1 reverse, 5 forward
+-GEARBOX_GEARS=6
+ GEARSTICK_DECORATION=golfball
++
++# description=Different choices of locking methods, if available.
++[namelist:locking]
++# title=Air Locking?
++air_locking=.false.
+__DIFF__
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+#-------------------------------------------------------------------------------
+TEST_KEY=$TEST_KEY_BASE-custom-diff-tool
+echo >conf/rose.conf
+run_pass "$TEST_KEY" rose config-diff --diff-tool='cat -n' \
+    $TEST_DIR/app{1,2}/rose-app.conf 
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<'__DIFF__'
+     1	# description=Environment variable configuration
+     2	[env]
+     3	# description=The number of gears available.
+     4	# title=Gearbox Gears
+     5	# 1 reverse, 5 forward
+     6	GEARBOX_GEARS=6
+     7	# help=1  3  5
+     8	#     =|  |  |
+     9	#     =-------
+    10	#     =|  |  |
+    11	#     =2  4  R
+    12	GEARSTICK_DECORATION=golfball
+    13	# description=Environment variable configuration
+    14	[env]
+    15	GEARSTICK_DECORATION=golfball
+    16	
+    17	# description=Different choices of locking methods, if available.
+    18	[namelist:locking]
+    19	# title=Air Locking?
+    20	air_locking=.false.
+__DIFF__
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+#-------------------------------------------------------------------------------
+TEST_KEY=$TEST_KEY_BASE-custom-diff-tool-config
+cat >conf/rose.conf <<__ROSE_CONF__
+[external]
+diff_tool=cat -n
+__ROSE_CONF__
+run_pass "$TEST_KEY" rose config-diff $TEST_DIR/app{1,2}/rose-app.conf 
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<'__DIFF__'
+     1	# description=Environment variable configuration
+     2	[env]
+     3	# description=The number of gears available.
+     4	# title=Gearbox Gears
+     5	# 1 reverse, 5 forward
+     6	GEARBOX_GEARS=6
+     7	# help=1  3  5
+     8	#     =|  |  |
+     9	#     =-------
+    10	#     =|  |  |
+    11	#     =2  4  R
+    12	GEARSTICK_DECORATION=golfball
+    13	# description=Environment variable configuration
+    14	[env]
+    15	GEARSTICK_DECORATION=golfball
+    16	
+    17	# description=Different choices of locking methods, if available.
+    18	[namelist:locking]
+    19	# title=Air Locking?
+    20	air_locking=.false.
+__DIFF__
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+#-------------------------------------------------------------------------------
+TEST_KEY=$TEST_KEY_BASE-custom-diff-tool-config-graphical
+cat >conf/rose.conf <<__ROSE_CONF__
+[external]
+gdiff_tool=diff -y
+__ROSE_CONF__
+run_fail "$TEST_KEY" rose config-diff -g $TEST_DIR/app{1,2}/rose-app.conf
+# Note: two column layout assumes 8 space tabs.
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<'__DIFF__'
+# description=Environment variable configuration		# description=Environment variable configuration
+[env]								[env]
+# description=The number of gears available.		      <
+# title=Gearbox Gears					      <
+# 1 reverse, 5 forward					      <
+GEARBOX_GEARS=6						      <
+# help=1  3  5						      <
+#     =|  |  |						      <
+#     =-------						      <
+#     =|  |  |						      <
+#     =2  4  R						      <
+GEARSTICK_DECORATION=golfball					GEARSTICK_DECORATION=golfball
+							      >
+							      >	# description=Different choices of locking methods, if availa
+							      >	[namelist:locking]
+							      >	# title=Air Locking?
+							      >	air_locking=.false.
+__DIFF__
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+teardown
+#-------------------------------------------------------------------------------
+exit 0

--- a/t/rose-config-diff/test_header
+++ b/t/rose-config-diff/test_header
@@ -35,6 +35,13 @@ function init_meta() {
     cat >"$TEST_DIR/$ROSE_TYPE$NUMBER/meta/rose-meta.conf"
 }
 
+function init_rose_meta() {
+    local category=$1
+    local version=$2    
+    mkdir -p $TEST_DIR/rose-meta/$category/$version
+    cat >$TEST_DIR/rose-meta/$category/$version/rose-meta.conf
+}
+
 function setup() {
     mkdir $TEST_DIR/run
     cd $TEST_DIR/run

--- a/t/rose-config-diff/test_header
+++ b/t/rose-config-diff/test_header
@@ -1,0 +1,46 @@
+#!/bin/bash
+#-------------------------------------------------------------------------------
+# (C) British Crown Copyright 2012-5 Met Office.
+#
+# This file is part of Rose, a framework for meteorological suites.
+#
+# Rose is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Rose is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Rose. If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Provides header for "rose config-dump" tests.
+#-------------------------------------------------------------------------------
+. $(dirname $0)/../lib/bash/test_header
+
+function init() {
+    local ROSE_TYPE=$1
+    local NUMBER=$2
+    mkdir "$TEST_DIR/$ROSE_TYPE$NUMBER/"
+    cat >"$TEST_DIR/$ROSE_TYPE$NUMBER/rose-$ROSE_TYPE.conf"
+}
+
+function init_meta() {
+    local ROSE_TYPE=$1
+    local NUMBER=$2
+    mkdir -p "$TEST_DIR/$ROSE_TYPE$NUMBER/meta/"
+    cat >"$TEST_DIR/$ROSE_TYPE$NUMBER/meta/rose-meta.conf"
+}
+
+function setup() {
+    mkdir $TEST_DIR/run
+    cd $TEST_DIR/run
+}
+
+function teardown() {
+    cd $TEST_DIR
+    rm -rf $TEST_DIR/run
+}


### PR DESCRIPTION
This produces diffs between two config files, altered to include
selected metadata as comment text. This closes #1293.

This is derived from the original work done by Craig
Maclachlan (@craigmaclachlan).