### PR TITLE
rose task-run: allow -O (key) syntax

### DIFF
--- a/bin/rose-app-run
+++ b/bin/rose-app-run
@@ -57,9 +57,11 @@
 #         works with the --config=DIR option and if $PWD is not DIR.
 #     --no-overwrite
 #         Do not overwrite existing files.
-#     --opt-conf-key=KEY, -O KEY
+#     --opt-conf-key=KEY, -O KEY, --opt-conf-key='(KEY)', -O '(KEY)'
 #         Each of these switches on an optional configuration identified by KEY.
-#         The configurations are applied first-to-last.
+#         The configurations are applied first-to-last. The '(KEY)' syntax
+#         denotes an optional configuration that can be missing. Otherwise, the
+#         optional configuration must exist.
 #     --quiet, -q
 #         Decrement verbosity.
 #     --verbose, -v

--- a/bin/rose-suite-run
+++ b/bin/rose-suite-run
@@ -86,7 +86,7 @@
 #         Do not overwrite existing files.
 #     --no-strict
 #         Do not validate (suite engine configuration) in strict mode.
-#     --opt-conf-key=KEY, -O KEY
+#     --opt-conf-key=KEY, -O KEY, --opt-conf-key='(KEY)', -O '(KEY)'
 #         Each of these switches on an optional configuration identified by KEY.
 #         The configurations are applied first-to-last. The '(KEY)' syntax
 #         denotes an optional configuration that can be missing. Otherwise, the

--- a/bin/rose-suite-run
+++ b/bin/rose-suite-run
@@ -88,7 +88,9 @@
 #         Do not validate (suite engine configuration) in strict mode.
 #     --opt-conf-key=KEY, -O KEY
 #         Each of these switches on an optional configuration identified by KEY.
-#         The configurations are applied first-to-last.
+#         The configurations are applied first-to-last. The '(KEY)' syntax
+#         denotes an optional configuration that can be missing. Otherwise, the
+#         optional configuration must exist.
 #     --quiet, -q
 #         Decrement verbosity.
 #     --reload

--- a/doc/rose-command.html
+++ b/doc/rose-command.html
@@ -2229,7 +2229,8 @@ launcher-preopts.mpiexec=-n $NPROC
 
       <dd>Do not validate (suite engine configuration) in strict mode.</dd>
 
-      <dt><kbd>--opt-conf-key=KEY, -O KEY</kbd></dt>
+      <dt><kbd>--opt-conf-key=KEY, -O KEY, --opt-conf-key='(KEY)',
+      -O '(KEY)'</kbd></dt>
 
       <dd>Each of these switches on an optional configuration identified by
       <var>KEY</var>. The configurations are applied first-to-last. The

--- a/doc/rose-command.html
+++ b/doc/rose-command.html
@@ -355,10 +355,13 @@ rosie UTIL [OPTS] [ARG ...]
 
       <dd>Do not overwrite existing files.</dd>
 
-      <dt><kbd>--opt-conf-key=KEY, -O KEY</kbd></dt>
+      <dt><kbd>--opt-conf-key=KEY, -O KEY, --opt-conf-key='(KEY)',
+      -O '(KEY)'</kbd></dt>
 
       <dd>Each of these switches on an optional configuration identified by
-      <var>KEY</var>. The configurations are applied first-to-last.</dd>
+      <var>KEY</var>. The configurations are applied first-to-last. The
+      <var>'(KEY)'</var> syntax denotes an optional configuration that can be
+      missing. Otherwise, the optional configuration must exist.</dd>
 
       <dt><kbd>--quiet, -q</kbd></dt>
 
@@ -2229,7 +2232,9 @@ launcher-preopts.mpiexec=-n $NPROC
       <dt><kbd>--opt-conf-key=KEY, -O KEY</kbd></dt>
 
       <dd>Each of these switches on an optional configuration identified by
-      <var>KEY</var>. The configurations are applied first-to-last.</dd>
+      <var>KEY</var>. The configurations are applied first-to-last. The
+      <var>'(KEY)'</var> syntax denotes an optional configuration that can be
+      missing. Otherwise, the optional configuration must exist.</dd>
 
       <dt><kbd>--quiet, -q</kbd></dt>
 

--- a/doc/rose-configuration.html
+++ b/doc/rose-configuration.html
@@ -270,7 +270,9 @@ opts=ketchup (mayonnaise)
       detail.)</li>
 
       <li>The command line option <code>--opt-conf-key=KEY</code> or <code>-O
-      KEY</code>.</li>
+      KEY</code> for optional configurations that must exist, and
+      <code>--opt-conf-key='(KEY)'</code> or <code>-O '(KEY)'</code> for
+      optional configurations that can be missing.</li>
     </ol>
 
     <h3 id="opts-meta">Optional Configurations and Metadata</h3>

--- a/doc/rose-variables.html
+++ b/doc/rose-variables.html
@@ -53,9 +53,10 @@
 
     <h3>Description</h3>
 
-    <p>Each KEY in this space delimited list switches on an optional
-    configuration in an application. The configurations are applied in
-    first-to-last order.</p>
+    <p>Each <var>KEY</var> in this space delimited list switches on an optional
+    configuration in an application. The <var>(KEY)</var> syntax can be used to
+    denote an optional configuration that can be missing. The configurations are
+    applied in first-to-last order.</p>
 
     <h3>Used By</h3>
 
@@ -372,8 +373,9 @@
     <h3>Description</h3>
 
     <p>Each KEY in this space delimited list switches on an optional
-    configuration when installing a suite. The configurations are applied in
-    first-to-last order.</p>
+    configuration when installing a suite. The <var>(KEY)</var> syntax can be
+    used to denote an optional configuration that can be missing. The
+    configurations are applied in first-to-last order.</p>
 
     <h3>Used By</h3>
 

--- a/lib/python/rose/config_tree.py
+++ b/lib/python/rose/config_tree.py
@@ -112,13 +112,13 @@ class ConfigTreeLoader(object):
             conf_dir, self._get_base_names, conf_name, conf_dir_paths,
             opt_keys, used_keys, nodes)
 
-        if opt_keys:
-            bad_keys = []
-            for opt_key in opt_keys:
-                if opt_key not in used_keys:
-                    bad_keys.append(opt_key)
-            if bad_keys:
-                raise BadOptionalConfigurationKeysError(bad_keys)
+        bad_keys = []
+        for opt_key in opt_keys:
+            if (opt_key not in used_keys and
+                    not self.node_loader.can_miss_opt_conf_key(opt_key)):
+                bad_keys.append(opt_key)
+        if bad_keys:
+            raise BadOptionalConfigurationKeysError(bad_keys)
 
         if conf_node is None:
             conf_tree.node = ConfigNode()

--- a/lib/python/rose/config_tree.py
+++ b/lib/python/rose/config_tree.py
@@ -112,13 +112,14 @@ class ConfigTreeLoader(object):
             conf_dir, self._get_base_names, conf_name, conf_dir_paths,
             opt_keys, used_keys, nodes)
 
-        bad_keys = []
-        for opt_key in opt_keys:
-            if (opt_key not in used_keys and
-                    not self.node_loader.can_miss_opt_conf_key(opt_key)):
-                bad_keys.append(opt_key)
-        if bad_keys:
-            raise BadOptionalConfigurationKeysError(bad_keys)
+        if opt_keys:
+            bad_keys = []
+            for opt_key in opt_keys:
+                if (opt_key not in used_keys and
+                        not self.node_loader.can_miss_opt_conf_key(opt_key)):
+                    bad_keys.append(opt_key)
+            if bad_keys:
+                raise BadOptionalConfigurationKeysError(bad_keys)
 
         if conf_node is None:
             conf_tree.node = ConfigNode()

--- a/t/rose-app-run/22-opt-conf-key-missing.t
+++ b/t/rose-app-run/22-opt-conf-key-missing.t
@@ -1,0 +1,78 @@
+#!/bin/bash
+#-------------------------------------------------------------------------------
+# (C) British Crown Copyright 2012-5 Met Office.
+#
+# This file is part of Rose, a framework for meteorological suites.
+#
+# Rose is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Rose is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Rose. If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test "rose app-run -O (key)" syntax.
+#-------------------------------------------------------------------------------
+. "$(dirname "$0")/test_header"
+tests 6
+#-------------------------------------------------------------------------------
+test_init <<'__CONFIG__'
+[command]
+default=printenv FOO BAR
+
+[env]
+BAR=bar bar
+__CONFIG__
+mkdir 'config/opt'
+cat >'config/opt/rose-app-num1.conf' <<'__CONF__'
+[env]
+FOO=foo foo
+__CONF__
+#-------------------------------------------------------------------------------
+TEST_KEY="${TEST_KEY_BASE}-cli"
+test_setup
+run_pass "${TEST_KEY}" \
+    rose app-run -O '(num0)' -O 'num1' -O '(num2)' --config='../config' -v
+sed '/^\[INFO\] export PATH=/d' "${TEST_KEY}.out" >"${TEST_KEY}.out.edited"
+file_cmp "${TEST_KEY}.out" "${TEST_KEY}.out.edited" <<'__OUT__'
+[INFO] Configuration: ../config/
+[INFO]     file: rose-app.conf
+[INFO]     optional key: (num0)
+[INFO]     optional key: num1
+[INFO]     optional key: (num2)
+[INFO] export BAR=bar\ bar
+[INFO] export FOO=foo\ foo
+[INFO] command: printenv FOO BAR
+foo foo
+bar bar
+__OUT__
+file_cmp "${TEST_KEY}.err" "${TEST_KEY}.err" <'/dev/null'
+test_teardown
+#-------------------------------------------------------------------------------
+TEST_KEY="${TEST_KEY_BASE}-env"
+test_setup
+ROSE_APP_OPT_CONF_KEYS='(num0) num1 (num2)' \
+run_pass "${TEST_KEY}" rose app-run --config='../config' -v
+sed '/^\[INFO\] export PATH=/d' "${TEST_KEY}.out" >"${TEST_KEY}.out.edited"
+file_cmp "${TEST_KEY}.out" "${TEST_KEY}.out.edited" <<'__OUT__'
+[INFO] Configuration: ../config/
+[INFO]     file: rose-app.conf
+[INFO]     optional key: (num0)
+[INFO]     optional key: num1
+[INFO]     optional key: (num2)
+[INFO] export BAR=bar\ bar
+[INFO] export FOO=foo\ foo
+[INFO] command: printenv FOO BAR
+foo foo
+bar bar
+__OUT__
+file_cmp "${TEST_KEY}.err" "${TEST_KEY}.err" <'/dev/null'
+test_teardown
+#-------------------------------------------------------------------------------
+exit


### PR DESCRIPTION
Allow missing optional configuration keys via CLI option and
environment variable.

Close #1694.