### PR TITLE
rosie go: allow prefix selection on suite create

### DIFF
--- a/lib/python/rosie/browser/__init__.py
+++ b/lib/python/rosie/browser/__init__.py
@@ -149,6 +149,7 @@ LOCAL_STATUS_UPDATE = "Local copy at older revision"
 # Dialog text
 
 DIALOG_MESSAGE_CHECKOUT = "checkout {0}"
+DIALOG_MESSAGE_CREATE_PREFIX = "Choose a repository to create the new suite:"
 DIALOG_MESSAGE_CLEAR_HISTORY_CONFIRMATION = ("Delete search history?")
 DIALOG_MESSAGE_DELETE_LOCAL_CONFIRM = ("You are about to delete your local" +
                                        " copy of {0}")
@@ -160,6 +161,7 @@ DIALOG_MESSAGE_UNCOMPLETED_FILTER = "Uncompleted filter"
 DIALOG_MESSAGE_UNREGISTERED_SUITE = ("Cannot launch gcontrol: " +
                                      "suite {0} is not registered.")
 DIALOG_TITLE_CHECKOUT = "Checkout"
+DIALOG_TITLE_CREATE_PREFIX = "Create"
 DIALOG_TITLE_DELETE = "Confirm Delete"
 DIALOG_TITLE_HISTORY_ERROR = "History Error"
 DIALOG_TITLE_INFO = "Suite Info"
@@ -228,7 +230,8 @@ LABEL_ERROR_DISCOVERY = "Ignore errors in suite info?"
 LABEL_ERROR_LOCAL = "Unable to retrieve details for local suites."
 LABEL_ERROR_PREFIX = "Unable to retrieve settings for prefix: {0}"
 LABEL_HISTORY_TREEVIEW = "Search History"
-TITLE_NEW_SUITE_WIZARD = "Edit new suite information"
+TITLE_NEW_SUITE_WIZARD_FROMID = "Create suite from {0}: edit suite information"
+TITLE_NEW_SUITE_WIZARD_PREFIX = "Create suite at {0}: edit suite information"
 TITLE_ERROR_DISCOVERY = "Errors found"
 TITLE_HISTORY_IO_ERROR = "History read/write error"
 TITLE_HISTORY_NAVIGATION_ERROR = "History navigation error"

--- a/lib/python/rosie/browser/main.py
+++ b/lib/python/rosie/browser/main.py
@@ -677,10 +677,13 @@ class MainWindow(gtk.Window):
             prefix = None
         config = self.suite_director.vc_client.generate_info_config(
             from_id, prefix)
-        finish_func = functools.partial(
-            self._create_suite_hook, config, from_id, prefix)
+        finish_func = lambda c: self._create_suite_hook(c, from_id, prefix)
+        if from_id:
+            title = rosie.browser.TITLE_NEW_SUITE_WIZARD_FROMID.format(from_id)
+        else:
+            title = rosie.browser.TITLE_NEW_SUITE_WIZARD_PREFIX.format(prefix)
         return self.suite_director.run_new_suite_wizard(
-            config, from_id, prefix, finish_func, self)
+            title, config, finish_func, self)
 
     def handle_delete(self, *args):
         """"Handles deletion of a suite."""

--- a/lib/python/rosie/browser/main.py
+++ b/lib/python/rosie/browser/main.py
@@ -131,7 +131,6 @@ class MainWindow(gtk.Window):
                               rosie.browser.PROGRAM_NAME))
         self.suite_engine_proc = SuiteEngineProcessor.get_processor(
             event_handler=self.handle_view_output_event)
-        self.prefix = SuiteId.get_prefix_default()
         rose.macro.add_site_meta_paths()
         rose.macro.add_env_meta_paths()
         self.show()
@@ -259,13 +258,13 @@ class MainWindow(gtk.Window):
         self.menubar.uimanager.get_widget(
             '/TopMenuBar/History/Show search history').set_active(False)
 
-    def _create_suite_hook(self, config, from_id=None):
+    def _create_suite_hook(self, config, from_id, prefix):
         """Hook function to create a suite from a configuration."""
         if config is None:
             return
         try:
             new_id = self.suite_director.vc_client.create(
-                config, from_id, self.prefix)
+                config, from_id, prefix)
         except Exception as exc:
             rose.gtk.dialog.run_dialog(rose.gtk.dialog.DIALOG_TYPE_ERROR,
                                        type(exc).__name__ + ": " + str(exc),
@@ -657,12 +656,31 @@ class MainWindow(gtk.Window):
 
     def handle_create(self, from_id=None):
         """Create a new suite."""
+        if from_id is None:
+            if len(self.ws_client.prefixes) > 1:
+                choices = {}
+                for value in self.ws_client.prefixes:
+                    key = value + " - " + SuiteId.get_prefix_location(value)
+                    choices[key] = value
+                choice = rose.gtk.dialog.run_choices_dialog(
+                    rosie.browser.DIALOG_MESSAGE_CREATE_PREFIX,
+                    sorted(choices.keys()),
+                    rosie.browser.DIALOG_TITLE_CREATE_PREFIX)
+                if choice is None:
+                    return
+                prefix = choices[choice]
+            elif self.ws_client.prefixes:
+                prefix = self.ws_client.prefixes[0]
+            else:
+                SuiteId.get_prefix_default()
+        else:
+            prefix = None
         config = self.suite_director.vc_client.generate_info_config(
-            from_id, self.prefix)
-        finish_func = functools.partial(self._create_suite_hook,
-                                        from_id=from_id)
+            from_id, prefix)
+        finish_func = functools.partial(
+            self._create_suite_hook, config, from_id, prefix)
         return self.suite_director.run_new_suite_wizard(
-            config, finish_func, self)
+            config, from_id, prefix, finish_func, self)
 
     def handle_delete(self, *args):
         """"Handles deletion of a suite."""

--- a/lib/python/rosie/browser/suite.py
+++ b/lib/python/rosie/browser/suite.py
@@ -184,12 +184,17 @@ class SuiteDirector():
         config = editor.output_config_objects()['/discovery']
         finish_function(config)
 
-    def run_new_suite_wizard(self, config, create_suite, parent_window,
-                             window=None):
+    def run_new_suite_wizard(self, config, from_id, prefix, create_suite,
+                             parent_window, window=None):
         """Run the suite wizard."""
         if window is None:
-            window = gtk.Dialog(title=rosie.browser.TITLE_NEW_SUITE_WIZARD,
-                                parent=parent_window)
+            if from_id:
+                title = rosie.browser.TITLE_NEW_SUITE_WIZARD_FROMID.format(
+                    from_id)
+            else:
+                title = rosie.browser.TITLE_NEW_SUITE_WIZARD_PREFIX.format(
+                    prefix)
+            window = gtk.Dialog(title=title, parent=parent_window)
             window.set_default_size(*rosie.browser.SIZE_WINDOW_NEW_SUITE)
             window.set_type_hint(gtk.gdk.WINDOW_TYPE_HINT_NORMAL)
             window.set_modal(False)
@@ -200,10 +205,8 @@ class SuiteDirector():
             window.destroy()
             return None
         config.set(["project"], project)
-        back_hook = lambda *a: self.run_new_suite_wizard(config,
-                                                         create_suite,
-                                                         parent_window,
-                                                         window)
+        back_hook = lambda *a: self.run_new_suite_wizard(
+            config, from_id, prefix, create_suite, parent_window, window)
         finish_hook = create_suite
         self._edit_config(config, window, back_hook, finish_hook)
 

--- a/lib/python/rosie/browser/suite.py
+++ b/lib/python/rosie/browser/suite.py
@@ -110,7 +110,7 @@ class SuiteDirector():
 
         return False
 
-    def _edit_config(self, config, window, back_function, finish_function):
+    def _edit_config(self, config, window, back_func, finish_func):
         project = config.get(["project"]).value
         config.set(["project"], project)
         meta_config = rose.macro.load_meta_config(config)
@@ -138,10 +138,10 @@ class SuiteDirector():
         ok_button.connect(
                   "clicked",
                   lambda b: self._finish_config(page_box, window,
-                                                editor, finish_function))
+                                                editor, finish_func))
         ok_button.show()
         back_button = gtk.Button(stock=gtk.STOCK_GO_BACK)
-        back_button.connect("clicked", back_function)
+        back_button.connect("clicked", back_func)
         back_button.show()
         cancel_button = gtk.Button(stock=gtk.STOCK_CANCEL)
         cancel_button.connect("clicked",
@@ -165,7 +165,7 @@ class SuiteDirector():
         vbox.grab_focus()
         window.resize(*rosie.browser.SIZE_WINDOW_NEW_SUITE_EDIT)
 
-    def _finish_config(self, page_container, window, editor, finish_function):
+    def _finish_config(self, page_container, window, editor, finish_func):
         page = page_container.get_children()[0]
         if page.validate_errors():
             ok_dialog = gtk.MessageDialog(
@@ -181,19 +181,12 @@ class SuiteDirector():
             if response != gtk.RESPONSE_ACCEPT:
                 return False
         window.destroy()
-        config = editor.output_config_objects()['/discovery']
-        finish_function(config)
+        finish_func(editor.output_config_objects()['/discovery'])
 
-    def run_new_suite_wizard(self, config, from_id, prefix, create_suite,
+    def run_new_suite_wizard(self, title, config, finish_func,
                              parent_window, window=None):
         """Run the suite wizard."""
         if window is None:
-            if from_id:
-                title = rosie.browser.TITLE_NEW_SUITE_WIZARD_FROMID.format(
-                    from_id)
-            else:
-                title = rosie.browser.TITLE_NEW_SUITE_WIZARD_PREFIX.format(
-                    prefix)
             window = gtk.Dialog(title=title, parent=parent_window)
             window.set_default_size(*rosie.browser.SIZE_WINDOW_NEW_SUITE)
             window.set_type_hint(gtk.gdk.WINDOW_TYPE_HINT_NORMAL)
@@ -205,10 +198,9 @@ class SuiteDirector():
             window.destroy()
             return None
         config.set(["project"], project)
-        back_hook = lambda *a: self.run_new_suite_wizard(
-            config, from_id, prefix, create_suite, parent_window, window)
-        finish_hook = create_suite
-        self._edit_config(config, window, back_hook, finish_hook)
+        back_func = lambda *a: self.run_new_suite_wizard(
+            title, config, finish_func, parent_window, window)
+        self._edit_config(config, window, back_func, finish_func)
 
     def _select_project(self, project, window):
         for child in window.action_area:


### PR DESCRIPTION
On issuing the command to create a new suite:
* If a single data source is selected, it will use the selected data
  source as the prefix of the new suite.
* If multiple data sources are selected, it will display a dialog box
  to allow the user to select a prefix from one of the data sources.

The title of the new suite info dialog will now display the prefix (for
a new create) or the from-id (for a copy).

@arjclark please review. Fix #1598.