### PR TITLE
rose edit: fix unnamed variable close page crash

### DIFF
--- a/lib/python/rose/config_editor/page.py
+++ b/lib/python/rose/config_editor/page.py
@@ -1038,10 +1038,12 @@ class ConfigPage(gtk.VBox):
         for variable in datavars:
             title = variable.metadata.get(rose.META_PROP_TITLE, variable.name)
             var_id = variable.metadata.get('id', variable.name)
-            key = ((variable.metadata.get(rose.META_PROP_SORT_KEY, '~')),
-                                                                     var_id)
+            key = (
+                variable.metadata.get(rose.META_PROP_SORT_KEY, '~'),
+                var_id
+            )
             if variable.name == '':
-                key = '~'
+                key = ('~', '')
             sorted_data.append((key, title, variable.name,
                                 variable.value, variable))
         ascending_cmp = lambda x, y: rose.config_editor.util.null_cmp(x[0],


### PR DESCRIPTION
This fixes #1656.

@kaday, please review 1.
@matthewrmshin, please review 2.