### PR TITLE
rose edit: array widgets: protect against unsaved null text

### DIFF
--- a/lib/python/rose/config_editor/valuewidget/array/entry.py
+++ b/lib/python/rose/config_editor/valuewidget/array/entry.py
@@ -113,6 +113,8 @@ class EntryArrayValueWidget(gtk.HBox):
             elif self.is_quoted_array:
                 val = rose.config_editor.util.text_from_quoted_widget(val)
             prefix = get_next_delimiter(self.value[len(text):], val)
+            if prefix is None:
+                return None
             if entry == self.entry_table.focus_child:
                 return len(text + prefix) + entry.get_position()
             text += prefix + val
@@ -129,6 +131,8 @@ class EntryArrayValueWidget(gtk.HBox):
             v = self.value[j:].index(val)
             prefix = get_next_delimiter(self.value[len(text):],
                                         val)
+            if prefix is None:
+                return
             if (len(text + prefix + val) >= focus_index or
                 i == len(value_array) - 1):
                 if len(self.entries) > i:
@@ -454,7 +458,11 @@ class EntryArrayValueWidget(gtk.HBox):
 
 def get_next_delimiter(array_text, next_element):
     """Return the part of array_text immediately preceding next_element."""
-    v = array_text.index(next_element)
+    try:
+        v = array_text.index(next_element)
+    except ValueError:
+        # Substring not found.
+        return
     if v == 0 and len(array_text) > 1:  # Null or whitespace element.
         while array_text[v].isspace():
             v += 1

--- a/lib/python/rose/config_editor/valuewidget/array/mixed.py
+++ b/lib/python/rose/config_editor/valuewidget/array/mixed.py
@@ -26,6 +26,7 @@ pygtk.require('2.0')
 import gtk
 import pango
 
+from . import entry
 import rose.gtk.util
 import rose.variable
 
@@ -146,8 +147,10 @@ class MixedArrayValueWidget(gtk.HBox):
         for r, widget_list in enumerate(self.rows):
             for i, widget in enumerate(widget_list):
                 val = self.value_array[r * self.num_cols + i]
-                prefix_text = get_next_delimiter(self.value[len(text):],
-                                                 val)
+                prefix_text = entry.get_next_delimiter(self.value[len(text):],
+                                                       val)
+                if prefix_text is None:
+                    return
                 if widget == self.entry_table.focus_child:
                     if hasattr(widget, "get_focus_index"):
                         position = widget.get_focus_index()
@@ -180,8 +183,10 @@ class MixedArrayValueWidget(gtk.HBox):
                 widgets[0].set_focus_index(focus_index)
             return
         for i, val in enumerate(value_array):
-            prefix = get_next_delimiter(self.value[len(text):],
-                                        val)
+            prefix = entry.get_next_delimiter(self.value[len(text):],
+                                              val)
+            if prefix is None:
+                return
             if len(text + prefix + val) >= focus_index:
                 if len(widgets) > i:
                     widgets[i].grab_focus()
@@ -382,13 +387,3 @@ class ArrayElementSetter(object):
 
     def set_value(self, value):
         self.setter_function(self.index, value)
-
-
-def get_next_delimiter(array_text, next_element):
-    v = array_text.index(next_element)
-    if v == 0 and len(array_text) > 1:  # Null or whitespace element.
-        while array_text[v].isspace():
-            v += 1
-        if array_text[v] == ",":
-            v += 1
-    return array_text[:v]

--- a/lib/python/rose/config_editor/valuewidget/array/python_list.py
+++ b/lib/python/rose/config_editor/valuewidget/array/python_list.py
@@ -27,6 +27,7 @@ pygtk.require('2.0')
 import gtk
 import pango
 
+from . import entry
 import rose.config_editor.util
 import rose.gtk.util
 import rose.variable
@@ -86,11 +87,13 @@ class PythonListValueWidget(gtk.HBox):
         if not self.value.startswith("["):
             return
         text = '['
-        for entry in self.entries:
-            val = entry.get_text()
-            prefix = get_next_delimiter(self.value[len(text):], val)
-            if entry == self.entry_table.focus_child:
-                return len(text + prefix) + entry.get_position()
+        for my_entry in self.entries:
+            val = my_entry.get_text()
+            prefix = entry.get_next_delimiter(self.value[len(text):], val)
+            if prefix is None:
+                return
+            if my_entry == self.entry_table.focus_child:
+                return len(text + prefix) + my_entry.get_position()
             text += prefix + val
         return None
 
@@ -105,8 +108,10 @@ class PythonListValueWidget(gtk.HBox):
         for i, val in enumerate(value_array):
             j = len(text)
             v = self.value[j:].index(val)
-            prefix = get_next_delimiter(self.value[len(text):],
-                                        val)
+            prefix = entry.get_next_delimiter(self.value[len(text):],
+                                              val)
+            if prefix is None:
+                return
             if (len(text + prefix + val) >= focus_index or
                 i == len(value_array) - 1):
                 if len(self.entries) > i:
@@ -412,16 +417,6 @@ class PythonListValueWidget(gtk.HBox):
         if event.button == 2:
             self.setter(widget)
         return False
-
-
-def get_next_delimiter(array_text, next_element):
-    v = array_text.index(next_element)
-    if v == 0 and len(array_text) > 1:  # Null or whitespace element.
-        while array_text[v].isspace():
-            v += 1
-        if array_text[v] == ",":
-            v += 1
-    return array_text[:v]
 
 
 def python_array_join(values):

--- a/lib/python/rose/config_editor/valuewidget/array/row.py
+++ b/lib/python/rose/config_editor/valuewidget/array/row.py
@@ -26,6 +26,7 @@ pygtk.require('2.0')
 import gtk
 import pango
 
+from . import entry
 import rose.gtk.util
 import rose.variable
 
@@ -176,8 +177,10 @@ class RowArrayValueWidget(gtk.HBox):
                 if value_index > len(self.value_array) - 1:
                     return len(text)
                 val = self.value_array[r * self.num_cols + i]
-                prefix_text = get_next_delimiter(self.value[len(text):],
-                                                 val)
+                prefix_text = entry.get_next_delimiter(self.value[len(text):],
+                                                       val)
+                if prefix_text is None:
+                    return
                 if widget == self.entry_table.focus_child:
                     if hasattr(widget, "get_focus_index"):
                         position = widget.get_focus_index()
@@ -209,8 +212,10 @@ class RowArrayValueWidget(gtk.HBox):
                 widgets[0].set_focus_index(focus_index)
             return
         for i, val in enumerate(value_array):
-            prefix = get_next_delimiter(self.value[len(text):],
-                                        val)
+            prefix = entry.get_next_delimiter(self.value[len(text):],
+                                              val)
+            if prefix_text is None:
+                return
             if len(text + prefix + val) >= focus_index:
                 if len(widgets) > i:
                     widgets[i].grab_focus()
@@ -464,13 +469,3 @@ class ArrayElementSetter(object):
 
     def set_value(self, value):
         self.setter_function(self.index, value)
-
-
-def get_next_delimiter(array_text, next_element):
-    v = array_text.index(next_element)
-    if v == 0 and len(array_text) > 1:  # Null or whitespace element.
-        while array_text[v].isspace():
-            v += 1
-        if array_text[v] == ",":
-            v += 1
-    return array_text[:v]

--- a/lib/python/rose/config_editor/valuewidget/array/spaced_list.py
+++ b/lib/python/rose/config_editor/valuewidget/array/spaced_list.py
@@ -85,11 +85,13 @@ class SpacedListValueWidget(gtk.HBox):
     def get_focus_index(self):
         """Get the focus and position within the table of entries."""
         text = ''
-        for entry in self.entries:
-            val = entry.get_text()
+        for my_entry in self.entries:
+            val = my_entry.get_text()
             prefix = get_next_delimiter(self.value[len(text):], val)
-            if entry == self.entry_table.focus_child:
-                return len(text + prefix) + entry.get_position()
+            if prefix is None:
+                return
+            if my_entry == self.entry_table.focus_child:
+                return len(text + prefix) + my_entry.get_position()
             text += prefix + val
         return None
 
@@ -407,7 +409,10 @@ class SpacedListValueWidget(gtk.HBox):
 
 def get_next_delimiter(array_text, next_element):
     """Return the part of array_text immediately preceding next_element."""
-    v = array_text.index(next_element)
+    try:
+        v = array_text.index(next_element)
+    except ValueError:
+        return
     return array_text[:v]
 
 


### PR DESCRIPTION
This fixes an edge case where an array widget causes a crash on error checking when
the variable has a null value but the widget has a null character string. This is allowed for
compulsory character type variables.

The traceback can be reproduced via having a `rose-app.conf` file that looks like this:
```ini
[env]
FOO=
```
and a `rose-meta.conf` file that looks like this:
```ini
[env=FOO]
compulsory=true
fail-if=true
length=:
type=character
```
Open in `rose edit`, navigate to the environment, click to add (the first) array element, and then click "Run all validators" in the toolbar. This will produce a traceback that looks like this:

```
Traceback (most recent call last):
  File "/opt/rose/lib/python/rose/gtk/util.py", line 294, in <lambda>
    lambda b: function())
  File "/opt/rose/lib/python/rose/config_editor/menu.py", line 411, in check_all_extra
    num_errors = self.check_fail_rules(configs_updated=True)
  File "/opt/rose/lib/python/rose/config_editor/menu.py", line 457, in check_fail_rules
    no_display=(not return_value))
  File "/opt/rose/lib/python/rose/config_editor/menu.py", line 938, in handle_macro_validation
    self.apply_macro_validation(config_name, macro_type, problem_list)
  File "/opt/rose/lib/python/rose/config_editor/main.py", line 1278, in apply_macro_validation
    self.updater.apply_macro_validation(*args, **kwargs)
  File "/opt/rose/lib/python/rose/config_editor/updater.py", line 754, in apply_macro_validation
    are_errors_done=is_macro_dynamic)
  File "/opt/rose/lib/python/rose/config_editor/updater.py", line 155, in refresh_ids
    page.refresh(changed_id)
  File "/opt/rose/lib/python/rose/config_editor/page.py", line 760, in refresh
    return self.handle_reload_var_widget(variable)
  File "/opt/rose/lib/python/rose/config_editor/page.py", line 781, in handle_reload_var_widget
    self.main_container.reload_variable_widget(variable)
  File "/opt/rose/lib/python/rose/config_editor/pagewidget/table.py", line 133, in reload_variable_widget
    focus_dict["index"] = variable_widget.get_focus_index()
  File "/opt/rose/lib/python/rose/config_editor/variable.py", line 421, in get_focus_index
    return self.valuewidget.get_focus_index()
  File "/opt/rose/lib/python/rose/config_editor/valuewidget/array/entry.py", line 115, in get_focus_index
    prefix = get_next_delimiter(self.value[len(text):], val)
  File "/opt/rose/lib/python/rose/config_editor/valuewidget/array/entry.py", line 457, in get_next_delimiter
    v = array_text.index(next_element)
ValueError: substring not found
```

This only really applies to character array widgets (`entry.py` in character mode) and maybe derived type widgets (`mixed.py`) with character sub-types, but I've added fixes for all of this type of array widgets. It's not worth falling over for a simple focus index (where is my cursor) problem.