### PR TITLE
rose test-battery: fix suite-hook smtp clash

### DIFF
--- a/t/lib/bash/test_header
+++ b/t/lib/bash/test_header
@@ -63,6 +63,12 @@
 #     file_grep_fail TEST_KEY PATTERN FILE
 #         Run "grep -q PATTERN FILE". pass $TEST_KEY if $PATTERN is not present
 #         and fail otherwise.
+#     bad_smtpd_init
+#         Start a server daemon that will not reply correctly to SMTP.
+#         Write host:port setting to the variable TEST_SMTPD_HOST. Write
+#         pid of daemon to TEST_SMTPD_PID.
+#     bad_smtpd_kill
+#         Kill the faux-SMTP server daemon process.
 #     mock_smtpd_init
 #         Start a mock SMTP server daemon for testing. Write host:port setting
 #         to the variable TEST_SMTPD_HOST. Write pid of daemon to
@@ -203,6 +209,52 @@ function file_grep_fail() {
         return
     fi
     pass $TEST_KEY
+}
+
+function bad_smtpd_init() {
+    local SMTPD_PORT=
+    for SMTPD_PORT in 8026 8126 8226 8326 8426 8526 8626 8726 8826 8926; do
+        local SMTPD_HOST=localhost:$SMTPD_PORT
+        local SMTPD_LOG="$TEST_DIR/badsmtpd.log"
+        # Piping the code directly to python does not work, for some reason.
+        cat >$TEST_DIR/smtpd.py <<__PYTHON__
+import socket, sys
+soc = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+soc.bind(('localhost', $SMTPD_PORT))
+sys.stdout.write("bound\n")
+sys.stdout.flush()
+soc.listen(5)
+while True:
+    client_soc, address = soc.accept()
+    # Antisocially cut off the connection!
+    client_soc.close()
+__PYTHON__
+       python $TEST_DIR/smtpd.py 1>"$SMTPD_LOG" 2>&1 &
+       local SMTPD_PID=$!
+       while ! grep -q '^bound$' "$SMTPD_LOG" 2>/dev/null; do
+            if ps $SMTPD_PID 1>/dev/null 2>&1; then
+                sleep 1
+            else
+                rm -f "$SMTPD_LOG"
+                unset SMTPD_HOST SMTPD_LOG SMTPD_PID
+                break
+            fi
+        done
+        if [[ -n ${SMTPD_PID:-} ]]; then
+            TEST_SMTPD_HOST=$SMTPD_HOST
+            TEST_SMTPD_PID=$SMTPD_PID
+            TEST_SMTPD_LOG=$SMTPD_LOG
+            break
+        fi
+    done
+}
+
+function bad_smtpd_kill() {
+    if [[ -n ${TEST_SMTPD_PID:-} ]] && ps $TEST_SMTPD_PID >/dev/null 2>&1; then
+        kill $TEST_SMTPD_PID
+        wait $TEST_SMTPD_PID 2>/dev/null || true
+        unset TEST_SMTPD_HOST TEST_SMTPD_PID
+    fi
 }
 
 function mock_smtpd_init() {

--- a/t/rose-config/04-meta.t
+++ b/t/rose-config/04-meta.t
@@ -31,7 +31,6 @@ tests 24
 TEST_KEY=$TEST_KEY_BASE-no-metadata
 setup
 run_pass "$TEST_KEY" rose config -f $FILE --meta
-cat $TEST_KEY.out >/dev/tty
 file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
 teardown

--- a/t/rose-suite-hook/03-mail.t
+++ b/t/rose-suite-hook/03-mail.t
@@ -85,7 +85,7 @@ file_grep "$TEST_KEY.smtp.content.2" "See: file://$SUITE_RUN_DIR" smtpd-tail.out
 TEST_KEY=$TEST_KEY_BASE-at-host
 cat >conf/rose.conf <<'__CONF__'
 [rose-suite-hook]
-smtp-host=localhost:8025
+smtp-host=$TEST_SMTP_HOST
 email-host=hms.beagle
 __CONF__
 run_pass "$TEST_KEY" rose suite-hook \

--- a/t/rose-suite-hook/03-mail.t
+++ b/t/rose-suite-hook/03-mail.t
@@ -20,7 +20,6 @@
 # Test "rose suite-hook --mail", without site/user configurations.
 #-------------------------------------------------------------------------------
 . $(dirname $0)/test_header
-
 mock_smtpd_init
 if [[ -z ${TEST_SMTPD_HOST:-} ]]; then
     skip_all "cannot start SMTP server"

--- a/t/rose-suite-hook/03-mail.t
+++ b/t/rose-suite-hook/03-mail.t
@@ -83,9 +83,9 @@ file_grep "$TEST_KEY.smtp.content.1" "Task: t1.1" smtpd-tail.out
 file_grep "$TEST_KEY.smtp.content.2" "See: file://$SUITE_RUN_DIR" smtpd-tail.out
 #-------------------------------------------------------------------------------
 TEST_KEY=$TEST_KEY_BASE-at-host
-cat >conf/rose.conf <<'__CONF__'
+cat >conf/rose.conf <<__CONF__
 [rose-suite-hook]
-smtp-host=$TEST_SMTP_HOST
+smtp-host=$TEST_SMTPD_HOST
 email-host=hms.beagle
 __CONF__
 run_pass "$TEST_KEY" rose suite-hook \

--- a/t/rose-suite-hook/04-mail-bad.t
+++ b/t/rose-suite-hook/04-mail-bad.t
@@ -26,7 +26,6 @@ SUITE_RUN_DIR=$(mktemp -d --tmpdir=$HOME/cylc-run 'rose-test-battery.XXXXXX')
 NAME=$(basename $SUITE_RUN_DIR)
 rose suite-run -C $TEST_SOURCE_DIR/$TEST_KEY_BASE --name=$NAME \
     --no-gcontrol --host=localhost -q
-sleep 5
 #-------------------------------------------------------------------------------
 # Start and stop the mail server.
 bad_smtpd_init

--- a/t/rose-suite-hook/04-mail-bad.t
+++ b/t/rose-suite-hook/04-mail-bad.t
@@ -17,22 +17,9 @@
 # You should have received a copy of the GNU General Public License
 # along with Rose. If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
-# Test "rose suite-hook --mail --shutdown" when email does not work. #-------------------------------------------------------------------------------
-. $(dirname $0)/test_header
-mock_smtpd_init
-if [[ -z ${TEST_SMTPD_HOST:-} ]]; then
-    skip_all "cannot start SMTP server"
-fi
-mkdir conf
-cat >conf/rose.conf <<__CONF__
-[rose-suite-hook]
-smtp-host=$TEST_SMTPD_HOST
-__CONF__
-export ROSE_CONF_PATH=$PWD/conf
-# Now kill the server so we can't contact it.
-mock_smtpd_kill
+# Test "rose suite-hook --mail --shutdown" when email does not work.
 #-------------------------------------------------------------------------------
-tests 4
+. $(dirname $0)/test_header
 #-------------------------------------------------------------------------------
 # Run the suite.
 SUITE_RUN_DIR=$(mktemp -d --tmpdir=$HOME/cylc-run 'rose-test-battery.XXXXXX')
@@ -41,11 +28,25 @@ rose suite-run -C $TEST_SOURCE_DIR/$TEST_KEY_BASE --name=$NAME \
     --no-gcontrol --host=localhost -q
 sleep 5
 #-------------------------------------------------------------------------------
+# Start and stop the mail server.
+bad_smtpd_init
+if [[ -z ${TEST_SMTPD_HOST:-} ]]; then
+    skip_all "cannot start fake SMTP server"
+fi
+mkdir conf
+cat >conf/rose.conf <<__CONF__
+[rose-suite-hook]
+smtp-host=$TEST_SMTPD_HOST
+__CONF__
+export ROSE_CONF_PATH=$PWD/conf
+#-------------------------------------------------------------------------------
+tests 4
+#-------------------------------------------------------------------------------
 TEST_KEY=$TEST_KEY_BASE
 run_fail "$TEST_KEY" rose suite-hook --mail --shutdown \
     some-event "$NAME" some-msg
 file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
-file_grep "$TEST_KEY.err" "^socket.error: " "$TEST_KEY.err"
+file_grep "$TEST_KEY.err" "^smtplib.SMTPServerDisconnected: " "$TEST_KEY.err"
 TIMEOUT=$(($(date +%s) + 30)) # Wait a maximum of 30 seconds
 while [[ -e $HOME/.cylc/ports/$NAME ]] && (($(date +%s) < TIMEOUT)); do
     sleep 1
@@ -56,5 +57,6 @@ else
     pass "$TEST_KEY"
 fi
 #-------------------------------------------------------------------------------
+bad_smtpd_kill
 rose suite-clean -q -y $NAME
 exit 0


### PR DESCRIPTION
This fixes the clash between `03-mail.t` and `04-mail-bad.t`.
The `04-mail-bad.t` test now uses an entirely fake SMTP server
on a different set of possible ports.

The underlying problem was that `03-mail.t` had hardcoded itself
to port 8025, which may explain the odd failures it had now and
then in past test battery runs.

@matthewrmshin, please review.