### PR TITLE
rose suite-hook: --retrieve-job-logs

### DIFF
--- a/bin/rose-suite-hook
+++ b/bin/rose-suite-hook
@@ -27,8 +27,7 @@
 #
 # DESCRIPTION
 #     Provide a common event hook for Cylc suites and tasks.
-#     * (Task event only) Pull remote task logs back to server host.
-#     * Generate suite log view.
+#     * (Task event only) Retrieve remote task logs back to server host.
 #     * Email user if --mail specified.
 #     * Shutdown suite if --shutdown specified.
 #
@@ -40,6 +39,8 @@
 #         comma separated list of additional addresses to email.
 #     --mail
 #         Trigger an email notification to the user.
+#     --retrieve-job-logs
+#         Retrieve remote task job logs.
 #     --shutdown
 #         Trigger a shutdown of the suite.
 #     --quiet, -q

--- a/doc/rose-command.html
+++ b/doc/rose-command.html
@@ -1947,6 +1947,10 @@ launcher-preopts.mpiexec=-n $NPROC
 
       <dd>Trigger an email notification to the user.</dd>
 
+      <dt><kbd>--retrieve-job-logs</kbd></dt>
+
+      <dd>Retrieve remote task job logs.</dd>
+
       <dt><kbd>--shutdown</kbd></dt>
 
       <dd>Trigger a shutdown of the suite.</dd>

--- a/lib/python/rose/opt_parse.py
+++ b/lib/python/rose/opt_parse.py
@@ -504,6 +504,11 @@ class RoseOptionParser(OptionParser):
              "const": "restart",
              "dest": "run_mode",
              "help": "Shorthand for --run=restart."}],
+        "retrieve_job_logs": [
+            ["--retrieve-job-logs"],
+            {"action": "store_true",
+             "default": False,
+             "help": "Retrieve remote task job logs."}],
         "run_mode": [
             ["--run"],
             {"action": "store",

--- a/lib/python/rose/suite_hook.py
+++ b/lib/python/rose/suite_hook.py
@@ -52,7 +52,8 @@ class RoseSuiteHook(object):
             return self.event_handler(*args, **kwargs)
 
     def run(self, suite_name, task_id, hook_event, hook_message=None,
-            should_mail=False, mail_cc_list=None, should_shutdown=False):
+            should_mail=False, mail_cc_list=None, should_shutdown=False,
+            should_retrieve_job_logs=False):
         """
         Invoke the hook for a suite.
 
@@ -65,7 +66,7 @@ class RoseSuiteHook(object):
         """
         # Retrieve log and populate job logs database
         task_ids = []
-        if task_id:
+        if task_id and should_retrieve_job_logs:
             task_ids = [task_id]
             self.suite_engine_proc.job_logs_pull_remote(suite_name, task_ids)
 
@@ -120,7 +121,8 @@ class RoseSuiteHook(object):
 def main():
     """Implement "rose suite-hook" command."""
     opt_parser = RoseOptionParser()
-    opt_parser.add_my_options("mail_cc", "mail", "shutdown")
+    opt_parser.add_my_options(
+        "mail_cc", "mail", "retrieve_job_logs", "shutdown")
     opts, args = opt_parser.parse_args()
     for key in ["mail_cc"]:
         values = []
@@ -139,7 +141,8 @@ def main():
     hook(*args,
          should_mail=opts.mail,
          mail_cc_list=opts.mail_cc,
-         should_shutdown=opts.shutdown)
+         should_shutdown=opts.shutdown,
+         should_retrieve_job_logs=opts.retrieve_job_logs)
 
 
 if __name__ == "__main__":

--- a/t/rose-suite-hook/01-job-host/suite.rc
+++ b/t/rose-suite-hook/01-job-host/suite.rc
@@ -13,8 +13,8 @@ my_task_1
 [runtime]
     [[root]]
         [[[event hooks]]]
-           succeeded handler = "rose suite-hook"
-           failed handler = "rose suite-hook --shutdown"
+           succeeded handler = "rose suite-hook --retrieve-job-logs"
+           failed handler = "rose suite-hook --shutdown --retrieve-job-logs"
            submission failed handler = "rose suite-hook --shutdown"
            submission timeout handler = "rose suite-hook"
            execution timeout handler = "rose suite-hook"

--- a/t/rose-suite-hook/05-job-logs-retrieved.t
+++ b/t/rose-suite-hook/05-job-logs-retrieved.t
@@ -30,7 +30,7 @@ fi
 HOST="$(rose host-select -q "${HOST}")"
 export ROSE_CONF_PATH="${TEST_SOURCE_DIR}/${TEST_KEY_BASE}/conf"
 
-tests 8
+tests 7
 
 #-------------------------------------------------------------------------------
 TEST_KEY="${TEST_KEY_BASE}"
@@ -52,12 +52,6 @@ Hello from ${TASK}.1
 __CONTENT__
 done
 cd "${OLDPWD}"
-
-grep "${SUITE_RUN_DIR}/bin/my-rsync .* ${SUITE_RUN_DIR}/log/job" \
-    'my-rsync.log' >'my-rsync.log.edited'
-file_cmp "${TEST_KEY}-rsync" 'my-rsync.log.edited' <<__LOG__
-${SUITE_RUN_DIR}/bin/my-rsync --include=/1 --include=/1/task-2 --exclude=/* --exclude=/*/* ${HOST}:cylc-run/${NAME}/log/job/ ${SUITE_RUN_DIR}/log/job
-__LOG__
 
 sqlite3 "${SUITE_RUN_DIR}/log/rose-job-logs.db" \
     'SELECT cycle,task,path FROM log_files ORDER BY cycle,task,path;' \

--- a/t/rose-suite-hook/05-job-logs-retrieved/suite.rc
+++ b/t/rose-suite-hook/05-job-logs-retrieved/suite.rc
@@ -15,7 +15,7 @@ task-2
     [[root]]
         script = echo "Hello from ${CYLC_TASK_ID}" >"${CYLC_TASK_LOG_ROOT}.txt"
         [[[events]]]
-            handlers = rose suite-hook
+            handlers = rose suite-hook --retrieve-job-logs
             handler events = succeeded, failed
             handler retry delays = PT20S
         [[[remote]]]

--- a/t/rose-suite-log/00-update-task/suite.rc
+++ b/t/rose-suite-log/00-update-task/suite.rc
@@ -15,7 +15,7 @@ my_task_2
     [[root]]
         command scripting = echo Hello
         [[[event hooks]]]
-            failed handler = rose suite-hook --shutdown
+            failed handler = rose suite-hook --shutdown --retrieve-job-logs
             submission failed handler = rose suite-hook --shutdown
             submission timeout handler = rose suite-hook
             execution timeout handler = rose suite-hook
@@ -27,5 +27,5 @@ my_task_2
 {% endif %}
     [[my_task_1]]
         [[[event hooks]]]
-           succeeded handler = rose suite-hook
+           succeeded handler = rose suite-hook --retrieve-job-logs
     [[my_task_2]]

--- a/t/rose-suite-log/01-update-cycle/suite.rc
+++ b/t/rose-suite-log/01-update-cycle/suite.rc
@@ -18,7 +18,7 @@ my_task_2
     [[root]]
         command scripting = echo Hello
         [[[event hooks]]]
-            failed handler = rose suite-hook --shutdown
+            failed handler = rose suite-hook --shutdown --retrieve-job-logs
             submission failed handler = rose suite-hook --shutdown
             submission timeout handler = rose suite-hook
             execution timeout handler = rose suite-hook
@@ -30,5 +30,5 @@ my_task_2
 {% endif %}
     [[my_task_1]]
         [[[event hooks]]]
-           succeeded handler = rose suite-hook
+           succeeded handler = rose suite-hook --retrieve-job-logs
     [[my_task_2]]

--- a/t/rose-suite-log/02-update-force/suite.rc
+++ b/t/rose-suite-log/02-update-force/suite.rc
@@ -18,7 +18,7 @@ my_task_2
     [[root]]
         command scripting = "echo Hello"
         [[[event hooks]]]
-            failed handler = "rose suite-hook --shutdown"
+            failed handler = "rose suite-hook --shutdown --retrieve-job-logs"
             submission failed handler = "rose suite-hook --shutdown"
             submission timeout handler = "rose suite-hook"
             execution timeout handler = "rose suite-hook"


### PR DESCRIPTION
Recent version of cylc, e.g. 6.7.1, has the ability to efficiently
retrieve remote job logs. The equivalent functionality in
`rose suite-hook` should now be considered unnecessary. This change
modifies the behaviour so that the functionality will not be carried out
unless the new `--retrieve-job-logs` option is specified.

See also #1731. @arjclark @kaday please review.