### PR TITLE
rose config-edit: source widget: import essentials

### DIFF
--- a/lib/python/rose/config_editor/valuewidget/source.py
+++ b/lib/python/rose/config_editor/valuewidget/source.py
@@ -25,7 +25,10 @@ import pygtk
 pygtk.require('2.0')
 import gtk
 
+import rose.config
 import rose.config_editor
+import rose.formats
+import rose.gtk.choice
 
 
 class SourceValueWidget(gtk.HBox):


### PR DESCRIPTION
Ensure that essential modules are imported. Close #1627.

@arjclark please review.