### PR TITLE
fcm make 2: improve support

### DIFF
--- a/doc/rose-rug-task-run.html
+++ b/doc/rose-rug-task-run.html
@@ -423,7 +423,7 @@ delays=0,6*10s,60*1m,1h
       mirror target. To switch off this feature, set <var>STEP-NAME</var> to a
       null string, i.e. <kbd>mirror-step=</kbd>.</dd>
 
-      <dt><kbd>task-name-orig2cont=ORIG-NAME:CONT-NAME</kbd></dt>
+      <dt><kbd>orig-cont-map=ORIG-NAME:CONT-NAME</kbd></dt>
 
       <dd>This setting allows you to override the default <code>fcm_make</code>
       &rarr; <code>fcm_make2</code> mapping between the names of the original

--- a/doc/rose-rug-task-run.html
+++ b/doc/rose-rug-task-run.html
@@ -426,8 +426,8 @@ delays=0,6*10s,60*1m,1h
       <dt><kbd>task-name-orig2cont=ORIG-NAME:CONT-NAME</kbd></dt>
 
       <dd>This setting allows you to override the default <code>fcm_make</code>
-      &rarr; <code>fcm_make2</code> mapping the suite task names between the
-      original and the continuation.</dd>
+      &rarr; <code>fcm_make2</code> mapping between the names of the original
+      and the continuation tasks in the suite.</dd>
 
       <dt><kbd>use-pwd=true</kbd></dt>
 

--- a/doc/rose-rug-task-run.html
+++ b/doc/rose-rug-task-run.html
@@ -362,41 +362,80 @@ delays=0,6*10s,60*1m,1h
     <p>The <code>fcm_make</code> built-in applications is provided for running
     <code>fcm make</code>.</p>
 
-    <p>N.B. If a task has a name that starts with <var>fcm_make*</var>,
-    <code>rose task-run</code> will run this built-in application.</p>
+    <p>N.B.:</p>
+    
+    <ul>
+      <li>If a task has a name that contains the string <var>fcm_make</var>,
+      <code>rose task-run</code> will run this built-in application
+      automatically.</li>
 
-    <p>N.B. If a task has a name that starts with <var>fcm_make2*</var> and it
-    does not have its own application configuration, <code>rose task-run</code>
-    will attempt to associate it with the corresponding <var>fcm_make*</var>
-    application configuration.</p>
+      <li>N.B. If a task has a name that contains the string
+      <var>fcm_make2*</var> and it does not have its own application
+      configuration, <code>rose task-run</code> will attempt to associate it
+      with the corresponding <var>fcm_make*</var> application
+      configuration.</li>
+
+      <li>In the default setting, the <samp>bin/</samp> directories of builds
+      will be prepended to the <var>PATH</var> environment variable by
+      <code>rose task-env</code> and/or <code>rose task-run</code> commands run
+      by subsequent tasks in the suite.</li>
+    </ul>
 
     <p>The <code>fcm_make</code> application expects a file
     <var>file/fcm-make.cfg</var> in its application configuration. It runs
     <code>fcm make</code> using this configuration file.</p>
 
-    <p>The <code>fcm make</code> application will also look for a matching
-    <code>fcm_make2*</code> task in the suite which would normally be a
-    continuation of the <code>fcm make</code> command as a separate
-    <var>USER@HOST</var>. If so, will export an environment variable
-    <var>ROSE_TASK_MIRROR_TARGET</var> to the <code>fcm make</code> command to
-    substitute the mirror target.</p>
-
     <p>You can configure these applications with environment variables or
     settings in <var>rose-app.conf</var>. (Settings in <var>rose-app.conf</var>
     override their equivalent environment variables.)</p>
 
-    <p><kbd>use-pwd=true</kbd>: By default, the application changes the working
-    directory to <var>$ROSE_SUITE_DIR/share/$ROSE_TASK_NAME</var>. This option
-    will stop this, and the working directory is the normal working directory
-    of the task.</p>
+    <dl>
+      <dt><kbd>args=ARG ...</kbd> or the environment variable
+      <var>ROSE_TASK_OPTIONS</var></dt>
 
-    <p><kbd>opt.jobs=N</kbd> or the environment variable
-    <var>ROSE_TASK_N_JOBS</var>: This can be used to control the number of
-    processes <code>fcm make</code> would use in parallel. (default=4)</p>
+      <dd>This can be used to pass extra arguments to the <code>fcm make</code>
+      command.</dd>
 
-    <p><kbd>args</kbd> or the environment variable
-    <var>ROSE_TASK_OPTIONS</var>: This can be used to pass extra arguments to
-    the <code>fcm make</code> command.</p>
+      <dt><kbd>opt.jobs=N</kbd> or the environment variable
+      <var>ROSE_TASK_N_JOBS</var></dt>
+
+      <dd>This can be used to control the number of processes <code>fcm
+      make</code> would use in parallel. (default=4)</dd>
+
+      <dt><kbd>make-name-cont=NAME</kbd></dt>
+
+      <dd>Specify the context name of the continuation make. If the default
+      <code>fcm_make</code> &rarr; <code>fcm_make2</code> mapping is used, the
+      context name of the continuation make will be set to <code>2</code>. You
+      can specify an alternate context name if this is undesirable. The
+      continuation command will be invoked with the <code>--name=NAME</code>
+      option of <code>fcm make</code>.</dd>
+
+      <dt><kbd>mirror-step=STEP-NAME</kbd></dt>
+
+      <dd>Specify the name of the mirror step, if not <samp>mirror</samp>. The
+      application will normally look for a matching task in the suite (e.g.
+      <code>fcm_make</code> &rarr; <code>fcm_make2</code>) which will continue
+      the <code>fcm make</code> command at a remote <var>HOST</var>. If such a
+      task is found, it will add the configuration
+      <var>mirror.target=HOST:cylc-run/$ROSE_SUITE_NAME/share/$ROSE_TASK_NAME</var>
+      as an argument to the <code>fcm make</code> command to substitute the
+      mirror target. To switch off this feature, set <var>STEP-NAME</var> to a
+      null string, i.e. <kbd>mirror-step=</kbd>.</dd>
+
+      <dt><kbd>task-name-orig2cont=ORIG-NAME:CONT-NAME</kbd></dt>
+
+      <dd>This setting allows you to override the default <code>fcm_make</code>
+      &rarr; <code>fcm_make2</code> mapping the suite task names between the
+      original and the continuation.</dd>
+
+      <dt><kbd>use-pwd=true</kbd></dt>
+
+      <dd>By default, the application changes the working directory to
+      <var>$ROSE_SUITE_DIR/share/$ROSE_TASK_NAME</var>. This option will stop
+      this, and the working directory is the normal working directory of the
+      task.</dd>
+    </dl>
 
     <p>E.g.:</p>
     <pre class="prettyprint lang-rose_conf">
@@ -626,7 +665,7 @@ source=stuffing-*.txt
 
       <dt><kbd>prune-server-logs-at=cycle ...</kbd></dt>
 
-      <dd>Remove logs on the suite server. Removes both log directories and 
+      <dd>Remove logs on the suite server. Removes both log directories and
       archived logs.</dd>
 
       <dt><kbd>archive-logs-at=cycle ...</kbd></dt>

--- a/doc/rose-rug-task-run.html
+++ b/doc/rose-rug-task-run.html
@@ -393,8 +393,8 @@ delays=0,6*10s,60*1m,1h
       <dt><kbd>args=ARG ...</kbd> or the environment variable
       <var>ROSE_TASK_OPTIONS</var></dt>
 
-      <dd>This can be used to pass extra arguments to the <code>fcm make</code>
-      command.</dd>
+      <dd>This can be used to pass extra options and arguments to the <code>fcm
+      make</code> command.</dd>
 
       <dt><kbd>opt.jobs=N</kbd> or the environment variable
       <var>ROSE_TASK_N_JOBS</var></dt>

--- a/doc/rose-variables.html
+++ b/doc/rose-variables.html
@@ -439,8 +439,8 @@
 
     <h3>Description</h3>
 
-    <p>The mirror target for the mirror step in the <var>fcm-make.cfg</var>
-    configuration.</p>
+    <p>(Deprecated) The mirror target for the mirror step in the
+    <var>fcm-make.cfg</var> configuration.</p>
 
     <h3>Provided By</h3>
 

--- a/etc/rose-meta/fcm_make/HEAD/rose-meta.conf
+++ b/etc/rose-meta/fcm_make/HEAD/rose-meta.conf
@@ -16,7 +16,7 @@ description=Number of processes "fcm make" can use in parallel
 range=1:
 type=integer
 
-[=task-name-orig2cont]
+[=orig-cont-map]
 description=This setting allows you to override the default fcm_make:fcm_make2
            =mapping between the names of the original and the continuation
            =tasks in the suite.

--- a/etc/rose-meta/fcm_make/HEAD/rose-meta.conf
+++ b/etc/rose-meta/fcm_make/HEAD/rose-meta.conf
@@ -4,6 +4,9 @@ values=fcm_make
 [=args]
 description=Extra options or arguments to pass to "fcm make"
 
+[=make-name-cont]
+description=Specify the context name of the continuation make.
+
 [=mirror-step]
 description=Name of the mirror step (default="mirror")
            =Specify an empty string to switch off mirroring
@@ -12,6 +15,12 @@ description=Name of the mirror step (default="mirror")
 description=Number of processes "fcm make" can use in parallel
 range=1:
 type=integer
+
+[=task-name-orig2cont]
+description=This setting allows you to override the default fcm_make:fcm_make2
+           =mapping between the names of the original and the continuation
+           =tasks in the suite.
+pattern=[^:]*:[^:]*
 
 [=use-pwd]
 description=Use current working directory instead of

--- a/etc/rose-meta/fcm_make/HEAD/rose-meta.conf
+++ b/etc/rose-meta/fcm_make/HEAD/rose-meta.conf
@@ -4,6 +4,10 @@ values=fcm_make
 [=args]
 description=Extra options or arguments to pass to "fcm make"
 
+[=mirror-step]
+description=Name of the mirror step (default="mirror")
+           =Specify an empty string to switch off mirroring
+
 [=opt.jobs]
 description=Number of processes "fcm make" can use in parallel
 range=1:

--- a/lib/python/rose/task_env.py
+++ b/lib/python/rose/task_env.py
@@ -30,7 +30,7 @@ import sys
 import traceback
 
 PATH_GLOBS = {
-    "PATH": ["share/fcm[_-]make*/*/bin", "work/1/fcm[_-]make*/*/bin"],
+    "PATH": ["share/fcm[_-]make*/*/bin", "work/*/fcm[_-]make*/*/bin"],
 }
 
 

--- a/t/rose-task-run/18-app-fcm-make-ctx-name.t
+++ b/t/rose-task-run/18-app-fcm-make-ctx-name.t
@@ -1,0 +1,60 @@
+#!/bin/bash
+#-------------------------------------------------------------------------------
+# (C) British Crown Copyright 2012-5 Met Office.
+#
+# This file is part of Rose, a framework for meteorological suites.
+#
+# Rose is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Rose is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Rose. If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test fcm_make built-in application:
+# * alternate ctx name for continuation
+# * alternate mapping for original and continuation task names
+# On job host with or without shared file system
+#
+# N.B. Test requires compatible versions of "rose" and "fcm make" on the job
+#      host, as well as "gfortran" being installed and available there.
+#-------------------------------------------------------------------------------
+. $(dirname $0)/test_header
+if ! fcm help make 1>/dev/null 2>&1; then
+    skip_all 'fcm make unavailable'
+fi
+if [[ "${TEST_KEY_BASE}" == *-with-share ]]; then
+    JOB_HOST="$(rose config --default= 't' 'job-host-with-share')"
+else
+    JOB_HOST="$(rose config --default= 't' 'job-host')"
+fi
+if [[ -n "${JOB_HOST}" ]]; then
+    JOB_HOST="$(rose host-select "${JOB_HOST}")"
+fi
+if [[ -z "${JOB_HOST}" ]]; then
+    skip_all '"[t]job-host" not defined or not available'
+fi
+#-------------------------------------------------------------------------------
+tests 1
+export ROSE_CONF_PATH=
+mkdir -p "${HOME}/cylc-run"
+#-------------------------------------------------------------------------------
+SUITE_RUN_DIR="$(mktemp -d --tmpdir="${HOME}/cylc-run" 'rose-test-battery.XXXXXX')"
+NAME="$(basename "${SUITE_RUN_DIR}")"
+timeout 120 rose suite-run -v -v --debug \
+    -C "${TEST_SOURCE_DIR}/${TEST_KEY_BASE}" --name="${NAME}" \
+    --no-gcontrol --host='localhost' \
+    -D "[jinja2:suite.rc]HOST=\"${JOB_HOST}\"" -- --debug
+#-------------------------------------------------------------------------------
+ssh -n -oBatchMode=yes "${JOB_HOST}" \
+    cat "cylc-run/${NAME}/share/hello.txt" >'hello.txt'
+file_cmp "${TEST_KEY_BASE}" 'hello.txt' <<<'Hello World!'
+#-------------------------------------------------------------------------------
+rose suite-clean -q -y "${NAME}"
+exit 0

--- a/t/rose-task-run/18-app-fcm-make-ctx-name/app/make/file/fcm-make.cfg
+++ b/t/rose-task-run/18-app-fcm-make-ctx-name/app/make/file/fcm-make.cfg
@@ -1,0 +1,6 @@
+steps=extract mirror
+extract.ns=foo
+extract.location[foo]=$HERE/src
+mirror.prop{config-file.steps}=build
+build.target{task}=link
+build.prop{file-ext.bin}=

--- a/t/rose-task-run/18-app-fcm-make-ctx-name/app/make/file/src/hello.f90
+++ b/t/rose-task-run/18-app-fcm-make-ctx-name/app/make/file/src/hello.f90
@@ -1,0 +1,3 @@
+program hello
+write(*, '(a)') 'Hello World!'
+end program hello

--- a/t/rose-task-run/18-app-fcm-make-ctx-name/app/make/rose-app.conf
+++ b/t/rose-task-run/18-app-fcm-make-ctx-name/app/make/rose-app.conf
@@ -1,4 +1,4 @@
 meta=fcm_make
 mode=fcm_make
 make-name-cont=-bin
-task-name-orig2cont=make:make-bin
+orig-cont-map=make:make-bin

--- a/t/rose-task-run/18-app-fcm-make-ctx-name/app/make/rose-app.conf
+++ b/t/rose-task-run/18-app-fcm-make-ctx-name/app/make/rose-app.conf
@@ -1,0 +1,4 @@
+meta=fcm_make
+mode=fcm_make
+make-name-cont=-bin
+task-name-orig2cont=make:make-bin

--- a/t/rose-task-run/18-app-fcm-make-ctx-name/app/run/rose-app.conf
+++ b/t/rose-task-run/18-app-fcm-make-ctx-name/app/run/rose-app.conf
@@ -1,0 +1,2 @@
+[command]
+default=hello | tee $ROSE_SUITE_DIR/share/hello.txt

--- a/t/rose-task-run/18-app-fcm-make-ctx-name/suite.rc
+++ b/t/rose-task-run/18-app-fcm-make-ctx-name/suite.rc
@@ -1,0 +1,23 @@
+#!jinja2
+[cylc]
+    UTC mode = True
+[scheduling]
+    [[dependencies]]
+        graph = """hello-make => hello-make-bin => hello-run"""
+
+[runtime]
+    [[root]]
+        [[[event hooks]]]
+            failed handler = rose suite-hook --shutdown
+    [[MAKE]]
+        script = rose task-run --app-key=make
+    [[hello-make]]
+        inherit = MAKE
+    [[hello-make-bin]]
+        inherit = MAKE
+        [[[remote]]]
+            host = {{HOST}}
+    [[hello-run]]
+        script = rose task-run --app-key=run --path=share/hello-make/build/bin
+        [[[remote]]]
+            host = {{HOST}}

--- a/t/rose-task-run/19-app-fcm-make-ctx-name-with-share
+++ b/t/rose-task-run/19-app-fcm-make-ctx-name-with-share
@@ -1,0 +1,1 @@
+18-app-fcm-make-ctx-name

--- a/t/rose-task-run/19-app-fcm-make-ctx-name-with-share.t
+++ b/t/rose-task-run/19-app-fcm-make-ctx-name-with-share.t
@@ -1,0 +1,1 @@
+18-app-fcm-make-ctx-name.t


### PR DESCRIPTION
Add `mirror.target=` to `fcm make` argument list as extra configuration, instead of relying on environment variables. This should work as long as we are on FCM 2014-03 or above.

Use `-n 2` option of `fcm make` where relevant - this allows the continuation make to be in the same physical location.

New functionality dependent on metomi/fcm#188, but change should otherwise be backward compatible.