### PR TITLE
rosie graph: plot suite ancestry

### DIFF
--- a/bin/rosie-graph
+++ b/bin/rosie-graph
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+#-------------------------------------------------------------------------------
+# (C) British Crown Copyright 2012-5 Met Office.
+#
+# This file is part of Rose, a framework for meteorological suites.
+#
+# Rose is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Rose is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Rose. If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# NAME
+#     rosie graph
+#
+# SYNOPSIS
+#     rosie graph [OPTIONS] [ID]
+#
+# DESCRIPTION
+#     Graph suite copy ancestry.
+#
+# OPTIONS
+#     --output=FILE, -o FILE
+#         The name of the file for dumping the output. Otherwise,
+#         the output will go to a temporary file which will get
+#         tidied up. The extension of the filename determines the
+#         output format - see graphviz AGraph.draw documentation.
+#     --prefix=PREFIX
+#         Display suites from only the specified web services.
+#         This option can be used multiple times.
+#     --property=PROPERTY, -p PROPERTY
+#         Add a certain suite property to the node labels - e.g.
+#         owner or title. This option can be used multiple times.
+# ARGUMENTS
+#     ID
+#         A suite id to graph. If given, only the suites that are
+#         connected to this id by copy history will be graphed.
+#-------------------------------------------------------------------------------
+exec python -m rosie.graph "$@"

--- a/bin/rosie-graph
+++ b/bin/rosie-graph
@@ -27,6 +27,11 @@
 #     Graph suite copy ancestry.
 #
 # OPTIONS
+#     --distance=DISTANCE, -d DISTANCE
+#         The maximum distance (graph depth) for suites related to ID
+#         to be plotted. For example, if the distance is 1, only the
+#         parents and children (but not siblings) of ID will be plotted.
+#         If not given, this is unlimited. Requires ID to be specified.
 #     --output=FILE, -o FILE
 #         The name of the file for dumping the output. Otherwise,
 #         the output will go to a temporary file which will get

--- a/doc/rose-command.html
+++ b/doc/rose-command.html
@@ -222,6 +222,10 @@
 
       <dd>Launch the Rosie client GTK+ GUI.</dd>
 
+      <dt><a href="#rosie-graph">rosie graph</a></dt>
+
+      <dd>Graph suite copy ancestry.</dd>
+
       <dt><a href="#rosie-hello">rosie hello</a></dt>
 
       <dd>Set up connection to a Rosie web service server.</dd>
@@ -2934,6 +2938,50 @@ environment scripting = "eval $(rose task-env)"
     <p><a href="#rosie-lookup">rosie lookup</a></p>
 
     <p><a href="#rosie-ls">rosie ls</a></p>
+
+    <h2 id="rosie-graph">rosie graph</h2>
+
+    <h3>NAME</h3>
+
+    <p><kbd>rosie graph</kbd></p>
+
+    <h3>SYNOPSIS</h3>
+
+    <p><kbd>rosie graph [OPTIONS] [ID]</kbd></p>
+
+    <h3>DESCRIPTION</h3>
+
+    <p>Graph suite copy ancestry.</p>
+
+    <h3>OPTIONS</h3>
+
+    <dl>
+      <dt><kbd>--output=FILE, -O FILE</kbd></dt>
+
+      <dd>The name of the file for dumping the output. Otherwise, the output
+      will go to a temporary file which will get tidied up. The extension of
+      the filename determines the output format - see graphviz AGraph.draw
+      documentation.</dd>
+
+      <dt><kbd>--prefix=PREFIX</kbd></dt>
+
+      <dd>Display suites from only the specified web services. This option can
+      be used multiple times.</dd>
+
+      <dt><kbd>--property=PROPERTY, -p PROPERTY</kbd></dt>
+
+      <dd>Add a certain suite property to the node labels - e.g. owner or
+      title. This option can be used multiple times.</dd>
+    </dl>
+
+    <h3>ARGUMENTS</h3>
+
+    <dl>
+      <dt><kbd>ID</kbd></dt>
+
+      <dd>A suite id to graph. If given, only the suites that are connected to
+      this id by copy history will be graphed.</dd>
+    </dl>
 
     <h2 id="rosie-hello">rosie hello</h2>
 

--- a/doc/rose-command.html
+++ b/doc/rose-command.html
@@ -2956,6 +2956,14 @@ environment scripting = "eval $(rose task-env)"
     <h3>OPTIONS</h3>
 
     <dl>
+      <dt><kbd>--distance=DISTANCE, -d DISTANCE</kbd></dt>
+
+      <dd>The maximum distance (graph depth) for suites related to
+      <var>ID</var> to be plotted. For example, if the distance is
+      <samp>1</samp>, only the parents and children (but not siblings) of
+      <var>ID</var> will be plotted. If not given, this is unlimited. Requires
+      <var>ID</var> to be specified.</dd>
+
       <dt><kbd>--output=FILE, -O FILE</kbd></dt>
 
       <dd>The name of the file for dumping the output. Otherwise, the output

--- a/lib/python/rose/metadata_graph.py
+++ b/lib/python/rose/metadata_graph.py
@@ -204,7 +204,7 @@ def add_trigger_graph(graph, config, meta_config, err_reporter,
                 graph.add_edge(value_id, dependent_id, **dependent_attrs)
 
 
-def output_graph(graph, debug_mode=False, format="svg"):
+def output_graph(graph, debug_mode=False, filename=None, format="svg"):
     """Output a Graphviz Graph object.
 
     If debug_mode is True, print the 'dot' text output.
@@ -213,7 +213,10 @@ def output_graph(graph, debug_mode=False, format="svg"):
     """
     if debug_mode:
         format = "dot"
-    image_file_handle = tempfile.NamedTemporaryFile(suffix=("." + format))
+    if filename is None:
+        image_file_handle = tempfile.NamedTemporaryFile(suffix=("." + format))
+    else:
+        image_file_handle = open(filename, "w")
     graph.draw(image_file_handle.name, prog="dot")
     if debug_mode:
         image_file_handle.seek(0)

--- a/lib/python/rose/opt_parse.py
+++ b/lib/python/rose/opt_parse.py
@@ -155,6 +155,13 @@ class RoseOptionParser(OptionParser):
              "dest": "diff_tool",
              "default": None,
              "help": "Specify an alternate diff tool like diffuse."}],
+        "distance": [
+            ["--distance", "-d"],
+            {"action": "store",
+             "dest": "distance",
+             "default": None,
+             "type": "int",
+             "help": "Specify a maximum distance."}],
         "downgrade": [
             ["--downgrade", "-d"],
             {"action": "store_true",

--- a/lib/python/rosie/graph.py
+++ b/lib/python/rosie/graph.py
@@ -101,7 +101,7 @@ def calculate_edges(graph, prefix, filter_id=None, properties=None):
         node_stack = []
         node_stack = [filter_id]
         add_node(graph, filter_id, node_rosie_properties.get(filter_id),
-                 color="red", shape="rectangle")
+                 fillcolor="lightgrey", style="filled")
 
         ok_nodes = set([])
         while node_stack:

--- a/lib/python/rosie/graph.py
+++ b/lib/python/rosie/graph.py
@@ -1,0 +1,180 @@
+# -*- coding: utf-8 -*-
+#-----------------------------------------------------------------------------
+# (C) British Crown Copyright 2012-5 Met Office.
+#
+# This file is part of Rose, a framework for meteorological suites.
+#
+# Rose is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Rose is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Rose. If not, see <http://www.gnu.org/licenses/>.
+#-----------------------------------------------------------------------------
+"""Plot suite ancestry."""
+
+import subprocess
+import sys
+import textwrap
+import time
+
+import pygraphviz
+
+import rose.metadata_graph
+import rose.opt_parse
+import rose.reporter
+import rosie.suite_id
+import rosie.ws_client
+import rosie.ws_client_cli
+
+
+class NoConnectionsEvent(rose.reporter.Event):
+    """An event raised if the graph has no edges or nodes.
+
+    event.args[0] is the filter id string.
+
+    """
+
+    KIND = rose.reporter.Reporter.KIND_ERR
+
+    def __str__(self):
+        id = self.args[0]
+        return "%s: no copy relationships to other suites" % id
+
+
+def calculate_edges(graph, prefix, filter_id=None, properties=None):
+    """Get all connected suites for a prefix, optionally filtered."""
+    if properties is None:
+        properties = []
+    ws_client = rosie.ws_client.RosieWSClient(
+        prefixes=[prefix],
+        event_handler=rose.reporter.Reporter()
+    )
+    node_rosie_properties = {}
+    edges = []
+    forward_edges = {}
+    back_edges = {}
+    dict_rows = ws_client.search(prefix, all_revs=1)[0][0]
+    for dict_row in sorted(dict_rows, key=lambda _: _["revision"]):
+        suite_id = rosie.suite_id.SuiteId.from_idx_branch_revision(
+                dict_row["idx"],
+                dict_row["branch"],
+                dict_row["revision"]
+            )
+        dict_row["suite"] = suite_id.to_string_with_version()
+        if "local" in properties:
+            dict_row["local"] = suite_id.get_status()
+        if "date" in properties:
+            dict_row["date"] = time.strftime(
+                rosie.ws_client_cli.DATE_TIME_FORMAT,
+                time.gmtime(dict_row.get("date"))
+            )
+        idx = dict_row["idx"]
+        node_rosie_properties[idx] = []
+        for property in properties:
+            node_rosie_properties[idx].append(dict_row.get(property))
+        from_idx = dict_row.get("from_idx")
+        if from_idx is None:
+            continue
+        edges.append((from_idx, idx))
+        forward_edges.setdefault(from_idx, [])
+        forward_edges[from_idx].append(idx)
+        back_edges.setdefault(idx, [])
+        back_edges[idx].append(from_idx)
+
+    if filter_id is None:
+        # Plot all the edges we've found.
+        for edge in sorted(edges):
+            node0, node1 = edge
+            add_node(graph, node0, node_rosie_properties.get(node0))
+            add_node(graph, node1, node_rosie_properties.get(node1))
+            graph.add_edge(edge[0], edge[1])
+    else:
+        # Only plot the connections involving filter_id.
+        nodes = [n for edge in edges for n in edge]
+        node_stack = []
+        node_stack = [filter_id]
+        add_node(graph, filter_id, node_rosie_properties.get(filter_id),
+                 color="red", shape="rectangle")
+
+        ok_nodes = set([])
+        while node_stack:
+            node = node_stack.pop()
+            ok_nodes.add(node)
+            for neighbour_node in (forward_edges.get(node, []) +
+                                   back_edges.get(node, [])):
+                if neighbour_node not in ok_nodes:
+                    node_stack.append(neighbour_node)
+
+        if len(ok_nodes) == 1:
+            # There are no related suites.
+            reporter = rose.reporter.Reporter()
+            reporter(NoConnectionsEvent(filter_id))
+
+        for edge in sorted(edges):
+            node0, node1 = edge
+            if node0 in ok_nodes:
+                # Implies 'or node1 in ok_nodes'.
+                add_node(graph, node0, node_rosie_properties.get(node0))
+                add_node(graph, node1, node_rosie_properties.get(node1))
+                graph.add_edge(node0, node1)
+
+
+def add_node(graph, node, node_label_properties, **kwargs):
+    """Add a node with a particular label."""
+    label_lines = [node]
+    if node_label_properties is not None:
+        for property_value in node_label_properties:
+            label_lines.extend(textwrap.wrap(str(property_value)))
+    label_text = "\\n".join(label_lines)  # \n must be escaped for graphviz.
+    kwargs.update({"label": label_text})
+    graph.add_node(node, **kwargs)
+
+
+def make_graph(prefix, filter_id, properties):
+    """Construct the pygraphviz graph."""
+    graph = pygraphviz.AGraph(directed=True)
+    graph.graph_attr["rankdir"] = "LR"
+    if filter_id:
+        graph.graph_attr["name"] = filter_id + " copy tree"
+    else:
+        graph.graph_attr["name"] = prefix + " copy tree"
+    calculate_edges(graph, prefix, filter_id, properties)
+    return graph
+
+
+def output_graph(graph, filename=None, debug_mode=False):
+    """Draw the graph to filename (or temporary file if None)."""
+    rose.metadata_graph.output_graph(graph, debug_mode=debug_mode,
+                                     filename=filename)
+
+
+def main():
+    """Provide the CLI interface."""
+    opt_parser = rose.opt_parse.RoseOptionParser()
+    opt_parser.add_my_options("output_file",
+                              "prefix",
+                              "property")
+    opts, args = opt_parser.parse_args()
+    filter_id = None
+    if args:
+        filter_id = args[0]    
+        prefix = rosie.suite_id.SuiteId(id_text=filter_id).prefix
+        if opts.prefix:
+            opt_parser.error("No need to specify --prefix when specifying ID")
+    elif opts.prefix:
+        prefix = opts.prefix
+    else:
+        prefix = rosie.suite_id.SuiteId.get_prefix_default()
+    graph = make_graph(prefix, filter_id, opts.property)
+    output_graph(graph, filename=opts.output_file, debug_mode=opts.debug_mode)
+
+
+if __name__ == "__main__":
+    main()

--- a/t/rosie-graph/00-basic.t
+++ b/t/rosie-graph/00-basic.t
@@ -25,7 +25,7 @@
 if ! python -c 'import cherrypy, sqlalchemy' 2>/dev/null; then
     skip_all 'python: cherrypy or sqlalchemy not installed'
 fi
-tests 18
+tests 27
 #-------------------------------------------------------------------------------
 # Setup Rose site/user configuration for the tests.
 export TZ='UTC'
@@ -200,12 +200,45 @@ file_cmp "$TEST_KEY.out" "$TEST_KEY.filtered.out" <<__OUTPUT__
 "foo-aa002" -> "foo-aa003" [
 "foo-aa002" [label="foo-aa002"
 "foo-aa003" -> "foo-aa004" [
-"foo-aa003" [color=red, label="foo-aa003", shape=rectangle
+"foo-aa003" [label="foo-aa003", style=filled
 "foo-aa004" [label="foo-aa004"
 graph [rankdir=LR
 node [label="\N"
 __OUTPUT__
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+#-------------------------------------------------------------------------------
+TEST_KEY=$TEST_KEY_BASE-filter-id-distance-1
+run_pass "$TEST_KEY" rosie graph --debug --distance=1 foo-aa004
+filter_graphviz <"$TEST_KEY.out" >"$TEST_KEY.filtered.out"
+file_cmp "$TEST_KEY.out" "$TEST_KEY.filtered.out" <<__OUTPUT__
+"foo-aa003" -> "foo-aa004" [
+"foo-aa003" [label="foo-aa003"
+"foo-aa004" [label="foo-aa004", style=filled
+graph [rankdir=LR
+node [label="\N"
+__OUTPUT__
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+#-------------------------------------------------------------------------------
+TEST_KEY=$TEST_KEY_BASE-filter-id-distance-2
+run_pass "$TEST_KEY" rosie graph --debug --distance=1 foo-aa002
+filter_graphviz <"$TEST_KEY.out" >"$TEST_KEY.filtered.out"
+file_cmp "$TEST_KEY.out" "$TEST_KEY.filtered.out" <<__OUTPUT__
+"foo-aa002" -> "foo-aa003" [
+"foo-aa002" [label="foo-aa002", style=filled
+"foo-aa003" [label="foo-aa003"
+graph [rankdir=LR
+node [label="\N"
+__OUTPUT__
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+#-------------------------------------------------------------------------------
+TEST_KEY=$TEST_KEY_BASE-no-filter-id-distance
+run_fail "$TEST_KEY" rosie graph --debug --distance=1
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" <<__ERROR__
+Usage: rosie graph [OPTIONS] [ID]
+
+rosie graph: error: distance option requires an ID
+__ERROR__
 #-------------------------------------------------------------------------------
 TEST_KEY=$TEST_KEY_BASE-property-owner
 run_pass "$TEST_KEY" rosie graph --debug --property=owner
@@ -262,7 +295,7 @@ TEST_KEY=$TEST_KEY_BASE-no-copy-tree
 run_pass "$TEST_KEY" rosie graph --debug foo-aa005
 filter_graphviz <"$TEST_KEY.out" >"$TEST_KEY.filtered.out"
 file_cmp "$TEST_KEY.out" "$TEST_KEY.filtered.out" <<__OUTPUT__
-"foo-aa005" [color=red, label="foo-aa005", shape=rectangle
+"foo-aa005" [label="foo-aa005", style=filled
 graph [rankdir=LR
 node [label="\N"
 __OUTPUT__

--- a/t/rosie-graph/00-basic.t
+++ b/t/rosie-graph/00-basic.t
@@ -1,0 +1,275 @@
+#!/bin/bash
+#-------------------------------------------------------------------------------
+# (C) British Crown Copyright 2012-5 Met Office.
+#
+# This file is part of Rose, a framework for meteorological suites.
+#
+# Rose is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Rose is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Rose. If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Basic tests for "rosie graph".
+#-------------------------------------------------------------------------------
+. $(dirname $0)/test_header_extra
+. $(dirname $0)/test_header
+#-------------------------------------------------------------------------------
+if ! python -c 'import cherrypy, sqlalchemy' 2>/dev/null; then
+    skip_all 'python: cherrypy or sqlalchemy not installed'
+fi
+tests 18
+#-------------------------------------------------------------------------------
+# Setup Rose site/user configuration for the tests.
+export TZ='UTC'
+
+mkdir repos
+svnadmin create repos/foo || exit 1
+SVN_URL=file://$PWD/repos/foo
+
+# Setup configuration file.
+mkdir conf
+cat >conf/rose.conf <<__ROSE_CONF__
+opts=port
+
+[rosie-db]
+repos.foo=$PWD/repos/foo
+db.foo=sqlite:///$PWD/repos/foo.db
+
+[rosie-id]
+local-copy-root=$PWD/roses
+prefix-default=foo
+prefix-location.foo=$SVN_URL
+
+[rosie-ws]
+log-dir=$PWD/rosie/log
+__ROSE_CONF__
+export ROSE_CONF_PATH=$PWD/conf
+
+mkdir 'conf/opt'
+touch 'conf/opt/rose-port.conf'
+
+# Setup repository - create a suite.
+cat >repos/foo/hooks/post-commit <<__POST_COMMIT__
+#!/bin/bash
+export ROSE_CONF_PATH=$ROSE_CONF_PATH
+$ROSE_HOME/sbin/rosa svn-post-commit --debug "\$@" \\
+    1>$PWD/rosa-svn-post-commit.out 2>$PWD/rosa-svn-post-commit.err
+echo \$? >$PWD/rosa-svn-post-commit.rc
+__POST_COMMIT__
+chmod +x repos/foo/hooks/post-commit
+export LANG=C
+cat >rose-suite.info <<'__ROSE_SUITE_INFO'
+access-list=*
+description=Bad corn ear and pew pull
+owner=iris
+project=eye pad
+title=Should have gone to ...
+__ROSE_SUITE_INFO
+rosie create -q -y --info-file=rose-suite.info --no-checkout || exit 1
+echo "2009-02-13T23:31:30.000000Z" >foo-date-1.txt
+svnadmin setrevprop $PWD/repos/foo -r 1 svn:date foo-date-1.txt
+
+# Setup repository - create and update another suite.
+# Create a suite.
+cat >rose-suite.info <<'__ROSE_SUITE_INFO'
+access-list=*
+description=Violets are Blue...
+owner=roses
+project=poetry
+title=Roses are Red,...
+__ROSE_SUITE_INFO
+rosie create -q -y --info-file=rose-suite.info foo-aa000 || exit 1
+echo "2009-02-13T23:31:31.000000Z" >foo-date-2.txt
+svnadmin setrevprop $PWD/repos/foo -r 2 svn:date foo-date-2.txt
+# Update this suite.
+cat >rose-suite.info <<'__ROSE_SUITE_INFO'
+access-list=roses violets
+owner=roses
+project=poetry
+title=Roses are Red; Violets are Blue,...
+__ROSE_SUITE_INFO
+cp rose-suite.info $PWD/roses/foo-aa001/
+(cd $PWD/roses/foo-aa001 && svn commit -q -m "update" && \
+     svn update -q) || exit 1
+echo "2009-02-13T23:31:32.000000Z" >foo-date-3.txt
+svnadmin setrevprop $PWD/repos/foo -r 3 svn:date foo-date-3.txt
+
+# Setup repository - delete the first suite.
+rosie delete -q -y foo-aa000 || exit 1
+echo "2009-02-13T23:31:33.000000Z" >foo-date-4.txt
+svnadmin setrevprop $PWD/repos/foo -r 4 svn:date foo-date-4.txt
+
+# Setup repository - create another suite.
+cat >rose-suite.info <<'__ROSE_SUITE_INFO'
+access-list=allthebugs
+description=Nom nom nom roses
+owner=aphids
+project=eat roses
+title=Eat all the roses!
+__ROSE_SUITE_INFO
+rosie create -q -y --info-file=rose-suite.info || exit 1
+echo "2009-02-13T23:31:34.000000Z" >foo-date-5.txt
+svnadmin setrevprop $PWD/repos/foo -r 5 svn:date foo-date-5.txt
+
+# Setup repository - create another suite.
+cat >rose-suite.info <<'__ROSE_SUITE_INFO'
+owner=bill
+project=sonnet 54
+title=The rose looks fair...
+__ROSE_SUITE_INFO
+rosie create -q -y --info-file=rose-suite.info foo-aa002 || exit 1
+echo "2009-02-13T23:31:35.000000Z" >foo-date-6.txt
+svnadmin setrevprop $PWD/repos/foo -r 6 svn:date foo-date-6.txt
+
+# Setup repository - create another suite.
+cat >rose-suite.info <<'__ROSE_SUITE_INFO'
+owner=bill
+project=sonnet 54
+title=The rose looks fair but fairer we it deem for that sweet odour which doth in it live.
+__ROSE_SUITE_INFO
+rosie create -q -y --info-file=rose-suite.info foo-aa003 || exit 1
+echo "2009-02-13T23:31:36.000000Z" >foo-date-7.txt
+svnadmin setrevprop $PWD/repos/foo -r 7 svn:date foo-date-7.txt
+
+# Setup repository - create another suite.
+cat >rose-suite.info <<'__ROSE_SUITE_INFO'
+owner=bill
+project=sonnet 54
+title=The rose looks fair but fairer we it deem for that sweet odour which doth in it live.
+__ROSE_SUITE_INFO
+rosie create -q -y --info-file=rose-suite.info || exit 1
+echo "2009-02-13T23:31:37.000000Z" >foo-date-8.txt
+svnadmin setrevprop $PWD/repos/foo -r 8 svn:date foo-date-8.txt
+
+# Setup db.
+$ROSE_HOME/sbin/rosa db-create -q
+
+#-------------------------------------------------------------------------------
+# Run ws.
+PORT="$((RANDOM + 10000))"
+while port_is_busy "${PORT}"; do
+    PORT="$((RANDOM + 10000))"
+done
+cat >conf/opt/rose-port.conf <<__ROSE_CONF__
+[rosie-id]
+prefix-ws.foo=http://${HOSTNAME}:${PORT}/foo
+
+[rosie-ws]
+port=${PORT}
+__ROSE_CONF__
+"${ROSE_HOME}/sbin/rosa" ws 0</dev/null 1>rosa-ws.out 2>rosa-ws.err &
+ROSA_WS_PID="${!}"
+T_INIT="$(date +%s)"
+while ! port_is_busy "${PORT}" && (($(date +%s) < T_INIT + 60)); do
+    sleep 1
+done
+if ! port_is_busy "${PORT}"; then
+    exit 1
+fi
+
+#-------------------------------------------------------------------------------
+TEST_KEY=$TEST_KEY_BASE-full
+run_pass "$TEST_KEY" rosie graph --debug
+filter_graphviz <"$TEST_KEY.out" >"$TEST_KEY.filtered.out"
+file_cmp "$TEST_KEY.out" "$TEST_KEY.filtered.out" <<__OUTPUT__
+"foo-aa000" -> "foo-aa001" [
+"foo-aa000" [label="foo-aa000"
+"foo-aa001" [label="foo-aa001"
+"foo-aa002" -> "foo-aa003" [
+"foo-aa002" [label="foo-aa002"
+"foo-aa003" -> "foo-aa004" [
+"foo-aa003" [label="foo-aa003"
+"foo-aa004" [label="foo-aa004"
+graph [rankdir=LR
+node [label="\N"
+__OUTPUT__
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+#-------------------------------------------------------------------------------
+TEST_KEY=$TEST_KEY_BASE-filter-id
+run_pass "$TEST_KEY" rosie graph --debug foo-aa003
+filter_graphviz <"$TEST_KEY.out" >"$TEST_KEY.filtered.out"
+file_cmp "$TEST_KEY.out" "$TEST_KEY.filtered.out" <<__OUTPUT__
+"foo-aa002" -> "foo-aa003" [
+"foo-aa002" [label="foo-aa002"
+"foo-aa003" -> "foo-aa004" [
+"foo-aa003" [color=red, label="foo-aa003", shape=rectangle
+"foo-aa004" [label="foo-aa004"
+graph [rankdir=LR
+node [label="\N"
+__OUTPUT__
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+#-------------------------------------------------------------------------------
+TEST_KEY=$TEST_KEY_BASE-property-owner
+run_pass "$TEST_KEY" rosie graph --debug --property=owner
+filter_graphviz <"$TEST_KEY.out" >"$TEST_KEY.filtered.out"
+file_cmp "$TEST_KEY.out" "$TEST_KEY.filtered.out" <<__OUTPUT__
+"foo-aa000" -> "foo-aa001" [
+"foo-aa000" [label="foo-aa000\niris"
+"foo-aa001" [label="foo-aa001\nroses"
+"foo-aa002" -> "foo-aa003" [
+"foo-aa002" [label="foo-aa002\naphids"
+"foo-aa003" -> "foo-aa004" [
+"foo-aa003" [label="foo-aa003\nbill"
+"foo-aa004" [label="foo-aa004\nbill"
+graph [rankdir=LR
+node [label="\N"
+__OUTPUT__
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+#-------------------------------------------------------------------------------
+TEST_KEY=$TEST_KEY_BASE-property-owner-project
+run_pass "$TEST_KEY" rosie graph --debug --property=owner --property=project
+filter_graphviz <"$TEST_KEY.out" >"$TEST_KEY.filtered.out"
+file_cmp "$TEST_KEY.out" "$TEST_KEY.filtered.out" <<__OUTPUT__
+"foo-aa000" -> "foo-aa001" [
+"foo-aa000" [label="foo-aa000\niris\neye pad"
+"foo-aa001" [label="foo-aa001\nroses\npoetry"
+"foo-aa002" -> "foo-aa003" [
+"foo-aa002" [label="foo-aa002\naphids\neat roses"
+"foo-aa003" -> "foo-aa004" [
+"foo-aa003" [label="foo-aa003\nbill\nsonnet 54"
+"foo-aa004" [label="foo-aa004\nbill\nsonnet 54"
+graph [rankdir=LR
+node [label="\N"
+__OUTPUT__
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+#-------------------------------------------------------------------------------
+TEST_KEY=$TEST_KEY_BASE-property-title
+run_pass "$TEST_KEY" rosie graph --debug --property=title
+filter_graphviz <"$TEST_KEY.out" >"$TEST_KEY.filtered.out"
+file_cmp "$TEST_KEY.out" "$TEST_KEY.filtered.out" <<__OUTPUT__
+"foo-aa000" -> "foo-aa001" [
+"foo-aa000" [label="foo-aa000\nShould have gone to ..."
+"foo-aa001" [label="foo-aa001\nRoses are Red; Violets are Blue,..."
+"foo-aa002" -> "foo-aa003" [
+"foo-aa002" [label="foo-aa002\nEat all the roses!"
+"foo-aa003" -> "foo-aa004" [
+"foo-aa003" [label="foo-aa003\nThe rose looks fair..."
+"foo-aa004" [label="foo-aa004\nThe rose looks fair but fairer we it deem for that sweet odour which\ndoth in it live."
+graph [rankdir=LR
+node [label="\N"
+__OUTPUT__
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+#-------------------------------------------------------------------------------
+TEST_KEY=$TEST_KEY_BASE-no-copy-tree
+run_pass "$TEST_KEY" rosie graph --debug foo-aa005
+filter_graphviz <"$TEST_KEY.out" >"$TEST_KEY.filtered.out"
+file_cmp "$TEST_KEY.out" "$TEST_KEY.filtered.out" <<__OUTPUT__
+"foo-aa005" [color=red, label="foo-aa005", shape=rectangle
+graph [rankdir=LR
+node [label="\N"
+__OUTPUT__
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" <<__ERROR__
+[WARN] foo-aa005: no copy relationships to other suites
+__ERROR__
+#-------------------------------------------------------------------------------
+kill "${ROSA_WS_PID}"
+wait
+exit

--- a/t/rosie-graph/test_header
+++ b/t/rosie-graph/test_header
@@ -1,0 +1,1 @@
+../lib/bash/test_header

--- a/t/rosie-graph/test_header_extra
+++ b/t/rosie-graph/test_header_extra
@@ -1,0 +1,1 @@
+../rose-metadata-graph/test_header_extra


### PR DESCRIPTION
The proliferation of suites and the copy-suite working practice can make it difficult
to keep track of which suites are related, and how. This command creates a graph
of suite ancestry.

The internals are similar to `rose metadata-graph` (but simpler).