### PR TITLE
meta types: Add python_boolean meta type

### DIFF
--- a/demo/rose-config-edit/demo_meta/app/01-types/meta/rose-meta.conf
+++ b/demo/rose-config-edit/demo_meta/app/01-types/meta/rose-meta.conf
@@ -82,6 +82,10 @@ type=logical
 description=A variable which is restricted by pattern to consist of 8 integers
 pattern=^\d{8}$
 
+[namelist:nl1=my_python_boolean]
+description=A Python-compatible boolean variable
+type=python_boolean
+
 [namelist:nl1=my_python_list]
 description=A Python-compatible list format variable
 type=python_list

--- a/demo/rose-config-edit/demo_meta/app/01-types/rose-app.conf
+++ b/demo/rose-config-edit/demo_meta/app/01-types/rose-app.conf
@@ -29,6 +29,7 @@ my_logical=.false.
 my_logical_array=.false.,.true.,.false.
 my_logical_array_varying=.true.,.false.,.false.,.true.
 my_pattern=20120101
+my_python_boolean=False
 my_python_list=["Foo",5,False,"banana"]
 my_quoted="Double quoted string, allows \" with backslash"
 my_quoted_array="a","b","c"

--- a/doc/rose-configuration-metadata.html
+++ b/doc/rose-configuration-metadata.html
@@ -301,6 +301,17 @@ sort-key=do-not-like-00
             <p><dfn>usage:</dfn> Fortran logical types</p>
           </dd>
 
+          <dt><code>python_boolean</code></dt>
+
+          <dd>
+            <p><dfn>example option:</dfn> <samp>ENABLE_THINGS=True</samp></p>
+
+            <p><dfn>description:</dfn> Python boolean type - either 
+            <samp>True</samp> or <samp>False</samp></p>
+
+            <p><dfn>usage:</dfn> Python boolean types</p>
+          </dd>
+
           <dt><code>python_list</code></dt>
 
           <dd>

--- a/lib/python/rose/__init__.py
+++ b/lib/python/rose/__init__.py
@@ -105,7 +105,7 @@ META_PROP_VALUE_FALSE = "false"  # Not actually used.
 # "meta" and "file" are for internal use.
 TYPE_VALUES = ["boolean", "character", "integer",
                "logical", "quoted", "raw", "real",
-               "meta", "file", "python_list", "spaced_list"]
+               "meta", "file", "python_list", "python_boolean", "spaced_list"]
 
 # Preferred Fortran logical and environment boolean syntax
 TYPE_BOOLEAN_VALUE_FALSE = "false"
@@ -114,6 +114,10 @@ TYPE_LOGICAL_VALUE_FALSE = ".false."
 TYPE_LOGICAL_VALUE_TRUE = ".true."
 TYPE_LOGICAL_FALSE_TITLE = "false"
 TYPE_LOGICAL_TRUE_TITLE = "true"
+
+# Preferred Python boolean syntax
+TYPE_PYTHON_BOOLEAN_VALUE_FALSE = "False"
+TYPE_PYTHON_BOOLEAN_VALUE_TRUE = "True"
 
 # File variable names in the specification.
 FILE_VAR_CHECKSUM = "checksum"

--- a/lib/python/rose/config_editor/valuewidget/__init__.py
+++ b/lib/python/rose/config_editor/valuewidget/__init__.py
@@ -74,7 +74,7 @@ def chooser(value, metadata, error):
        m_hint is None):
         return text.RawValueWidget
     if (m_values is None and m_length is None and m_hint is None and
-       m_type in ['logical', 'boolean']):
+       m_type in ['logical', 'boolean', 'python_boolean']):
         return booltoggle.BoolToggleValueWidget
     if m_length is None:
         if m_values is not None and len(m_values) <= 4:

--- a/lib/python/rose/config_editor/valuewidget/booltoggle.py
+++ b/lib/python/rose/config_editor/valuewidget/booltoggle.py
@@ -43,6 +43,11 @@ class BoolToggleValueWidget(gtk.HBox):
                                    rose.TYPE_BOOLEAN_VALUE_TRUE]
             self.label_dict = dict(zip(self.allowed_values,
                                        self.allowed_values))
+        elif metadata.get(rose.META_PROP_TYPE) == "python_boolean":
+            self.allowed_values = [rose.TYPE_PYTHON_BOOLEAN_VALUE_FALSE,
+                                   rose.TYPE_PYTHON_BOOLEAN_VALUE_TRUE]
+            self.label_dict = dict(zip(self.allowed_values,
+                                       self.allowed_values))
         else:
             self.allowed_values = [rose.TYPE_LOGICAL_VALUE_FALSE,
                                    rose.TYPE_LOGICAL_VALUE_TRUE]

--- a/lib/python/rose/meta_type.py
+++ b/lib/python/rose/meta_type.py
@@ -101,6 +101,18 @@ class IntegerMetaType(MetaType):
         return [True, None]
 
 
+class PythonBooleanMetaType(MetaType):
+
+    KEY = "python_boolean"
+    WARNING = "Not a valid Python boolean format (True/False): {0}"
+
+    def is_valid(self, value):
+        if value not in [rose.TYPE_PYTHON_BOOLEAN_VALUE_TRUE,
+                         rose.TYPE_PYTHON_BOOLEAN_VALUE_FALSE]:
+            return [False, self.WARNING.format(repr(value))]
+        return [True, None]
+
+
 class PythonListMetaType(MetaType):
 
     KEY = "python_list"

--- a/t/rose-macro/01-value-type-check-ok.t
+++ b/t/rose-macro/01-value-type-check-ok.t
@@ -73,9 +73,11 @@ my_real_array_slice_2d(5:90,1)=5.0,6.0,3.0
 my_python_list=["Spam", True, "Cheese", False, 2000.0]
 my_python_list_empty=[]
 my_spaced_list=1 2 3 "bob"
+my_python_boolean_true=True
+my_python_boolean_false=False
 __CONFIG__
 #-------------------------------------------------------------------------------
-tests 36
+tests 39
 #-------------------------------------------------------------------------------
 # Check boolean type checking.
 TEST_KEY=$TEST_KEY_BASE-boolean-ok
@@ -365,4 +367,18 @@ file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
 teardown
 #-------------------------------------------------------------------------------
+# Check python boolean type checking.
+TEST_KEY=$TEST_KEY_BASE-boolean-ok
+setup
+init_meta <<'__META_CONFIG__'
+[namelist:values_nl1=my_python_boolean_true]
+type=python_boolean
+
+[namelist:values_nl1=my_python_boolean_false]
+type=python_boolean
+__META_CONFIG__
+run_pass "$TEST_KEY" rose macro -V --config=../config
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+teardown
 exit


### PR DESCRIPTION
Adds a python boolean metadata type.

Motivated by:
 * frequent using of jinja2 switches in suite.conf files and desire for suitable metadata type for that
 * desire for python boolean as part of #1696 

@kaday - please review 1
@benfitzpatrick - please review 2