### PR TITLE
Removed an obsolete import.

### DIFF
--- a/lib/python/rose/config_editor/pagewidget/__init__.py
+++ b/lib/python/rose/config_editor/pagewidget/__init__.py
@@ -18,5 +18,4 @@
 # along with Rose. If not, see <http://www.gnu.org/licenses/>.
 #-----------------------------------------------------------------------------
 
-import chooser
 import table


### PR DESCRIPTION
```lib/python/rose/config_editor/pagewidget/__init__.py``` tries to import  ```chooser```, which was deleted by 20e2dc78a24ff034bdbf76874574c20aea613863

(although maybe I've missed something as evidently this didn't break your Rose installation?)