### PR TITLE
rose suite-run: fix occasional tarfile crash

### DIFF
--- a/lib/python/rose/suite_run.py
+++ b/lib/python/rose/suite_run.py
@@ -538,9 +538,14 @@ class SuiteRunner(Runner):
                     continue
                 log_tar = log + ".tar"
                 f_bsize = os.statvfs(log).f_bsize
-                tar_handle = tarfile.open(log_tar, "w", bufsize=f_bsize)
+                tar_f = open(log_tar, "w")
+                tar_handle = tarfile.open(mode="w", fileobj=tar_f,
+                                          bufsize=f_bsize)
                 tar_handle.add(log)
                 tar_handle.close()
+                tar_f.flush()
+                os.fsync(tar_f.fileno())           
+                tar_f.close()
                 # N.B. Python's gzip is slow
                 self.popen.run_simple("gzip", "-f", log_tar)
                 self.handle_event(SuiteLogArchiveEvent(log_tar + ".gz", log))


### PR DESCRIPTION
Python 2's `tarfile.TarFile.close()` is sometimes inadequate for our large files.
This can cause a fatal problem in the `gzip` call on the next line ('log.XXX.tar not found').

@matthewrmshin, please review 1.