### PR TITLE
rose doc: typo values

### DIFF
--- a/doc/rose-rug-metadata.html
+++ b/doc/rose-rug-metadata.html
@@ -289,11 +289,11 @@ warn-if=this &gt;= namelist:run_snow=max_ok_ice_fraction or this &lt; 0.2
       <h3 class="alwayshidden">More Metadata Options - value</h3>
 
       <dl>
-        <dt><code>value</code></dt>
+        <dt><code>values</code></dt>
 
         <dd>Allows you to set a comma separated list of permitted
         <code>values</code> e.g. <samp>values=0, 1</samp> or 
-        <samp>value=False, True</samp>.</dd>
+        <samp>values=False, True</samp>.</dd>
       </dl>
     </div>
 


### PR DESCRIPTION
values not value