### PR TITLE
rose.config: check section syntax

### DIFF
--- a/lib/python/rose/apps/rose_arch.py
+++ b/lib/python/rose/apps/rose_arch.py
@@ -134,6 +134,7 @@ class RoseArchApp(BuiltinApp):
             else:
                 target.status = target.ST_OLD
             targets.append(target)
+        targets.sort(key=lambda target: target.name)
 
         # Delete from database items that are no longer relevant
         dao.delete_all(filter_targets=targets)

--- a/lib/python/rose/config.py
+++ b/lib/python/rose/config.py
@@ -746,13 +746,19 @@ class ConfigLoader(object):
     @classmethod
     def _check_section_value(cls, section):
         """Check value of section title for bad braces."""
+        # Square braces
         for char in CHAR_SECTION_OPEN, CHAR_SECTION_CLOSE:
             bad_index = section.find(char)
             if bad_index > -1:
                 return bad_index
+        # Don't check string with environment variable substitution syntax
+        if "${" in section:
+            return -1
+        # Check only section values with schemes
         scheme, _, path = section.partition(":")
         if not path:
             return -1
+        # Check brackets and curly braces
         index_of = {}
         for char in "{}()":
             index_of[char] = -1
@@ -778,6 +784,7 @@ class ConfigLoader(object):
                 # has close, but no open
                 # or close before open
                 return len(scheme) + index_of[sym_close] + 1
+        # Curly braces should be placed before brackets
         if index_of["("] > -1:
             if index_of["{"] > index_of["("]:
                 return len(scheme) + index_of["{"] + 1

--- a/t/rose-config/03-syntax-error.t
+++ b/t/rose-config/03-syntax-error.t
@@ -20,14 +20,14 @@
 # Test "rose config", syntax error.
 #-------------------------------------------------------------------------------
 . $(dirname $0)/test_header
-tests 24
+tests 60
 #-------------------------------------------------------------------------------
 TEST_KEY=$TEST_KEY_BASE-bad-indent-below-root
 echo '    foo=bar' >rose-bad.conf
 run_fail "$TEST_KEY" rose config -f rose-bad.conf
 file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" <<__ERR__
-[FAIL] $TEST_DIR/rose-bad.conf(1): Expecting "[SECTION]" or "KEY=VALUE"
+[FAIL] $TEST_DIR/rose-bad.conf(1): expecting "[SECTION]" or "KEY=VALUE"
 [FAIL]     foo=bar
 [FAIL] ^
 __ERR__
@@ -37,7 +37,7 @@ echo 'foo' >rose-bad.conf
 run_fail "$TEST_KEY" rose config -f rose-bad.conf
 file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" <<__ERR__
-[FAIL] $TEST_DIR/rose-bad.conf(1): Expecting "[SECTION]" or "KEY=VALUE"
+[FAIL] $TEST_DIR/rose-bad.conf(1): expecting "[SECTION]" or "KEY=VALUE"
 [FAIL] foo
 [FAIL] ^
 __ERR__
@@ -50,7 +50,7 @@ __CONF__
 run_fail "$TEST_KEY" rose config -f rose-bad.conf
 file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" <<__ERR__
-[FAIL] $TEST_DIR/rose-bad.conf(2): Expecting "[SECTION]" or "KEY=VALUE"
+[FAIL] $TEST_DIR/rose-bad.conf(2): expecting "[SECTION]" or "KEY=VALUE"
 [FAIL]     ivy=poison
 [FAIL] ^
 __ERR__
@@ -63,12 +63,12 @@ __CONF__
 run_fail "$TEST_KEY" rose config -f rose-bad.conf
 file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" <<__ERR__
-[FAIL] $TEST_DIR/rose-bad.conf(2): Expecting "[SECTION]" or "KEY=VALUE"
+[FAIL] $TEST_DIR/rose-bad.conf(2): expecting "[SECTION]" or "KEY=VALUE"
 [FAIL] jasmine
 [FAIL] ^
 __ERR__
 #-------------------------------------------------------------------------------
-TEST_KEY="$TEST_KEY_BASE-open-brace-in-section"
+TEST_KEY="$TEST_KEY_BASE-open-sq-brace-in-section"
 cat >rose-bad.conf <<'__CONF__'
 [[flower]
 ivy=poison
@@ -76,12 +76,12 @@ __CONF__
 run_fail "$TEST_KEY" rose config -f rose-bad.conf
 file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" <<__ERR__
-[FAIL] $TEST_DIR/rose-bad.conf(1): Unexpected character in name
+[FAIL] $TEST_DIR/rose-bad.conf(1): unexpected character or end of value
 [FAIL] [[flower]
 [FAIL]  ^
 __ERR__
 #-------------------------------------------------------------------------------
-TEST_KEY="$TEST_KEY_BASE-open-brace-in-section-with-state"
+TEST_KEY="$TEST_KEY_BASE-open-sq-brace-in-section-with-state"
 cat >rose-bad.conf <<'__CONF__'
 [![flower]
 ivy=poison
@@ -89,12 +89,12 @@ __CONF__
 run_fail "$TEST_KEY" rose config -f rose-bad.conf
 file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" <<__ERR__
-[FAIL] $TEST_DIR/rose-bad.conf(1): Unexpected character in name
+[FAIL] $TEST_DIR/rose-bad.conf(1): unexpected character or end of value
 [FAIL] [![flower]
 [FAIL]   ^
 __ERR__
 #-------------------------------------------------------------------------------
-TEST_KEY="$TEST_KEY_BASE-open-brace-in-section-with-space"
+TEST_KEY="$TEST_KEY_BASE-open-sq-brace-in-section-with-space"
 cat >rose-bad.conf <<'__CONF__'
 [ what [flower]
 ivy=poison
@@ -102,12 +102,12 @@ __CONF__
 run_fail "$TEST_KEY" rose config -f rose-bad.conf
 file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" <<__ERR__
-[FAIL] $TEST_DIR/rose-bad.conf(1): Unexpected character in name
+[FAIL] $TEST_DIR/rose-bad.conf(1): unexpected character or end of value
 [FAIL] [ what [flower]
 [FAIL]        ^
 __ERR__
 #-------------------------------------------------------------------------------
-TEST_KEY="$TEST_KEY_BASE-close-brace-in-section"
+TEST_KEY="$TEST_KEY_BASE-close-sq-brace-in-section"
 cat >rose-bad.conf <<'__CONF__'
 [flower]]
 ivy=poison
@@ -115,9 +115,165 @@ __CONF__
 run_fail "$TEST_KEY" rose config -f rose-bad.conf
 file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" <<__ERR__
-[FAIL] $TEST_DIR/rose-bad.conf(1): Unexpected character in name
+[FAIL] $TEST_DIR/rose-bad.conf(1): unexpected character or end of value
 [FAIL] [flower]]
 [FAIL]        ^
+__ERR__
+#-------------------------------------------------------------------------------
+TEST_KEY="$TEST_KEY_BASE-open-bracket-not-closed"
+cat >rose-bad.conf <<'__CONF__'
+[flower:daisy(21]
+ivy=poison
+__CONF__
+run_fail "$TEST_KEY" rose config -f rose-bad.conf
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" <<__ERR__
+[FAIL] $TEST_DIR/rose-bad.conf(1): unexpected character or end of value
+[FAIL] [flower:daisy(21]
+[FAIL]                 ^
+__ERR__
+#-------------------------------------------------------------------------------
+TEST_KEY="$TEST_KEY_BASE-close-bracket-not-opened"
+cat >rose-bad.conf <<'__CONF__'
+[flower:daisy)]
+ivy=poison
+__CONF__
+run_fail "$TEST_KEY" rose config -f rose-bad.conf
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" <<__ERR__
+[FAIL] $TEST_DIR/rose-bad.conf(1): unexpected character or end of value
+[FAIL] [flower:daisy)]
+[FAIL]              ^
+__ERR__
+#-------------------------------------------------------------------------------
+TEST_KEY="$TEST_KEY_BASE-open-brace-not-closed"
+cat >rose-bad.conf <<'__CONF__'
+[flower:daisy{white]
+ivy=poison
+__CONF__
+run_fail "$TEST_KEY" rose config -f rose-bad.conf
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" <<__ERR__
+[FAIL] $TEST_DIR/rose-bad.conf(1): unexpected character or end of value
+[FAIL] [flower:daisy{white]
+[FAIL]                    ^
+__ERR__
+#-------------------------------------------------------------------------------
+TEST_KEY="$TEST_KEY_BASE-close-brace-not-opened"
+cat >rose-bad.conf <<'__CONF__'
+[flower:daisywhite}]
+ivy=poison
+__CONF__
+run_fail "$TEST_KEY" rose config -f rose-bad.conf
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" <<__ERR__
+[FAIL] $TEST_DIR/rose-bad.conf(1): unexpected character or end of value
+[FAIL] [flower:daisywhite}]
+[FAIL]                   ^
+__ERR__
+#-------------------------------------------------------------------------------
+TEST_KEY="$TEST_KEY_BASE-close-bracket-before-open"
+cat >rose-bad.conf <<'__CONF__'
+[flower:daisy)2(]
+ivy=poison
+__CONF__
+run_fail "$TEST_KEY" rose config -f rose-bad.conf
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" <<__ERR__
+[FAIL] $TEST_DIR/rose-bad.conf(1): unexpected character or end of value
+[FAIL] [flower:daisy)2(]
+[FAIL]              ^
+__ERR__
+#-------------------------------------------------------------------------------
+TEST_KEY="$TEST_KEY_BASE-close-brace-before-open"
+cat >rose-bad.conf <<'__CONF__'
+[flower:daisy}white{]
+ivy=poison
+__CONF__
+run_fail "$TEST_KEY" rose config -f rose-bad.conf
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" <<__ERR__
+[FAIL] $TEST_DIR/rose-bad.conf(1): unexpected character or end of value
+[FAIL] [flower:daisy}white{]
+[FAIL]              ^
+__ERR__
+#-------------------------------------------------------------------------------
+TEST_KEY="$TEST_KEY_BASE-2-open-bracket"
+cat >rose-bad.conf <<'__CONF__'
+[flower:daisy((2)]
+ivy=poison
+__CONF__
+run_fail "$TEST_KEY" rose config -f rose-bad.conf
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" <<__ERR__
+[FAIL] $TEST_DIR/rose-bad.conf(1): unexpected character or end of value
+[FAIL] [flower:daisy((2)]
+[FAIL]               ^
+__ERR__
+#-------------------------------------------------------------------------------
+TEST_KEY="$TEST_KEY_BASE-2-close-bracket"
+cat >rose-bad.conf <<'__CONF__'
+[flower:daisy(2))]
+ivy=poison
+__CONF__
+run_fail "$TEST_KEY" rose config -f rose-bad.conf
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" <<__ERR__
+[FAIL] $TEST_DIR/rose-bad.conf(1): unexpected character or end of value
+[FAIL] [flower:daisy(2))]
+[FAIL]                 ^
+__ERR__
+#-------------------------------------------------------------------------------
+TEST_KEY="$TEST_KEY_BASE-2-open-braces"
+cat >rose-bad.conf <<'__CONF__'
+[flower:daisy{{2}]
+ivy=poison
+__CONF__
+run_fail "$TEST_KEY" rose config -f rose-bad.conf
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" <<__ERR__
+[FAIL] $TEST_DIR/rose-bad.conf(1): unexpected character or end of value
+[FAIL] [flower:daisy{{2}]
+[FAIL]               ^
+__ERR__
+#-------------------------------------------------------------------------------
+TEST_KEY="$TEST_KEY_BASE-2-close-braces"
+cat >rose-bad.conf <<'__CONF__'
+[flower:daisy{2}}]
+ivy=poison
+__CONF__
+run_fail "$TEST_KEY" rose config -f rose-bad.conf
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" <<__ERR__
+[FAIL] $TEST_DIR/rose-bad.conf(1): unexpected character or end of value
+[FAIL] [flower:daisy{2}}]
+[FAIL]                 ^
+__ERR__
+#-------------------------------------------------------------------------------
+TEST_KEY="$TEST_KEY_BASE-bracket-before-brace"
+cat >rose-bad.conf <<'__CONF__'
+[flower:daisy(2){white}]
+ivy=poison
+__CONF__
+run_fail "$TEST_KEY" rose config -f rose-bad.conf
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" <<__ERR__
+[FAIL] $TEST_DIR/rose-bad.conf(1): unexpected character or end of value
+[FAIL] [flower:daisy(2){white}]
+[FAIL]                 ^
+__ERR__
+#-------------------------------------------------------------------------------
+TEST_KEY="$TEST_KEY_BASE-bracket-open-before-brace-close"
+cat >rose-bad.conf <<'__CONF__'
+[flower:daisy{white(2)}]
+ivy=poison
+__CONF__
+run_fail "$TEST_KEY" rose config -f rose-bad.conf
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" <<__ERR__
+[FAIL] $TEST_DIR/rose-bad.conf(1): unexpected character or end of value
+[FAIL] [flower:daisy{white(2)}]
+[FAIL]                    ^
 __ERR__
 #-------------------------------------------------------------------------------
 exit 0

--- a/t/rose-task-run/07-app-arch/app/archive/rose-app.conf
+++ b/t/rose-task-run/07-app-arch/app/archive/rose-app.conf
@@ -2,6 +2,8 @@ mode=rose_arch
 
 [env]
 FOO_SESSION=$ROSE_TASK_CYCLE_TIME.$CYLC_TASK_TRY_NUMBER
+MY_UNKNOWN=unknown
+MY_STUFF=stuff
 
 [file:$ROSE_DATAC/try.nl]
 source=namelist:try
@@ -31,7 +33,7 @@ source=hello/spaceship-[1-9].txt
 rename-format=%(cycle)s-%(name)s
 source=star-[1-9].txt
 
-[arch:unknown/stuff.pax]
+[arch:${MY_UNKNOWN}/${MY_STUFF}.pax]
 rename-format=hello/%(cycle)s-%(name_head)s%(name_tail)s
 rename-parser=^(?P<name_head>stuff)ing(?P<name_tail>-[1-9]\.txt)$
 source=stuffing-*.txt


### PR DESCRIPTION
Apply to sections with schemes, e.g. `[namelist:foo{bar}(24)]`

Check syntax of braces `{}` and brackets `()`. Allow only:
* 0 or 1 pair of each.
* braces before brackets.

E.g. an extra close bracket in the section value will result in an exception like:

```
rose.config.ConfigSyntaxError: /home/matt/foo/opt/rose-app-ouch.conf(32): unexpected character or end of value
[namelist:teddy{bad}}]
                    ^
```