### PR TITLE
t: fix logic to get temp dir in job host

### DIFF
--- a/t/rose-app-run/12-file-incr-3.t
+++ b/t/rose-app-run/12-file-incr-3.t
@@ -31,7 +31,7 @@ tests 9
 #-------------------------------------------------------------------------------
 set -e
 JOB_HOST=$(rose host-select $JOB_HOST)
-JOB_HOST_TEST_DIR=$(ssh -oBatchMode=yes $JOB_HOST "bash -l -c 'mktemp -d'")
+JOB_HOST_TEST_DIR=$(ssh -oBatchMode=yes $JOB_HOST 'TMPDIR=$HOME mktemp -d')
 JOB_HOST_TEST_DIR=$(tail -1 <<<"$JOB_HOST_TEST_DIR")
 MY_FINALLY() {
     FINALLY "$@"


### PR DESCRIPTION
Using `bash -l` may not work if temp dir gets removed at end of session.

@benfitzpatrick please review.