### PR TITLE
rose edit: speed up macro changes

### DIFF
--- a/lib/python/rose/config.py
+++ b/lib/python/rose/config.py
@@ -417,6 +417,17 @@ class ConfigNodeDiff(object):
             set(self._data[self.KEY_MODIFIED]) |
             set(self._data[self.KEY_REMOVED]))
 
+    def get_reversed(self):
+        """Return an inverse (add->remove, etc) copy of this diff."""
+        rev_diff = ConfigNodeDiff()
+        for keys, data in self.get_removed():
+            rev_diff.set_added_setting(keys, data)
+        for keys, data in self.get_modified():
+            rev_diff.set_modified_setting(keys, data[1], data[0])
+        for keys, data in self.get_added():
+            rev_diff.set_removed_setting(keys, data)
+        return rev_diff
+
 
 class ConfigDumper(object):
 

--- a/lib/python/rose/config_editor/__init__.py
+++ b/lib/python/rose/config_editor/__init__.py
@@ -436,6 +436,7 @@ STACK_GROUP_REORDER = "Reorder"
 STACK_ACTION_ADDED = "Added"
 STACK_ACTION_CHANGED = "Changed"
 STACK_ACTION_CHANGED_COMMENTS = "Changed #"
+STACK_ACTION_DIFF = "Patched"
 STACK_ACTION_ENABLED = "Enabled"
 STACK_ACTION_IGNORED = "Ignored"
 STACK_ACTION_REMOVED = "Removed"
@@ -447,11 +448,13 @@ COLOUR_STACK_ADDED = "green"
 COLOUR_STACK_CHANGED = "blue"
 # Configure the colour for 'changed comments' action.
 COLOUR_STACK_CHANGED_COMMENTS = "dark blue"
-# Configure the colour for 'light green' action.
+# Configure the colour for 'apply a diff from a macro' action.
+COLOUR_STACK_DIFF = "purple"
+# Configure the colour for 'enabled' action.
 COLOUR_STACK_ENABLED = "light green"
-# Configure the colour for 'grey' action.
+# Configure the colour for 'ignore' action.
 COLOUR_STACK_IGNORED = "grey"
-# Configure the colour for 'red' action.
+# Configure the colour for 'remove' action.
 COLOUR_STACK_REMOVED = "red"
 
 # User-relevant: Macro Dialog Colours

--- a/lib/python/rose/config_editor/__init__.py
+++ b/lib/python/rose/config_editor/__init__.py
@@ -434,28 +434,31 @@ STACK_GROUP_RENAME = "Rename"
 STACK_GROUP_REORDER = "Reorder"
 
 STACK_ACTION_ADDED = "Added"
+STACK_ACTION_APPLIED = "Applied"
 STACK_ACTION_CHANGED = "Changed"
 STACK_ACTION_CHANGED_COMMENTS = "Changed #"
-STACK_ACTION_DIFF = "Patched"
 STACK_ACTION_ENABLED = "Enabled"
 STACK_ACTION_IGNORED = "Ignored"
 STACK_ACTION_REMOVED = "Removed"
+STACK_ACTION_REVERSED = "Reversed"
 
 # User-relevant: Undo/Redo Stack Viewer Colours
 # Configure the colour for 'added' action.
 COLOUR_STACK_ADDED = "green"
+# Configure the colour for 'applied a diff' action.
+COLOUR_STACK_APPLIED = "green"
 # Configure the colour for 'changed' action.
 COLOUR_STACK_CHANGED = "blue"
 # Configure the colour for 'changed comments' action.
 COLOUR_STACK_CHANGED_COMMENTS = "dark blue"
-# Configure the colour for 'apply a diff from a macro' action.
-COLOUR_STACK_DIFF = "purple"
 # Configure the colour for 'enabled' action.
 COLOUR_STACK_ENABLED = "light green"
 # Configure the colour for 'ignore' action.
 COLOUR_STACK_IGNORED = "grey"
 # Configure the colour for 'remove' action.
 COLOUR_STACK_REMOVED = "red"
+# Configure the colour for 'revert a diff' action.
+COLOUR_STACK_REVERSED = "red"
 
 # User-relevant: Macro Dialog Colours
 # Configure the colour for 'changed' action.

--- a/lib/python/rose/config_editor/main.py
+++ b/lib/python/rose/config_editor/main.py
@@ -205,6 +205,7 @@ class MainController(object):
             self.undo_stack, self.redo_stack,
             self.check_cannot_enable_setting,
             self.update_namespace,
+            self.update_namespace_sub_data,
             self.update_ns_info,
             update_tree_func=self.reload_namespace_tree,
             view_page_func=self.view_page,
@@ -240,6 +241,7 @@ class MainController(object):
             self.update_config,
             self.apply_macro_transform,
             self.apply_macro_validation,
+            self.group_ops,
             self.section_ops,
             self.variable_ops,
             self.perform_find_by_ns_id
@@ -822,6 +824,7 @@ class MainController(object):
             self.undo_stack, self.redo_stack,
             self.check_cannot_enable_setting,
             self.updater.update_namespace,
+            self.updater.update_ns_sub_data,
             self.updater.update_ns_info,
             update_tree_func=self.reload_namespace_tree,
             view_page_func=self.view_page,
@@ -1083,6 +1086,10 @@ class MainController(object):
     def update_namespace(self, *args, **kwargs):
         """Placeholder for updater function of the same name."""
         self.updater.update_namespace(*args, **kwargs)
+
+    def update_namespace_sub_data(self, *args, **kwargs):
+        """Placeholder for updater function of the same name."""
+        self.updater.update_ns_sub_data(*args, **kwargs)
 
     def update_ns_info(self, *args, **kwargs):
         """Placeholder for updater function of the same name."""
@@ -1715,7 +1722,11 @@ class MainController(object):
         for stack_item in do_list:
             action = stack_item.action
             node = stack_item.node
-            node_id = node.metadata.get('id')
+            node_id = None
+            try:
+                node_id = node.metadata['id']
+            except (AttributeError, KeyError):
+                pass
             # We need to handle namespace and metadata changes
             if node_id is None:
                 # Not a variable or section
@@ -1928,7 +1939,7 @@ def main():
                                         metadata_off=opts.no_metadata)""",
                         globals(), locals(), f.name)
         p = pstats.Stats(f.name)
-        p.strip_dirs().sort_stats("cumulative").print_stats(50)
+        p.strip_dirs().sort_stats("cumulative").print_stats(100)
         f.close()
     else:
         spawn_window(cwd, debug_mode=opts.debug_mode,

--- a/lib/python/rose/config_editor/main.py
+++ b/lib/python/rose/config_editor/main.py
@@ -1798,9 +1798,14 @@ class MainController(object):
                 self.update_bar_widgets()
                 self.updater.update_stack_viewer_if_open()
             if not is_group:
-                self.updater.focus_sub_page_if_open(namespace, node_id)
+                if namespace is not None:
+                    self.updater.focus_sub_page_if_open(namespace, node_id)
+                if node_id is None:
+                    title = stack_item.name
+                else:
+                    title = node_id
                 id_text = rose.config_editor.EVENT_UNDO_ACTION_ID.format(
-                    action, node_id)
+                    action, title)
                 self.reporter.report(event_text.format(id_text))
         if is_group:
             group_name = do_list[0].group.split("-")[0]

--- a/lib/python/rose/config_editor/main.py
+++ b/lib/python/rose/config_editor/main.py
@@ -1944,7 +1944,7 @@ def main():
                                         metadata_off=opts.no_metadata)""",
                         globals(), locals(), f.name)
         p = pstats.Stats(f.name)
-        p.strip_dirs().sort_stats("cumulative").print_stats(100)
+        p.strip_dirs().sort_stats("cumulative").print_stats()
         f.close()
     else:
         spawn_window(cwd, debug_mode=opts.debug_mode,

--- a/lib/python/rose/config_editor/nav_controller.py
+++ b/lib/python/rose/config_editor/nav_controller.py
@@ -35,6 +35,8 @@ class NavTreeManager(object):
 
     def is_ns_in_tree(self, ns):
         """Determine if the namespace is in the tree or not."""
+        if ns is None:
+            return False
         spaces = ns.lstrip('/').split('/')
         subtree = self.namespace_tree
         while spaces:

--- a/lib/python/rose/config_editor/ops/group.py
+++ b/lib/python/rose/config_editor/ops/group.py
@@ -150,22 +150,10 @@ class GroupOperations(object):
                         rose.variable.IGNORED_BY_USER not in reason):
                     # Enable from user-ignored.
                     is_ignored = False
-                    nses.extend(
-                        self.sect_ops.ignore_section(config_name, sect, False,
-                                                     override=True,
-                                                     skip_update=True,
-                                                     skip_undo=True)
-                    )
                 elif (rose.variable.IGNORED_BY_USER not in old_reason and
                           rose.variable.IGNORED_BY_USER in reason):
                     # User-ignore from enabled.
                     is_ignored = True
-                    nses.extend(
-                        self.sect_ops.ignore_section(config_name, sect, True,
-                                                     override=True,
-                                                     skip_update=True,
-                                                     skip_undo=True)
-                    )
                 elif (triggers_ok and
                           rose.variable.IGNORED_BY_SYSTEM not in old_reason
                           and rose.variable.IGNORED_BY_SYSTEM in reason):
@@ -174,12 +162,6 @@ class GroupOperations(object):
                               rose.config_editor.WARNING_TYPE_ENABLED,
                               rose.config_editor.IGNORED_STATUS_MACRO)
                     is_ignored = True
-                    nses.extend(
-                        self.sect_ops.ignore_section(config_name, sect, True,
-                                                     override=True,
-                                                     skip_update=True,
-                                                     skip_undo=True)
-                    )
                 elif (triggers_ok and
                           rose.variable.IGNORED_BY_SYSTEM in old_reason and
                           rose.variable.IGNORED_BY_SYSTEM not in reason):
@@ -191,13 +173,15 @@ class GroupOperations(object):
                 else:
                     ignored_changed = False
                 if ignored_changed:
-                    nses.extend(
+                    ignore_nses, ignore_ids = (
                         self.sect_ops.ignore_section(config_name, sect,
                                                      is_ignored,
                                                      override=True,
                                                      skip_update=True,
                                                      skip_undo=True)
                     )
+                    nses.extend(ignore_nses)
+                    ids.extend(ignore_ids)
             elif set(reason) != set(old_reason):
                 nses.append(
                     self.var_ops.set_var_ignored(var, new_reason_dict=reason,

--- a/lib/python/rose/config_editor/ops/section.py
+++ b/lib/python/rose/config_editor/ops/section.py
@@ -132,6 +132,8 @@ class SectionOperations(object):
         config_data = self.__data.config[config_name]
         sect_data = config_data.sections.now[section]
         nses_to_do = [sect_data.metadata["full_ns"]]
+        ids_to_do = [section]
+
         if is_ignored:
             # User-ignore request for this section.
             # The section must be enabled and optional.
@@ -179,6 +181,7 @@ class SectionOperations(object):
                 if error in my_errors:
                     sect_data.error.pop(error)
             action = rose.config_editor.STACK_ACTION_ENABLED
+
         ns = sect_data.metadata["full_ns"]
         copy_sect_data = sect_data.copy()
         if not skip_undo:
@@ -196,6 +199,7 @@ class SectionOperations(object):
             self.trigger_info_update(var)
             if var.metadata['full_ns'] not in nses_to_do:
                 nses_to_do.append(var.metadata['full_ns'])
+            ids_to_do.append(var.metadata['id'])
             if is_ignored:
                 var.ignored_reason.update(
                             {rose.variable.IGNORED_BY_SECTION:
@@ -205,12 +209,12 @@ class SectionOperations(object):
             else:
                 continue
         if skip_update:
-            return nses_to_do
+            return nses_to_do, ids_to_do
         for ns in nses_to_do:
             self.trigger_update(ns)
             self.trigger_info_update(ns)
         self.trigger_update(config_name)
-        return []
+        return [], []
 
     def remove_section(self, config_name, section, skip_update=False,
                        skip_undo=False):

--- a/lib/python/rose/config_editor/ops/section.py
+++ b/lib/python/rose/config_editor/ops/section.py
@@ -76,7 +76,7 @@ class SectionOperations(object):
                      rose.config_editor.ERROR_SECTION_ADD.format(section),
                      title=rose.config_editor.ERROR_SECTION_ADD_TITLE,
                      modal=False)
-            return False
+            return
         if section in config_data.sections.latent:
             new_section_data = config_data.sections.latent.pop(section)
             was_latent = True
@@ -143,7 +143,7 @@ class SectionOperations(object):
                         rose.config_editor.WARNING_CANNOT_USER_IGNORE.format(
                                         section),
                         rose.config_editor.WARNING_CANNOT_IGNORE_TITLE)
-                return
+                return []
             for error in [rose.config_editor.WARNING_TYPE_USER_IGNORED,
                           rose.config_editor.WARNING_TYPE_ENABLED]:
                 if error in sect_data.error:
@@ -173,7 +173,7 @@ class SectionOperations(object):
                       rose.config_editor.WARNING_CANNOT_ENABLE.format(
                                          section),
                       rose.config_editor.WARNING_CANNOT_ENABLE_TITLE)
-                return
+                return []
             sect_data.ignored_reason.clear()
             for error in ign_errors:
                 if error in my_errors:

--- a/lib/python/rose/config_editor/ops/variable.py
+++ b/lib/python/rose/config_editor/ops/variable.py
@@ -216,16 +216,20 @@ class VariableOperations(object):
             if rose.config_editor.WARNING_TYPE_NOT_TRIGGER in variable.error:
                 variable.error.pop(
                          rose.config_editor.WARNING_TYPE_NOT_TRIGGER)
-        if len(variable.ignored_reason.keys()) > len(old_reason.keys()):
+        my_ignored_keys = variable.ignored_reason.keys()
+        if rose.variable.IGNORED_BY_SECTION in my_ignored_keys:
+            my_ignored_keys.remove(rose.variable.IGNORED_BY_SECTION)
+        old_ignored_keys = old_reason.keys()
+        if rose.variable.IGNORED_BY_SECTION in old_ignored_keys:
+            old_ignored_keys.remove(rose.variable.IGNORED_BY_SECTION)
+        if len(my_ignored_keys) > len(old_ignored_keys):
             action_text = rose.config_editor.STACK_ACTION_IGNORED
-            if (not old_reason and
+            if (not old_ignored_keys and
                 rose.config_editor.WARNING_TYPE_ENABLED in variable.error):
                 variable.error.pop(rose.config_editor.WARNING_TYPE_ENABLED)
         else:
             action_text = rose.config_editor.STACK_ACTION_ENABLED
-            if (not variable.ignored_reason.keys() or
-                    variable.ignored_reason.keys() ==
-                    [rose.variable.IGNORED_BY_SECTION]):
+            if not my_ignored_keys:
                 for err_type in rose.config_editor.WARNING_TYPES_IGNORE:
                     if err_type in variable.error:
                         variable.error.pop(err_type)

--- a/lib/python/rose/config_editor/ops/variable.py
+++ b/lib/python/rose/config_editor/ops/variable.py
@@ -223,7 +223,9 @@ class VariableOperations(object):
                 variable.error.pop(rose.config_editor.WARNING_TYPE_ENABLED)
         else:
             action_text = rose.config_editor.STACK_ACTION_ENABLED
-            if len(variable.ignored_reason.keys()) == 0:
+            if (not variable.ignored_reason.keys() or
+                    variable.ignored_reason.keys() ==
+                    [rose.variable.IGNORED_BY_SECTION]):
                 for err_type in rose.config_editor.WARNING_TYPES_IGNORE:
                     if err_type in variable.error:
                         variable.error.pop(err_type)

--- a/lib/python/rose/config_editor/ops/variable.py
+++ b/lib/python/rose/config_editor/ops/variable.py
@@ -127,7 +127,7 @@ class VariableOperations(object):
             latent_variables.remove(variable)
             if not config_data.vars.latent[sect]:
                 config_data.vars.latent.pop(sect)
-            return
+            return None
         if variable in variables:
             variables.remove(variable)
             if not config_data.vars.now[sect]:
@@ -206,7 +206,7 @@ class VariableOperations(object):
         variable.ignored_reason = new_reason_dict.copy()
         if not set(old_reason.keys()) ^ set(new_reason_dict.keys()):
             # No practical difference, so don't do anything.
-            return
+            return None
         # Protect against user-enabling of triggered ignored.
         if (not override and
             rose.variable.IGNORED_BY_SYSTEM in old_reason and
@@ -249,7 +249,7 @@ class VariableOperations(object):
         variable = self._get_proper_variable(variable)
         if variable.value == new_value:
             # A bad valuewidget setter.
-            return False
+            return None
         variable.old_value = variable.value
         variable.value = new_value
         if not skip_undo:

--- a/lib/python/rose/config_editor/stack.py
+++ b/lib/python/rose/config_editor/stack.py
@@ -69,18 +69,20 @@ class StackViewer(gtk.Window):
         self.action_colour_map = {
                 rose.config_editor.STACK_ACTION_ADDED:
                 rose.config_editor.COLOUR_STACK_ADDED,
+                rose.config_editor.STACK_ACTION_APPLIED:
+                rose.config_editor.COLOUR_STACK_APPLIED,
                 rose.config_editor.STACK_ACTION_CHANGED:
                 rose.config_editor.COLOUR_STACK_CHANGED,
                 rose.config_editor.STACK_ACTION_CHANGED_COMMENTS:
                 rose.config_editor.COLOUR_STACK_CHANGED_COMMENTS,
-                rose.config_editor.STACK_ACTION_DIFF:
-                rose.config_editor.COLOUR_STACK_DIFF,
                 rose.config_editor.STACK_ACTION_ENABLED:
                 rose.config_editor.COLOUR_STACK_ENABLED,
                 rose.config_editor.STACK_ACTION_IGNORED:
                 rose.config_editor.COLOUR_STACK_IGNORED,
                 rose.config_editor.STACK_ACTION_REMOVED:
-                rose.config_editor.COLOUR_STACK_REMOVED}
+                rose.config_editor.COLOUR_STACK_REMOVED,
+                rose.config_editor.STACK_ACTION_REVERSED:
+                rose.config_editor.COLOUR_STACK_REVERSED}
         self.undo_func = undo_func
         self.undo_stack = undo_stack
         self.redo_stack = redo_stack
@@ -178,7 +180,10 @@ class StackViewer(gtk.Window):
                 colour = self.action_colour_map[stack_item.action]
                 marked_up_action = ("<span foreground='" + colour + "'>"
                                      + stack_item.action + "</span>")
-            short_label = re.sub('^/[^/]+/', '', stack_item.page_label)
+            if stack_item.page_label is None:
+                short_label = 'None'
+            else:
+                short_label = re.sub('^/[^/]+/', '', stack_item.page_label)
             model.append((short_label, marked_up_action,
                           stack_item.name, repr(stack_item.value),
                           repr(stack_item.old_value), False))

--- a/lib/python/rose/config_editor/stack.py
+++ b/lib/python/rose/config_editor/stack.py
@@ -33,11 +33,14 @@ class StackItem(object):
 
     def __init__(self, page_label, action_text, node,
                        undo_function, undo_args=None,
-                       group=None):
+                       group=None, custom_name=None):
         self.page_label = page_label
         self.action = action_text
         self.node = node
-        self.name = self.node.name
+        if custom_name is None:
+            self.name = self.node.name
+        else:
+            self.name = custom_name
         self.group = group
         if hasattr(self.node, "value"):
             self.value = self.node.value
@@ -70,6 +73,8 @@ class StackViewer(gtk.Window):
                 rose.config_editor.COLOUR_STACK_CHANGED,
                 rose.config_editor.STACK_ACTION_CHANGED_COMMENTS:
                 rose.config_editor.COLOUR_STACK_CHANGED_COMMENTS,
+                rose.config_editor.STACK_ACTION_DIFF:
+                rose.config_editor.COLOUR_STACK_DIFF,
                 rose.config_editor.STACK_ACTION_ENABLED:
                 rose.config_editor.COLOUR_STACK_ENABLED,
                 rose.config_editor.STACK_ACTION_IGNORED:

--- a/lib/python/rose/config_editor/updater.py
+++ b/lib/python/rose/config_editor/updater.py
@@ -210,7 +210,6 @@ class Updater(object):
             self.update_sections(namespace)
             self.update_ignored_statuses(namespace)
             if not are_errors_done and not is_loading:
-                print "Perform error check", namespace
                 self.perform_error_check(namespace)
             self.update_tree_status(namespace)
             if not is_loading:

--- a/lib/python/rose/config_editor/updater.py
+++ b/lib/python/rose/config_editor/updater.py
@@ -130,7 +130,7 @@ class Updater(object):
                 self.update_ns_sub_data(only_this_namespace)
 
     def refresh_ids(self, config_name, setting_ids, is_loading=False,
-                    are_errors_done=False):
+                    are_errors_done=False, skip_update=True):
         """Refresh and redraw settings if needed."""
         self.pagelist = self.get_pagelist_func()
         nses_to_do = []
@@ -155,8 +155,9 @@ class Updater(object):
                     page.refresh(changed_id)
             if ns not in nses_to_do and not are_errors_done:
                 nses_to_do.append(ns)
-        for ns in nses_to_do:
-            self.update_namespace(ns, is_loading=is_loading)
+        if not skip_update:
+            for ns in nses_to_do:
+                self.update_namespace(ns, is_loading=is_loading)
 
     def update_all(self, only_this_config=None, is_loading=False,
                    skip_checking=False, skip_sub_data_update=False):
@@ -753,6 +754,7 @@ class Updater(object):
                          is_loading,
                          are_errors_done=is_macro_dynamic)
 
-    def apply_macro_transform(self, config_name, macro_type, changed_ids):
+    def apply_macro_transform(self, config_name, changed_ids,
+                              skip_update=False):
         """Refresh pages with changes."""
-        self.refresh_ids(config_name, changed_ids)
+        self.refresh_ids(config_name, changed_ids, skip_update=skip_update)

--- a/lib/python/rose/config_editor/updater.py
+++ b/lib/python/rose/config_editor/updater.py
@@ -210,6 +210,7 @@ class Updater(object):
             self.update_sections(namespace)
             self.update_ignored_statuses(namespace)
             if not are_errors_done and not is_loading:
+                print "Perform error check", namespace
                 self.perform_error_check(namespace)
             self.update_tree_status(namespace)
             if not is_loading:


### PR DESCRIPTION
This change speeds up applying large macro changes in `rose edit`.

There are two parts to this:
 * Don't store an 'undo' for each operation - instead, store a config diff object (from #1334) for the whole macro change set. This closes #836.
 * Consolidate updating so that it is only done at the end of the whole change set, with each namespace only being updated once.

There is a move of code from menu.py to 'apply_diff' in group.py, which largely preserves the previous logic. The changes are now dependent on the actual diff from the original config, instead of being awkwardly based around the macro reports as before. This is good as a macro may lie about its reports!

498509c and 62869f4 fix a bug where variable errors weren't always being removed if their section was ignored.
 