### PR TITLE
Use hostname for authentication prompts

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,6 +35,7 @@ below:
 * Matt Shin (Met Office, UK)
 * Stuart Whitehouse (Met Office, UK)
 * Steve Wardle (Met Office, UK)
+* Scott Wales (ARC Centre of Excellence for Climate Systems Science, Australia)
 
 (All contributors are identifiable with email addresses in the version control
 logs or otherwise.)

--- a/lib/python/rosie/ws_client_auth.py
+++ b/lib/python/rosie/ws_client_auth.py
@@ -246,8 +246,8 @@ class RosieWSClientAuthManager(object):
         "gnomekeyring": GnomekeyringStore,
         #KeyringStore,
     }
-    PROMPT_USERNAME = "Username for %(prefix)r: "
-    PROMPT_PASSWORD = "Password for %(username)s at %(prefix)r: "
+    PROMPT_USERNAME = "Username for %(host)r: "
+    PROMPT_PASSWORD = "Password for %(username)s at %(host)r: "
     STR_CANCELLED = "cancelled by user"
 
     def __init__(self, prefix, popen=None, prompt_func=None):
@@ -379,7 +379,7 @@ class RosieWSClientAuthManager(object):
             if self.username:
                 username = ""
 
-            prompt = self.PROMPT_USERNAME % {"prefix": self.prefix}
+            prompt = self.PROMPT_USERNAME % {"host": self.root}
             if self.popen.which("zenity") and os.getenv("DISPLAY"):
                 username = self.popen.run(
                     "zenity", "--entry",
@@ -397,7 +397,7 @@ class RosieWSClientAuthManager(object):
                     return
 
         if self.username and self.password is None or is_retry:
-            prompt = self.PROMPT_PASSWORD % {"prefix": self.prefix,
+            prompt = self.PROMPT_PASSWORD % {"host": self.root,
                                              "username": self.username}
             if hasattr(self.password_store, "prompt_password"):
                 password = self.password_store.prompt_password(

--- a/lib/python/rosie/ws_client_auth.py
+++ b/lib/python/rosie/ws_client_auth.py
@@ -246,8 +246,8 @@ class RosieWSClientAuthManager(object):
         "gnomekeyring": GnomekeyringStore,
         #KeyringStore,
     }
-    PROMPT_USERNAME = "Username for %(host)r: "
-    PROMPT_PASSWORD = "Password for %(username)s at %(host)r: "
+    PROMPT_USERNAME = "Username for %(prefix)r - %(root)r: "
+    PROMPT_PASSWORD = "Password for %(username)s at %(prefix)r - %(root)r: "
     STR_CANCELLED = "cancelled by user"
 
     def __init__(self, prefix, popen=None, prompt_func=None):
@@ -379,7 +379,7 @@ class RosieWSClientAuthManager(object):
             if self.username:
                 username = ""
 
-            prompt = self.PROMPT_USERNAME % {"host": self.root}
+            prompt = self.PROMPT_USERNAME % {"prefix": self.prefix, "root": self.root}
             if self.popen.which("zenity") and os.getenv("DISPLAY"):
                 username = self.popen.run(
                     "zenity", "--entry",
@@ -397,7 +397,8 @@ class RosieWSClientAuthManager(object):
                     return
 
         if self.username and self.password is None or is_retry:
-            prompt = self.PROMPT_PASSWORD % {"host": self.root,
+            prompt = self.PROMPT_PASSWORD % {"prefix": self.prefix,
+                                             "root": self.root, 
                                              "username": self.username}
             if hasattr(self.password_store, "prompt_password"):
                 password = self.password_store.prompt_password(


### PR DESCRIPTION
When a user first starts `rosie go` it asks to authenticate to the various servers. It requests this using the site prefix, e.g. `e`, which isn't necessarily meaningful to new users.

Instead of using the site prefix prompt users with the full URL, e.g. `https://example.com/rosie`. This way users can easily identify what they're being asked to connect to, and can go to that URL if necessary to learn more about it.