### PR TITLE
rose host-select: a localhost str may have 1+ IP

### DIFF
--- a/t/rose-host-select/02-localhost.t
+++ b/t/rose-host-select/02-localhost.t
@@ -27,7 +27,7 @@ MORE_HOST=$(rose config --default= 't' 'job-host-with-share')
 export ROSE_CONF_PATH=
 
 LOCAL_HOSTS='localhost 127.0.0.1'
-for CMD in 'hostname -s' 'hostname' 'hostname --fqdn' 'hostname -i'; do
+for CMD in 'hostname -s' 'hostname' 'hostname --fqdn' 'hostname -I'; do
     if LOCAL_HOST=$(eval "$CMD"); then
         LOCAL_HOSTS="${LOCAL_HOSTS} ${LOCAL_HOST}"
     fi


### PR DESCRIPTION
This was causing test failures in Ubuntu 15.10.
The fix should allow it to identify more IP addresses associated with
the localhost.