### PR TITLE
t: improve robustness

### DIFF
--- a/t/rose-suite-log/00-update-task.t
+++ b/t/rose-suite-log/00-update-task.t
@@ -32,6 +32,7 @@ fi
 tests 6
 #-------------------------------------------------------------------------------
 # Run the suite.
+export CYLC_CONF_PATH=
 export ROSE_CONF_PATH=
 TEST_KEY=$TEST_KEY_BASE
 SUITE_RUN_DIR=$(mktemp -d --tmpdir=$HOME/cylc-run 'rose-test-battery.XXXXXX')

--- a/t/rose-suite-log/01-update-cycle.t
+++ b/t/rose-suite-log/01-update-cycle.t
@@ -34,6 +34,7 @@ fi
 tests 17
 #-------------------------------------------------------------------------------
 # Run the suite.
+export CYLC_CONF_PATH=
 export ROSE_CONF_PATH=
 TEST_KEY=$TEST_KEY_BASE
 SUITE_RUN_DIR=$(mktemp -d --tmpdir=$HOME/cylc-run 'rose-test-battery.XXXXXX')

--- a/t/rose-task-run/05-app-prune-compat.t
+++ b/t/rose-task-run/05-app-prune-compat.t
@@ -34,6 +34,7 @@ else
 fi
 #-------------------------------------------------------------------------------
 # Run the suite.
+export CYLC_CONF_PATH=
 export ROSE_CONF_PATH=
 TEST_KEY=$TEST_KEY_BASE
 mkdir -p $HOME/cylc-run

--- a/t/rose-task-run/06-app-prune-iso.t
+++ b/t/rose-task-run/06-app-prune-iso.t
@@ -27,6 +27,7 @@ JOB_HOST=$(rose config --default= 't' 'job-host')
 if [[ -n $JOB_HOST ]]; then
     JOB_HOST=$(rose host-select -q $JOB_HOST)
 fi
+export CYLC_CONF_PATH=
 export ROSE_CONF_PATH=
 TEST_KEY=$TEST_KEY_BASE
 mkdir -p $HOME/cylc-run

--- a/t/rose-task-run/12-app-prune-integer.t
+++ b/t/rose-task-run/12-app-prune-integer.t
@@ -30,6 +30,7 @@ else
 fi
 #-------------------------------------------------------------------------------
 # Run the suite.
+export CYLC_CONF_PATH=
 export ROSE_CONF_PATH=
 TEST_KEY=$TEST_KEY_BASE
 mkdir -p $HOME/cylc-run

--- a/t/rose-task-run/14-app-prune-remove.t
+++ b/t/rose-task-run/14-app-prune-remove.t
@@ -25,6 +25,7 @@ JOB_HOST=$(rose config --default= 't' 'job-host')
 tests 10
 #-------------------------------------------------------------------------------
 # Run the suite.
+export CYLC_CONF_PATH=
 export ROSE_CONF_PATH=
 TEST_KEY=$TEST_KEY_BASE
 mkdir -p $HOME/cylc-run

--- a/t/rose-task-run/31-app-bunch.t
+++ b/t/rose-task-run/31-app-bunch.t
@@ -113,8 +113,7 @@ APP=bunch_bigpop
 TEST_KEY_PREFIX=big-pop
 FILE=$LOG_DIR/$APP/01/job.out
 for INSTANCE in $(seq 0 14); do
-file_grep $TEST_KEY_PREFIX-ran-$INSTANCE \
-    "\[OK\] $INSTANCE" $FILE
+    file_grep $TEST_KEY_PREFIX-ran-$INSTANCE "\[OK\] $INSTANCE" $FILE
 done
 #-------------------------------------------------------------------------------
 # Testing names works ok
@@ -123,9 +122,8 @@ APP=bunch_names
 #-------------------------------------------------------------------------------
 TEST_KEY_PREFIX=names
 FILE=$LOG_DIR/$APP/01/job.out
-for NAME in foo bar baz qux; do
-file_grep $TEST_KEY_PREFIX-ran-$NAME \
-    "\[OK\] $NAME" $FILE
+for KEY in foo bar baz qux; do
+    file_grep $TEST_KEY_PREFIX-ran-$KEY "\[OK\] $KEY" $FILE
 done
 #-------------------------------------------------------------------------------
 rose suite-clean -q -y $NAME


### PR DESCRIPTION
Retry delays in cylc `global.rc` can cause some tests to fail. This
change allows the tests to run in purer form without cylc `global.rc`
settings.
This change also ensures that the new rose_bunch test is able to tidy up
the suite. The NAME variable (suite name) was modified before it is
supplied to the `rose suite-clean` command.

@arjclark @kaday please review.