### PR TITLE
rose bush: default to escaping output HTML

### DIFF
--- a/lib/html/rose-bush/view-mode.html
+++ b/lib/html/rose-bush/view-mode.html
@@ -1,10 +1,10 @@
 <ul class="nav pull-right">
-{% if mode != "text" -%}
-<li class="active"><a>Normal</a></li>
-<li><a href="{{script}}/view/{{user}}/{{suite}}?path={{path}}{%- if path_in_tar -%}&amp;path_in_tar={{path_in_tar}}{%- endif -%}&amp;mode=text">Text</a></li>
+{% if mode == "tags" -%}
+<li><a href="{{script}}/view/{{user}}/{{suite}}?path={{path}}{%- if path_in_tar -%}&amp;path_in_tar={{path_in_tar}}{%- endif -%}">Text</a></li>
+<li class="active"><a>Tags</a></li>
 {% else -%}
-<li><a href="{{script}}/view/{{user}}/{{suite}}?path={{path}}{%- if path_in_tar -%}&amp;path_in_tar={{path_in_tar}}{%- endif -%}">Normal</a></li>
 <li class="active"><a>Text</a></li>
+<li><a href="{{script}}/view/{{user}}/{{suite}}?path={{path}}{%- if path_in_tar -%}&amp;path_in_tar={{path_in_tar}}{%- endif -%}&amp;mode=tags">Tags</a></li>
 {% endif -%}
 <li><a href="{{script}}/view/{{user}}/{{suite}}?path={{path}}{%- if path_in_tar -%}&amp;path_in_tar={{path_in_tar}}{%- endif -%}&amp;mode=download">Raw</a></li>
 </ul>

--- a/lib/python/rose/bush.py
+++ b/lib/python/rose/bush.py
@@ -401,7 +401,7 @@ class Root(object):
                 cherrypy.response.headers["Content-Type"] = mime
                 return cherrypy.lib.static.serve_file(f_name, mime)
             s = open(f_name).read()
-        if mode == "text":
+        if mode is None:
             s = jinja2.escape(s)
         try:
             lines = [unicode(line) for line in s.splitlines()]


### PR DESCRIPTION
This addresses #1684.

@steoxley, this change would mean that HTML tags wouldn't be processed by default
(although the 'HTML view' is still available). What do you think?