### PR TITLE
rose.env.env_export: report 1st time and on change

### DIFF
--- a/t/rose.env/00-export.t
+++ b/t/rose.env/00-export.t
@@ -1,0 +1,23 @@
+#!/bin/bash
+#-----------------------------------------------------------------------------
+# (C) British Crown Copyright 2012-5 Met Office.
+#
+# This file is part of Rose, a framework for meteorological suites.
+#
+# Rose is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Rose is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Rose. If not, see <http://www.gnu.org/licenses/>.
+#-----------------------------------------------------------------------------
+. "$(dirname "$0")/test_header"
+tests 1
+run_pass "${TEST_KEY_BASE}" python -m "rose.env" "$@"
+exit 0

--- a/t/rose.env/test_header
+++ b/t/rose.env/test_header
@@ -1,0 +1,1 @@
+../lib/bash/test_header


### PR DESCRIPTION
E.g. This fixes `rose task-run` reporting `export PATH=...` twice.

@kaday please review.