### PR TITLE
rose config-dump: don't prettify metadata

### DIFF
--- a/lib/python/rose/config_dump.py
+++ b/lib/python/rose/config_dump.py
@@ -60,7 +60,8 @@ def main():
     for file_name in file_names:
         t = NamedTemporaryFile()
         node = ConfigLoader()(file_name)
-        if not opts.no_pretty_mode and file_name != META_CONFIG_NAME:
+        if (not opts.no_pretty_mode and
+                os.path.basename(file_name) != META_CONFIG_NAME):
             pretty_format_config(node, ignore_error=True)
         ConfigDumper()(node, t)
         t.seek(0)

--- a/t/rose-config-dump/03-prettyprint.t
+++ b/t/rose-config-dump/03-prettyprint.t
@@ -21,7 +21,7 @@
 #-------------------------------------------------------------------------------
 . $(dirname $0)/test_header
 #-------------------------------------------------------------------------------
-tests 8
+tests 12
 #-------------------------------------------------------------------------------
 # Mixed string-integer section indices.
 TEST_KEY=$TEST_KEY_BASE-basic
@@ -85,6 +85,7 @@ perfect=6,28,496,8128,33550336,8589869056,137438691328
 powers_of_one=54*1
 __CONF__
 file_cmp "$TEST_KEY.f2" f2 rose-app.conf
+#-------------------------------------------------------------------------------
 TEST_KEY=$TEST_KEY_BASE-basic-metadata
 rm rose-app.conf
 cat > f3 <<'__CONF__'
@@ -99,6 +100,22 @@ run_pass "$TEST_KEY" rose config-dump
 file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
 file_cmp "$TEST_KEY.f3" f3 rose-meta.conf
+#-------------------------------------------------------------------------------
+TEST_KEY=$TEST_KEY_BASE-basic-metadata-subdir
+rm rose-app.conf
+cat > f4 <<'__CONF__'
+[namelist:sequences=fibonacci]
+help=Here are some values in the sequence:
+    =0,1,1,2,3,5,8,13,21,34,55,89,144,233,377,610,987,1597,2584,4181,6765,10946,17711,28657,46368,75025,121393,196418,
+    =317811,514229,832040,1346269,2178309,3524578,5702887,
+    =9227465,14930352,24157817,39088169
+__CONF__
+mkdir meta
+cp f4 meta/rose-meta.conf
+run_pass "$TEST_KEY" rose config-dump
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+file_cmp "$TEST_KEY.f3" f4 rose-meta.conf
 teardown
 #-------------------------------------------------------------------------------
 exit 0


### PR DESCRIPTION
This fixes an inconsistency (bug) in rose config-dump, where it would tidy
up metadata files as long as they weren't in the current directory.