### PR TITLE
rose.namelist: fix parsing of blank value repeats

### DIFF
--- a/lib/python/rose/formats/namelist.py
+++ b/lib/python/rose/formats/namelist.py
@@ -357,6 +357,9 @@ def _expand_repeats(val_item):
     search = REC_VALUE_REPEAT.search(val_item)
     if search:
         repeat, data = search.groups()
+        if data is None:
+            # null string, e.g. '7*'
+            data = ""
         return ",".join([data] * int(repeat))
     else:
         return val_item
@@ -366,6 +369,7 @@ def pretty_format_value(values):
     """Pretty-format a namelist value list."""
     nm_item = NamelistObject("", values)
     return nm_item.get_rhs_as_string(wrapped=True)
+
 
 def pretty_format_keys(keys):
     """Pretty-format namelist keys."""

--- a/t/rose-macro/22-repeats.t
+++ b/t/rose-macro/22-repeats.t
@@ -1,0 +1,41 @@
+#!/bin/bash
+#-------------------------------------------------------------------------------
+# (C) British Crown Copyright 2012-5 Met Office.
+#
+# This file is part of Rose, a framework for meteorological suites.
+#
+# Rose is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Rose is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Rose. If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test "rose macro" for repeat syntax.
+#-------------------------------------------------------------------------------
+. $(dirname $0)/test_header
+init <<'__CONFIG__'
+[namelist:values_nl1]
+my_many_blank_repeats=50*
+__CONFIG__
+#-------------------------------------------------------------------------------
+tests 3
+#-------------------------------------------------------------------------------
+# Check boolean type checking.
+TEST_KEY=$TEST_KEY_BASE-can-read-blank-repeats
+setup
+init_meta <<__META_CONFIG__
+[namelist:values_nl1=my_many_blank_repeats]
+__META_CONFIG__
+run_pass "$TEST_KEY" rose macro --config=../config rose.macros.DefaultValidators
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+teardown
+#-------------------------------------------------------------------------------
+exit


### PR DESCRIPTION
This fixes a bug in namelist repeat syntax parsing.

@matthewrmshin, please review. No 2-review necessary, I think.