### PR TITLE
rosie.ws_client: improve diagnostics on null conf

### DIFF
--- a/lib/python/rosie/browser/main.py
+++ b/lib/python/rosie/browser/main.py
@@ -83,7 +83,7 @@ class MainWindow(gtk.Window):
             rose.gtk.dialog.run_dialog(
                 rose.gtk.dialog.DIALOG_TYPE_ERROR,
                 str(exc),
-                str(exc))
+                rosie.browser.TITLE_ERROR)
             sys.exit(1)
         except UndefinedRosiePrefixWS as exc:
             prefix = exc.args[0]

--- a/lib/python/rosie/browser/main.py
+++ b/lib/python/rosie/browser/main.py
@@ -58,7 +58,8 @@ import rosie.browser.suite
 import rosie.browser.util
 from rosie.suite_id import SuiteId, SuiteIdError
 import rosie.vc
-from rosie.ws_client import RosieWSClient, RosieWSClientError
+from rosie.ws_client import (
+    RosieWSClient, RosieWSClientError, RosieWSClientConfError)
 from rosie.ws_client_auth import UndefinedRosiePrefixWS
 
 
@@ -77,6 +78,13 @@ class MainWindow(gtk.Window):
                               rosie.browser.SPLASH_SEARCH_MANAGER))
         try:
             self.ws_client = RosieWSClient(opts.prefixes)
+        except RosieWSClientConfError as exc:
+            splash_updater.stop()
+            rose.gtk.dialog.run_dialog(
+                rose.gtk.dialog.DIALOG_TYPE_ERROR,
+                str(exc),
+                str(exc))
+            sys.exit(1)
         except UndefinedRosiePrefixWS as exc:
             prefix = exc.args[0]
             splash_updater.stop()

--- a/lib/python/rosie/ws_client.py
+++ b/lib/python/rosie/ws_client.py
@@ -37,6 +37,14 @@ import simplejson
 from time import sleep
 
 
+class RosieWSClientConfError(Exception):
+
+    """Raised if no Rosie service server is configured."""
+
+    def __str__(self):
+        return "[rosie-id] settings not defined in site/user configuration."
+
+
 class RosieWSClientError(Exception):
 
     """Raised if no data were retrieved from the server."""
@@ -73,13 +81,14 @@ class RosieWSClient(object):
         self.auth_managers = {}
         conf = ResourceLocator.default().get_conf()
         conf_rosie_id = conf.get(["rosie-id"], no_ignore=True)
-        if conf_rosie_id is not None:
-            for key, node in conf_rosie_id.value.items():
-                if node.is_ignored() or not key.startswith("prefix-ws."):
-                    continue
-                prefix = key.replace("prefix-ws.", "")
-                self.auth_managers[prefix] = RosieWSClientAuthManager(
-                    prefix, popen=self.popen, prompt_func=self.prompt_func)
+        if conf_rosie_id is None:
+            raise RosieWSClientConfError()
+        for key, node in conf_rosie_id.value.items():
+            if node.is_ignored() or not key.startswith("prefix-ws."):
+                continue
+            prefix = key.replace("prefix-ws.", "")
+            self.auth_managers[prefix] = RosieWSClientAuthManager(
+                prefix, popen=self.popen, prompt_func=self.prompt_func)
         if not prefixes:
             prefixes_str = conf_rosie_id.get_value(["prefixes-ws-default"])
             if prefixes_str:

--- a/lib/python/rosie/ws_client_cli.py
+++ b/lib/python/rosie/ws_client_cli.py
@@ -23,7 +23,8 @@
 import os
 import re
 from rosie.suite_id import SuiteId
-from rosie.ws_client import RosieWSClient, RosieWSClientError
+from rosie.ws_client import (
+    RosieWSClient, RosieWSClientError, RosieWSClientConfError)
 from rosie.ws_client_auth import UndefinedRosiePrefixWS
 from rose.opt_parse import RoseOptionParser
 from rose.popen import RosePopenError
@@ -262,7 +263,8 @@ def main():
         sys.exit(func(argv[1:]))
     except KeyboardInterrupt:
         pass
-    except (RosieWSClientError, UndefinedRosiePrefixWS) as exc:
+    except (RosieWSClientError, RosieWSClientConfError,
+            UndefinedRosiePrefixWS) as exc:
         sys.exit(str(exc))
 
 

--- a/t/rosie-hello/00-null.t
+++ b/t/rosie-hello/00-null.t
@@ -1,0 +1,31 @@
+#!/bin/bash
+#-------------------------------------------------------------------------------
+# (C) British Crown Copyright 2012-5 Met Office.
+#
+# This file is part of Rose, a framework for meteorological suites.
+#
+# Rose is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Rose is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Rose. If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test "rosie hello" with no settings.
+#-------------------------------------------------------------------------------
+. $(dirname $0)/test_header
+tests 2
+
+export ROSE_CONF_PATH=
+run_fail "${TEST_KEY_BASE}" rosie hello
+file_cmp "${TEST_KEY_BASE}.err" "${TEST_KEY_BASE}.err" <<'__ERR__'
+[rosie-id] settings not defined in site/user configuration.
+__ERR__
+
+exit

--- a/t/rosie-hello/test_header
+++ b/t/rosie-hello/test_header
@@ -1,0 +1,1 @@
+../lib/bash/test_header


### PR DESCRIPTION
Return a friendlier error message when no [rosie-id] settings are defined in
the site/user configuration.

Close #1634.