### PR TITLE
rose edit: fix value hints widget initialisation

### DIFF
--- a/lib/python/rose/config_editor/valuewidget/valuehints.py
+++ b/lib/python/rose/config_editor/valuewidget/valuehints.py
@@ -31,7 +31,7 @@ import rose.variable
 class HintsValueWidget(gtk.HBox):
     """This class generates a widget for entering value-hints."""
 
-    def __init__(self, value, metadata, set_value, hook):
+    def __init__(self, value, metadata, set_value, hook, arg_str=None):
         super(HintsValueWidget, self).__init__(homogeneous=False, spacing=0)
         self.value = value
         self.metadata = metadata


### PR DESCRIPTION
This fixes a traceback for a `value-hints` widget:
```
  File "/opt/rose/lib/python/rose/config_editor/variable.py", line 73, in __init__
    self.generate_valuewidget(variable)
  File "/opt/rose/lib/python/rose/config_editor/variable.py", line 197, in generate_valuewidget
    hook_object, custom_arg)
TypeError: __init__() takes exactly 5 arguments (6 given)
```

@kaday, please review.