### PR TITLE
Fix tests

### DIFF
--- a/t/rose-ana/00-run-basic/suite.rc
+++ b/t/rose-ana/00-run-basic/suite.rc
@@ -4,6 +4,7 @@ UTC mode=True
     [[event hooks]]
         timeout handler=rose suite-hook --shutdown
         timeout=PT30S
+        abort on timeout=False
 
 [scheduling]
     [[dependencies]]

--- a/t/rose-suite-restart/02-basic.t
+++ b/t/rose-suite-restart/02-basic.t
@@ -38,7 +38,7 @@ file_grep "${TEST_KEY}.out.1" \
     "${TEST_KEY}.out"
 # N.B. This relies on output from "cylc restart"
 file_grep "${TEST_KEY}.out.2" \
-    "\\[INFO\\] cylc job-submit ${SUITE_RUN_DIR}/log/job/1/t2/01/job" \
+    "\\[INFO\\] cylc jobs-submit --debug -- ${SUITE_RUN_DIR}/log/job 1/t2/01" \
     "${TEST_KEY}.out"
 file_cmp "${TEST_KEY}.err" "${TEST_KEY}.err" '/dev/null'
 #-------------------------------------------------------------------------------

--- a/t/rose-suite-restart/03-host.t
+++ b/t/rose-suite-restart/03-host.t
@@ -48,7 +48,7 @@ file_grep "${TEST_KEY}.out.1" \
     "${TEST_KEY}.out"
 # N.B. This relies on output from "cylc restart"
 file_grep "${TEST_KEY}.out.2" \
-    "\\[INFO\\] cylc job-submit ${SUITE_RUN_DIR}/log/job/1/t2/01/job" \
+    "\\[INFO\\] cylc jobs-submit --debug -- ${SUITE_RUN_DIR}/log/job 1/t2/01" \
     "${TEST_KEY}.out"
 file_cmp "${TEST_KEY}.err" "${TEST_KEY}.err" '/dev/null'
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
* rose suite-restart tests broken by cylc/cylc#1591
* rose-ana tests becomes sensitive to abort on timeout setting in cylc's
  global.rc since cylc/cylc#1548

@benfitzpatrick @arjclark please review.