### PR TITLE
doc: rose task-env: remove cycle point notes

### DIFF
--- a/doc/rose-command.html
+++ b/doc/rose-command.html
@@ -2564,14 +2564,6 @@ launcher-preopts.mpiexec=-n $NPROC
       <dd>Increment verbosity.</dd>
     </dl>
 
-    <h3>NOTE ON CYCLE TIME</h3>
-
-    <p>Cycle time is expected to be in the <var>YYYYmmdd[HH[MM]]</var> format
-    at the moment. It would be desirable to move to an ISO 8601 compliant
-    format, e.g. <var>&lt;date&gt;[T&lt;time&gt;]</var> where
-    <var>&lt;date&gt;</var> is <var>YYYYmmdd</var> and <var>&lt;time&gt;</var>
-    is <var>HH[MM]</var>.</p>
-
     <h3>USAGE IN SUITES</h3>
 
     <p><kbd>rose task-env</kbd> can be used to make environment variables


### PR DESCRIPTION
The notes are no longer required now that we fully support ISO-8601 date
time cycle points.

@kaday please review.