### PR TITLE
rose suite-run: install: handle colon in file name

### DIFF
--- a/bin/rose-rug-brief-tour
+++ b/bin/rose-rug-brief-tour
@@ -21,21 +21,21 @@
 #     rose-rug-brief-tour
 #
 # SYNOPSIS
-#     rose rug-brief-tour
+#     rose rug-brief-tour [DEST]
 #
 # DESCRIPTION
-#     Populate the current directory for Rose User Guide: A Brief Tour.
+#     Populate the destination directory for Rose User Guide: A Brief Tour.
+#
+# ARGUMENTS
+#     DEST - Destination directory. (default=$PWD)
 #-------------------------------------------------------------------------------
-. $(dirname $0)/../lib/bash/rose_init
-echo Copying Rose brief tour files to current directory...
-rose_init rose_log
-run rsync \
-    -a --exclude='.svn' --timeout=1800 \
-    --rsh='ssh -oBatchMode=yes -oStrictHostKeyChecking=no' \
-    $ROSE_HOME/etc/$(basename $0)/* .
-if [[ $? == 0 ]]; then
-    echo ...done
+. "$(dirname "$0")/../lib/bash/rose_init"
+echo -n 'rose rug-brief-tour: copying brief tour files to current directory...'
+rose_init 'rose_log'
+if run rsync -a "${ROSE_HOME}/etc/$(basename "$0")/" "${1:-${PWD}}"; then
+    echo 'done'
 else
-    echo ...failed
+    echo
+    echo 'rose rug-brief-tour: failed' >&2
     exit 1
 fi

--- a/t/rose-suite-run/02-install.t
+++ b/t/rose-suite-run/02-install.t
@@ -19,14 +19,14 @@
 #-------------------------------------------------------------------------------
 # Test "rose suite-run", with and without site/user configurations.
 #-------------------------------------------------------------------------------
-. $(dirname $0)/test_header
+. "$(dirname "$0")/test_header"
 #-------------------------------------------------------------------------------
-JOB_HOST=$(rose config --default= 't' 'job-host')
-if [[ -n $JOB_HOST ]]; then
-    JOB_HOST=$(rose host-select $JOB_HOST)
+JOB_HOST="$(rose config --default= 't' 'job-host')"
+if [[ -n "${JOB_HOST}" ]]; then
+    JOB_HOST="$(rose host-select "${JOB_HOST}")"
 fi
 #-------------------------------------------------------------------------------
-if [[ $TEST_KEY_BASE == *conf ]]; then
+if [[ "${TEST_KEY_BASE}" == *conf ]]; then
     if ! rose config -q 'rose-suite-run' 'hosts'; then
         skip_all '[rose-suite-run]hosts not defined'
     fi
@@ -34,55 +34,55 @@ else
     export ROSE_CONF_PATH=
 fi
 #-------------------------------------------------------------------------------
-N_TESTS=6
-tests $N_TESTS
+tests 6
 #-------------------------------------------------------------------------------
-TEST_KEY=$TEST_KEY_BASE
-mkdir -p $HOME/cylc-run
-SUITE_RUN_DIR=$(mktemp -d --tmpdir=$HOME/cylc-run 'rose-test-battery.XXXXXX')
-NAME=$(basename $SUITE_RUN_DIR)
-OPTION=-i
-if [[ $TEST_KEY_BASE == *local* ]]; then
-    OPTION=-l
+TEST_KEY="${TEST_KEY_BASE}"
+mkdir -p "${HOME}/cylc-run"
+SUITE_RUN_DIR="$(mktemp -d --tmpdir="${HOME}/cylc-run" 'rose-test-battery.XXXXXX')"
+NAME="$(basename "${SUITE_RUN_DIR}")"
+OPTION='-i'
+if [[ "${TEST_KEY_BASE}" == *local* ]]; then
+    OPTION='-l'
 fi
-if [[ -n $JOB_HOST ]]; then
-    run_pass "$TEST_KEY" rose suite-run --debug \
-        -C $TEST_SOURCE_DIR/$TEST_KEY_BASE $OPTION --name=$NAME --no-gcontrol \
-        -S "HOST=\"$JOB_HOST\""
+if [[ -n "${JOB_HOST}" ]]; then
+    run_pass "${TEST_KEY}" rose suite-run --debug \
+        -C "${TEST_SOURCE_DIR}/${TEST_KEY_BASE}" "${OPTION}" \
+        --name="${NAME}" --no-gcontrol \
+        -S "HOST=\"${JOB_HOST}\""
 else
-    run_pass "$TEST_KEY" rose suite-run --debug \
-        -C $TEST_SOURCE_DIR/$TEST_KEY_BASE $OPTION --name=$NAME --no-gcontrol
+    run_pass "${TEST_KEY}" rose suite-run --debug \
+        -C "${TEST_SOURCE_DIR}/${TEST_KEY_BASE}" "${OPTION}" \
+        --name="${NAME}" --no-gcontrol
 fi
 #-------------------------------------------------------------------------------
-TEST_KEY=$TEST_KEY_BASE-port-file
-run_fail "$TEST_KEY" test -e $HOME/.cylc/ports/$NAME
+TEST_KEY="${TEST_KEY_BASE}-port-file"
+run_fail "${TEST_KEY}" test -e "${HOME}/.cylc/ports/${NAME}"
 #-------------------------------------------------------------------------------
-TEST_KEY=$TEST_KEY_BASE-items
-run_pass "$TEST_KEY" ls $SUITE_RUN_DIR/{app,etc}
-file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<__OUT__
-$SUITE_RUN_DIR/app:
-my_task_1
-
-$SUITE_RUN_DIR/etc:
-junk
+TEST_KEY="${TEST_KEY_BASE}-items"
+run_pass "${TEST_KEY}" find "${SUITE_RUN_DIR}/"{app,colon:is:ok,etc} -type f
+sort "${TEST_KEY}.out" >"${TEST_KEY}.out.sort"
+file_cmp "${TEST_KEY}.out" "${TEST_KEY}.out.sort" <<__OUT__
+${SUITE_RUN_DIR}/app/my_task_1/rose-app.conf
+${SUITE_RUN_DIR}/colon:is:ok
+${SUITE_RUN_DIR}/etc/junk
 __OUT__
 #-------------------------------------------------------------------------------
-TEST_KEY=$TEST_KEY_BASE-items-$JOB_HOST
-if [[ $TEST_KEY_BASE == *local* ]]; then
-    skip 2 "$TEST_KEY: local-install-only"
-elif [[ -n $JOB_HOST ]]; then
-    run_pass "$TEST_KEY" \
-        ssh -oBatchMode=yes $JOB_HOST ls cylc-run/$NAME/{app,etc}
-    file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<__OUT__
-cylc-run/$NAME/app:
-my_task_1
-
-cylc-run/$NAME/etc:
-junk
+TEST_KEY="${TEST_KEY_BASE}-items-${JOB_HOST}"
+if [[ "${TEST_KEY_BASE}" == *local* ]]; then
+    skip 2 "${TEST_KEY}: local-install-only"
+elif [[ -n "${JOB_HOST}" ]]; then
+    run_pass "${TEST_KEY}" \
+        ssh -oBatchMode=yes "${JOB_HOST}" \
+        "find 'cylc-run/${NAME}/'{app,colon:is:ok,etc} -type f"
+    sort "${TEST_KEY}.out" >"${TEST_KEY}.out.sort"
+    file_cmp "${TEST_KEY}.out" "${TEST_KEY}.out.sort" <<__OUT__
+cylc-run/${NAME}/app/my_task_1/rose-app.conf
+cylc-run/${NAME}/colon:is:ok
+cylc-run/${NAME}/etc/junk
 __OUT__
 else
-    skip 2 "$TEST_KEY_BASE-items: [t]job-host not defined"
+    skip 2 "${TEST_KEY_BASE}-items: [t]job-host not defined"
 fi
 #-------------------------------------------------------------------------------
-rose suite-clean -q -y $NAME
+rose suite-clean -q -y "${NAME}"
 exit 0


### PR DESCRIPTION
Improve `rsync` commands in logic.
* The `rose rug-brief-tour` command was far too complicated. All it does is a local copy.
* For `rose suite-run`,
  use `rsync` command's `--exclude=PATTERN` options to exclude items from source,
  instead of listing items in the source directory.

Added a file with colon in its name to the install test.

@arjclark @kaday please review.