### PR TITLE
Documentation tweaks/updates.

### DIFF
--- a/bin/rose-suite-hook
+++ b/bin/rose-suite-hook
@@ -26,7 +26,7 @@
 #     rose task-hook [OPTIONS] EVENT SUITE TASK_ID MSG
 #
 # DESCRIPTION
-#     Provide a common event hook for Cylc suites and tasks.
+#     Provide a common event hook for cylc suites and tasks.
 #     * (Task event only) Retrieve remote task logs back to server host.
 #     * Email user if --mail specified.
 #     * Shutdown suite if --shutdown specified.

--- a/bin/rose-suite-restart
+++ b/bin/rose-suite-restart
@@ -23,16 +23,16 @@
 # SYNOPSIS
 #     rose suite-restart [OPTIONS] [[--] CYLC-RESTART-ARGS]
 #
-#     # Restart Cylc suite with name equal to basename of $PWD.
+#     # Restart cylc suite with name equal to basename of $PWD.
 #     rose suite-restart
 #
-#     # Restart Cylc suite NAME
+#     # Restart cylc suite NAME
 #     rose suite-restart --name=NAME
 #
-#     # Restart Cylc suite NAME with a given state dump
+#     # Restart cylc suite NAME with a given state dump
 #     rose suite-restart --name=NAME -- state.20141118T161121.195326Z
 #
-#     # Restart Cylc suite NAME on given host
+#     # Restart cylc suite NAME on given host
 #     rose suite-restart --name=NAME --host=my-suite-host
 #
 # DESCRIPTION
@@ -48,7 +48,7 @@
 #     --host=HOST
 #         Specify a host for restarting the suite.
 #     --name=NAME, -n NAME
-#         Specify the suite NAME in Cylc, instead of using the basename of the
+#         Specify the suite NAME in cylc, instead of using the basename of the
 #         current working directory.
 #     --no-gcontrol
 #         Do not run "cylc gui". Default is to run "cylc gui" if the suite is

--- a/doc/rose-command.html
+++ b/doc/rose-command.html
@@ -1913,7 +1913,7 @@ launcher-preopts.mpiexec=-n $NPROC
 
     <h3>SYNOPSIS</h3>
 
-    <p>Cylc interface:</p>
+    <p>cylc interface:</p>
 
     <p><kbd>rose suite-hook [OPTIONS] EVENT SUITE MSG</kbd></p>
 
@@ -2065,16 +2065,16 @@ launcher-preopts.mpiexec=-n $NPROC
 
       <dt><kbd>rose suite-restart --name=foobar</kbd></dt>
 
-      <dd>Restart Cylc suite <samp>foobar</samp></dd>
+      <dd>Restart cylc suite <samp>foobar</samp></dd>
 
       <dt><kbd>rose suite-restart --name=foobar --
       state.20141118T161121.195326Z</kbd></dt>
 
-      <dd>Restart Cylc suite <samp>foobar</samp> with a given state dump</dd>
+      <dd>Restart cylc suite <samp>foobar</samp> with a given state dump</dd>
 
       <dt><kbd>rose suite-restart --name=foobar --host=my-suite-host</kbd></dt>
 
-      <dd>Restart Cylc suite <samp>foobar</samp> on given host</dd>
+      <dd>Restart cylc suite <samp>foobar</samp> on given host</dd>
     </dl>
 
     <h3>DESCRIPTION</h3>

--- a/doc/rose-rug-files.html
+++ b/doc/rose-rug-files.html
@@ -150,7 +150,8 @@ meta/                   # Metadata for the Rose suite configuration:
         <li>See <a href="rose-configuration.html#format">Configuration
         Format</a>.</li>
 
-        <li>modified INI format:
+        <li>modified <a href="https://en.wikipedia.org/wiki/INI_file">INI
+        format</a>:
           <pre class="prettyprint lang-rose_conf">
 [command]
 default=hello.exe
@@ -414,7 +415,7 @@ source=svn://host/nice_things_svn/trunk/icecreams.dat@100
 
       <p>You can find out more at the <a href=
       "rose-configuration.html#appendix-file-creation-mode">File Creation
-      Reference Page</a>.</p>
+      Reference</a>.</p>
     </div>
 
     <div class="slide">
@@ -535,7 +536,8 @@ rose config --meta env=SPAM_NUMBER help
       <h3 class="alwayshidden">Other Useful Commands (2)</h3>
 
       <p>See the <a href="rose-command.html">CLI documentation</a> for details
-      of further options.</p>
+      of further options and the <a href="rose-quick-ref.html">Quick
+      Reference</a> for a list of commonly used Rose commands.</p>
     </div>
 
     <div class="slide">
@@ -559,14 +561,19 @@ rose config --meta env=SPAM_NUMBER help
 
       <p>However, when proposing or testing changes to a suite, it's usually
       better to use a branch (<code>fcm branch-create</code>).</p>
+
+      <p>To examine the ancestry of a suite - what suite it was copied from and
+      what suites have been copied from it - you can use <code>rosie graph
+      SUITEID</code> to get a graphical view.</p>
     </div>
 
     <div class="slide">
       <h3 class="alwayshidden">Suite Version Control - config edit</h3>
 
-      <p>The config editor does not interface with Subversion/FCM - saving
-      changes purely modifies your working copy, just like a text editor.
-      Changes should be committed from the command line.</p>
+      <p>The config editor <strong>does not</strong> interface with
+      Subversion/FCM - saving changes purely modifies your working copy, just
+      like a text editor. Changes should be committed from the command line
+      using FCM commands.</p>
     </div>
 
     <div class="slide">

--- a/doc/rose-rug-getting-started.html
+++ b/doc/rose-rug-getting-started.html
@@ -139,7 +139,7 @@ geditor=gvim -f
     can locate your <samp>$ROSE_HOME</samp> by running <code>rose
     --version</code>.</p>
 
-    <h2 id="cylc">Configuring Cylc</h2>
+    <h2 id="cylc">Configuring cylc</h2>
 
     <p>See <a href=
     "http://cylc.github.io/cylc/html/single/cug-html.html#x1-160004.2">cylc Use

--- a/doc/rose-rug-introduction.html
+++ b/doc/rose-rug-introduction.html
@@ -273,34 +273,34 @@
     </div>
 
     <div class="slide">
-      <h2 id="what-is-cylc">What is Cylc?</h2>
+      <h2 id="what-is-cylc">What is cylc?</h2>
 
       <ul class="incremental">
-        <li>Cylc is a suite engine or <em>metascheduler</em>.</li>
+        <li>cylc is a suite engine or <em>metascheduler</em>.</li>
 
-        <li>Cylc runs scientific applications when their dependencies are
+        <li>cylc runs scientific applications when their dependencies are
         satisfied.</li>
 
-        <li>Cylc is configured via a <code>suite.rc</code> file that lives in
+        <li>cylc is configured via a <code>suite.rc</code> file that lives in
         the top directory of a Rose suite.</li>
 
-        <li>Cylc was originally developed by Hilary Oliver at NIWA, and is now
+        <li>cylc was originally developed by Hilary Oliver at NIWA, and is now
         a collaboration including the Rose team.</li>
       </ul>
     </div>
 
     <div class="slide">
-      <h3 class="alwayshidden">What is Cylc? Continued</h3>
+      <h3 class="alwayshidden">What is cylc? Continued</h3>
 
       <p>What's so special about cylc? Couldn't I just use a cron job?</p>
 
       <ul class="incremental">
-        <li>Cylc has a concise, easy-to-use configuration.</li>
+        <li>cylc has a concise, easy-to-use configuration.</li>
 
-        <li>Cylc has a very clever algorithm for deciding when applications are
+        <li>cylc has a very clever algorithm for deciding when applications are
         ready to run.</li>
 
-        <li>Cylc has nice utilities, including a GUI, for controlling and
+        <li>cylc has nice utilities, including a GUI, for controlling and
         monitoring your suite.</li>
 
         <li>Lots more features are described <a href=
@@ -309,7 +309,7 @@
     </div>
 
     <div class="slide">
-    <h3 class="alwayshidden">What is Cylc? Example</h3>
+    <h3 class="alwayshidden">What is cylc? Example</h3>
 
     <p class="caption">This is the cylc control/monitoring GUI.</p><img src=
     "cylc-gui.png" alt="cylc gui" width="60%" /></div>

--- a/doc/rose-rug-quiz.html
+++ b/doc/rose-rug-quiz.html
@@ -81,7 +81,7 @@
         </li>
 
         <li>
-          <p>Cylc is:</p>
+          <p>cylc is:</p>
 
           <div id="cylc-is" class="questions">
             <input type="radio" value="A" /><label for="A">a washing machine

--- a/doc/rose-rug-suites-I.html
+++ b/doc/rose-rug-suites-I.html
@@ -83,16 +83,16 @@
         <li>A Rose suite is a collection of scientific task configurations (or
         'applications') with a <q>common purpose</q><!-- (Hilary) -->.</li>
 
-        <li>Cylc is a suite engine that drives task submission and
+        <li>cylc is a suite engine that drives task submission and
         monitoring.</li>
       </ul>
     </div>
 
     <div class="slide">
-      <h3>That's too abstract - what's Cylc again?</h3>
+      <h3>That's too abstract - what's cylc again?</h3>
 
       <ul class="incremental">
-        <li>Cylc makes your Rose stuff happen.</li>
+        <li>cylc makes your Rose stuff happen.</li>
       </ul>
     </div>
 
@@ -102,9 +102,9 @@
       <p>What does this cover?</p>
 
       <ul class="incremental">
-        <li>Cylc background and philosophy</li>
+        <li>cylc background and philosophy</li>
 
-        <li>Cylc basic usage</li>
+        <li>cylc basic usage</li>
 
         <li>basic suite design</li>
       </ul>
@@ -128,7 +128,7 @@
     <div class="slide">
       <h3 class="alwayshidden">Background - NIWA</h3>
 
-      <p>Cylc was originally developed by <a href=
+      <p>cylc was originally developed by <a href=
       "https://github.com/hjoliver">Hilary Oliver</a> at <a href=
       "http://www.niwa.co.nz/">NIWA</a>. It runs their <a href=
       "http://ecoconnect.niwa.co.nz/">EcoConnect</a> operational
@@ -136,7 +136,7 @@
       "http://cylc.github.io/cylc/graphics/png/scaled/niwa-colour-small.png"
       alt="NIWA logo" />
 
-      <p>Cylc was developed to provide a fast, automated way of scheduling
+      <p>cylc was developed to provide a fast, automated way of scheduling
       tasks so that a suite could <em>catch up</em> after outages.</p>
     </div>
 
@@ -148,14 +148,14 @@
     <div class="slide">
       <h3>Background - Current</h3>
 
-      <p>Cylc is now a collaborative effort, involving the Met Office.</p>
+      <p>cylc is now a collaborative effort, involving the Met Office.</p>
 
-      <p>Cylc is written in <a href="www.python.org">Python</a> and uses
+      <p>cylc is written in <a href="www.python.org">Python</a> and uses
       <a href="www.pygtk.org">PyGTK</a> for its GUIs. It is open source and
       licensed under <a href="http://www.gnu.org/licenses/gpl.html">GPL
       v3</a>.</p>
 
-      <p>Cylc lives on <a href="http://github.com/cylc/">github</a>.</p>
+      <p>cylc lives on <a href="http://github.com/cylc/">github</a>.</p>
     </div>
 
     <div class="slide">
@@ -200,7 +200,7 @@
     <div class="slide">
       <h2 id="suite-rc">The suite.rc File</h2>
 
-      <p>Cylc has a single file to configure the suite, the
+      <p>cylc has a single file to configure the suite, the
       <samp>suite.rc</samp> file. It configures:</p>
 
       <ul class="incremental">
@@ -215,7 +215,7 @@
     <div class="slide">
       <h3 id="suite-rc-format">Format</h3>
 
-      <p>Cylc uses a nested INI-based configuration format that looks like
+      <p>cylc uses a nested INI-based configuration format that looks like
       this:</p>
       <pre class="prettyprint lang-cylc">
 [scheduling]                     # Scheduling section
@@ -229,7 +229,7 @@
     </div>
 
     <div class="slide">
-      <h2 id="hello-world">Hello World Cylc Suite</h2>
+      <h2 id="hello-world">Hello World cylc suite</h2>
 
       <p>A simple cylc suite has a single <samp>suite.rc</samp> file that looks
       like this:</p>
@@ -247,7 +247,7 @@
     </div>
 
     <div class="slide">
-      <h3 id="hello-world-demo">Demoing the Hello World Cylc Suite</h3>
+      <h3 id="hello-world-demo">Demoing the Hello World cylc suite</h3>
 
       <p>Demo this by creating and running the simple cylc suite:</p>
       <pre class="prettyprint lang_sh">
@@ -427,7 +427,7 @@ default=echo 'Hello World'
     <div class="slide">
       <h2 id="multiple-inheritance">Multiple Family Inheritance</h2>
 
-      <p>Cylc supports multiple inheritance, so tasks can combine useful
+      <p>cylc supports multiple inheritance, so tasks can combine useful
       configuration from more than one separate family. If you set up families
       like this:</p>
       <pre class="prettyprint lang-cylc">
@@ -511,7 +511,7 @@ default=echo 'Hello World'
     <div class="slide">
       <h2 id="jinja2">Jinja2</h2>
 
-      <p>Cylc uses a templating language called Jinja2 that you can use to
+      <p>cylc uses a templating language called Jinja2 that you can use to
       collapse duplicated portions of configuration or insert settings.</p>
 
       <p>This means that you can embed special instruction code in the
@@ -715,7 +715,7 @@ type=boolean
     <div class="slide">
       <h3 class="alwayshidden">Job Submission Methods</h3>
 
-      <p>Cylc supports the following job submission methods (potentially more
+      <p>cylc supports the following job submission methods (potentially more
       later):</p>
 
       <ul class="incremental">

--- a/doc/rose-rug-suites-II.html
+++ b/doc/rose-rug-suites-II.html
@@ -259,7 +259,7 @@
     <div class="slide">
       <h2 id="cylc-cap">Cylc Capabilities</h2>
 
-      <p>Cylc has some nice capabilities:</p>
+      <p>cylc has some nice capabilities:</p>
 
       <ul class="incremental">
         <li>inserting tasks at runtime</li>
@@ -354,7 +354,7 @@
     <div class="slide">
       <h2 id="cylc-run">cylc-run Directories</h2>
 
-      <p>Cylc keeps a runtime directory for each suite in
+      <p>cylc keeps a runtime directory for each suite in
       <samp>~/cylc-run/</samp>, which is updated when you run the suite.</p>
 
       <p>It is a mirror of your suite directory structure and content, but with


### PR DESCRIPTION
Minor documentation changes to correct or update some slides that have been annoying me.

Of note:

 * Correcting capitalisation of cylc in line with how used in cylc user guide
 * Add mention of rosie graph to suite copy/branch slides

@kaday - please review (feel free to add a 2nd reviewer if you think that's appropriate).