### PR TITLE
rose suite-shutdown: Add missing line to cli help.

### DIFF
--- a/bin/rose-suite-shutdown
+++ b/bin/rose-suite-shutdown
@@ -52,5 +52,8 @@
 #         Decrement verbosity.
 #     --verbose, -v
 #         Increment verbosity.
+#     -- --EXTRA-ARGS
+#         See the cylc documentation, cylc shutdown for options and details on 
+#         EXTRA-ARGS.
 #-------------------------------------------------------------------------------
 exec python -m rose.suite_control shutdown "$@"


### PR DESCRIPTION
Missed adding the documentation addition from #1573 to the CLI help.

Verified as OK by @kaday at my desk.