### PR TITLE
fcm_make built-in: fix fast location perm mode

### DIFF
--- a/lib/python/rose/apps/fcm_make.py
+++ b/lib/python/rose/apps/fcm_make.py
@@ -150,8 +150,10 @@ class FCMMakeApp(BuiltinApp):
             # "rsync" fast working directory to dests[0], if relevant
             if dest != dests[0] and os.path.isdir(dest):
                 app_runner.fs_util.makedirs(dests[0])
+                stat = os.stat(dests[0])
                 cmd = rsync_prefixes + [dest + os.sep, dests[0] + os.sep]
                 app_runner.popen.run_simple(*cmd)
+                os.chmod(dests[0], stat.st_mode)
                 app_runner.fs_util.delete(dest)
 
     def _run_orig(self, app_runner, conf_tree, opts, args, uuid, task,

--- a/t/rose-task-run/24-app-fcm-make-fast.t
+++ b/t/rose-task-run/24-app-fcm-make-fast.t
@@ -31,7 +31,7 @@ if ! gfortran --version 1>/dev/null 2>&1; then
     skip_all '"gfortran" unavailable'
 fi
 #-------------------------------------------------------------------------------
-tests 4
+tests 5
 export ROSE_CONF_PATH=
 mkdir -p "${HOME}/cylc-run"
 mkdir 'fast'
@@ -44,10 +44,18 @@ timeout 120 rose suite-run -q --debug \
     --no-gcontrol --host='localhost' -S "FAST_DEST_ROOT=\"${PWD}/fast\"" \
     -- --debug
 #-------------------------------------------------------------------------------
+# Permission modes of make directory should be the same as a normal directory
+mkdir "${SUITE_RUN_DIR}/share/hello-make-perm-mode-test"
+run_pass "${TEST_KEY_BASE}-perm-mode" test \
+    "$(stat -c'%a' "${SUITE_RUN_DIR}/share/hello-make-perm-mode-test")" = \
+    "$(stat -c'%a' "${SUITE_RUN_DIR}/share/hello-make")"
+rmdir "${SUITE_RUN_DIR}/share/hello-make-perm-mode-test"
+# Executable runs OK
 file_cmp "${TEST_KEY_BASE}" "${SUITE_RUN_DIR}/share/hello.txt" <<__TXT__
 ${SUITE_RUN_DIR}/share/hello-make/build/bin/hello
 Hello World!
 __TXT__
+# Logs
 HOST=$(hostname)
 file_grep "${TEST_KEY_BASE}.log" \
     "\\[info\\] dest=${USER}@${HOST}:${PWD}/fast/hello-make.1.${NAME}" \


### PR DESCRIPTION
When using a fast location, the logic creates a temporary directory on
the fast location. This is rsync to the final destination on exit of the
`fcm make` command. The old did take into account permission mode of the
temporary directory back to the final destination, but the logic was
insufficient, as the directory permission mode is overridden by
`rsync -a`. The new logic fixes this by inquiring the permission mode of
the normally created directory at the final destination, then run the
`rsync -a` command, before setting the permission mode of the directory
to the the value of that of the normally created directory.