### PR TITLE
Document ROSE_TASK_LOG_DIR

### DIFF
--- a/doc/rose-variables.html
+++ b/doc/rose-variables.html
@@ -405,6 +405,18 @@
       <li><a href="rose-command.html#rose-task-env">rose task-env</a></li>
     </ul>
 
+    <h2 id="ROSE_TASK_LOG_DIR"><var>ROSE_TASK_LOG_DIR</var></h2>
+
+    <h3>Description</h3>
+
+    <p>The directory for log files of the suite task.</p>
+
+    <h3>Provided By</h3>
+
+    <ul>
+      <li><a href="rose-command.html#rose-task-env">rose task-env</a></li>
+    </ul>
+
     <h2 id="ROSE_TASK_LOG_ROOT"><var>ROSE_TASK_LOG_ROOT</var></h2>
 
     <h3>Description</h3>


### PR DESCRIPTION
Adds `ROSE_TASK_LOG_DIR` to the documentation (currently missing).

@matthewrmshin - please review.