### PR TITLE
Rosie go: Add try except to catch broken pipe error on puma.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,7 @@ below:
 * Joseph Mancell (Met Office, UK)
 * Dave Matthews (Met Office, UK)
 * Hilary Oliver (National Institute of Water and Atmospheric Research, New Zealand)
+* Annette Osprey (NCAS Computational Modelling Services, UK)
 * Stephen Oxley (Met Office, UK)
 * Matt Pryor (Met Office, UK)
 * Matt Shin (Met Office, UK)

--- a/lib/python/rose/gtk/splash.py
+++ b/lib/python/rose/gtk/splash.py
@@ -232,7 +232,10 @@ class SplashScreenProcess(object):
 
     def stop(self):
         if self.process is not None and not self.process.stdin.closed:
-            self.process.communicate(input=json.dumps("stop") + "\n")
+            try: 
+                self.process.communicate(input=json.dumps("stop") + "\n")
+            except IOError as e: 
+                pass
         self.process = None
 
 

--- a/lib/python/rose/gtk/splash.py
+++ b/lib/python/rose/gtk/splash.py
@@ -234,7 +234,7 @@ class SplashScreenProcess(object):
         if self.process is not None and not self.process.stdin.closed:
             try: 
                 self.process.communicate(input=json.dumps("stop") + "\n")
-            except IOError as e: 
+            except IOError: 
                 pass
         self.process = None
 


### PR DESCRIPTION
Fix for "IOError [Errno32] Broken pipe" which is seen frequently on puma without this change. Issue occurs when launching rosie go. 

Ros did quite a lot of testing, including using the exact same versions of python modules as at the MetO, but was unable to track down the cause of the error. 

![roseguibrokenpipe](https://cloud.githubusercontent.com/assets/4313200/9473528/2d94b4d6-4b53-11e5-933e-9a965b766a96.png)
