### PR TITLE
rosie: rose-suite.info metadata doc update

### DIFF
--- a/doc/rose-command.html
+++ b/doc/rose-command.html
@@ -2751,7 +2751,7 @@ environment scripting = "eval $(rose task-env)"
       <dd>Specify the prefix (i.e. the suite repository) to use. The default
       behaviour is to use the site default.</dd>
 
-      <dt><kbd>--prefix=PROJECT</kbd></dt>
+      <dt><kbd>--project=PROJECT</kbd></dt>
 
       <dd>Specify a project to check/query any available metadata. The default
       behaviour is to use no project and no metadata.</dd>

--- a/doc/rose-configuration-metadata.html
+++ b/doc/rose-configuration-metadata.html
@@ -831,6 +831,31 @@ main             beef      spaghetti   coq au vin       lamb
 petits_fours    .false.     .true.       .false.       .true.
 </pre>
       </dd>
+      <dt id="meta.conf.behaviour.copy-mode">copy-mode (metadata useage with
+      the rose-suite.info file)</dt>
+
+      <dd>
+        <p>Setting copy-mode in the metadata allows for the field to be
+           either "never" copied or copied with any value associated 
+           to be "clear".</p>
+
+        <p>For example: in a rose-suite.info file</p>
+        <pre class="prettyprint lang-rose_conf">
+[ensemble members]
+copy-mode=never
+</pre>
+        <p>The setting the <var>ensemble members</var> field to include
+        <var>copy-mode=never</var> means that the ensemble members field would
+        never be copied.</p>
+        <pre class="prettyprint lang-rose_conf">
+[additional info]
+copy-mode=clear
+</pre>
+        <p>The setting the <var>additional info</var> field to include
+        <var>copy-mode=never</var> means that the additional info field
+        would be copied, but any value associated with it would be cleared.</p>
+
+      </dd>
     </dl>
 
     <h3 id="meta.conf.help">Metadata for Help</h3>

--- a/doc/rose-configuration-metadata.html
+++ b/doc/rose-configuration-metadata.html
@@ -831,27 +831,27 @@ main             beef      spaghetti   coq au vin       lamb
 petits_fours    .false.     .true.       .false.       .true.
 </pre>
       </dd>
-      <dt id="meta.conf.behaviour.copy-mode">copy-mode (metadata useage with
+      <dt id="meta.conf.behaviour.copy-mode">copy-mode (metadata usage with
       the rose-suite.info file)</dt>
 
       <dd>
         <p>Setting copy-mode in the metadata allows for the field to be
-           either "never" copied or copied with any value associated 
-           to be "clear".</p>
+           either <code>never</code> copied or copied with any value associated 
+           to be <code>clear</code>.</p>
 
         <p>For example: in a rose-suite.info file</p>
         <pre class="prettyprint lang-rose_conf">
 [ensemble members]
 copy-mode=never
 </pre>
-        <p>The setting the <var>ensemble members</var> field to include
+        <p>Setting the <var>ensemble members</var> field to include
         <var>copy-mode=never</var> means that the ensemble members field would
         never be copied.</p>
         <pre class="prettyprint lang-rose_conf">
 [additional info]
 copy-mode=clear
 </pre>
-        <p>The setting the <var>additional info</var> field to include
+        <p>Setting the <var>additional info</var> field to include
         <var>copy-mode=never</var> means that the additional info field
         would be copied, but any value associated with it would be cleared.</p>
 


### PR DESCRIPTION
Typo corrected and documentation on `copy-mode` added.