### PR TITLE
rosie.ws_client_auth: swap keyring agent order

### DIFF
--- a/lib/python/rosie/ws_client_auth.py
+++ b/lib/python/rosie/ws_client_auth.py
@@ -67,8 +67,8 @@ class RosieWSClientAuthManager(object):
     ST_UNC = "UNC"  # Item is unchanged
     ST_MOD = "MOD"  # Item is modified
     PASSWORD_STORE_NAMES = [
-        "GnomekeyringStore",
         "GPGAgentStore",
+        "GnomekeyringStore",
         #KeyringStore,
     ]
     PROMPT_USERNAME = "Username for %(prefix)r: "


### PR DESCRIPTION
Move gpg-agent above GnomeKeyring (as gpg-agent is more readily available).

@benfitzpatrick please review.