### PR TITLE
rosie.ws_client_auth: handle keyring denied, disable bad prefixes

### DIFF
--- a/lib/python/rosie/browser/__init__.py
+++ b/lib/python/rosie/browser/__init__.py
@@ -121,6 +121,7 @@ ERROR_NO_NEXT_SEARCH = "No next search"
 ERROR_NO_PREVIOUS_SEARCH = "No previous search"
 ERROR_PERMISSIONS = ("Error: You do not have the required permissions to " +
                      "delete this suite")
+ERROR_PREFIX_UNREACHABLE = "Cannot connect to prefix(es) {0}"
 ERROR_UNRECOGNISED_LAST_SEARCH = "Unrecognised last search type"
 ERROR_UNRECOGNISED_NEXT_SEARCH = "Unrecognised next search type"
 ERROR_UNRECOGNISED_SEARCH = "Unrecognised search type"

--- a/lib/python/rosie/ws_client.py
+++ b/lib/python/rosie/ws_client.py
@@ -109,7 +109,7 @@ class RosieWSClient(object):
             self.auth_managers[prefix] = RosieWSClientAuthManager(
                 prefix, popen=self.popen, prompt_func=self.prompt_func,
                 event_handler=self.event_handler)
-        # Remove uncontactable prefixes from the list.        
+        # Remove uncontactable prefixes from the list.
         ok_prefixes = self.hello(return_ok_prefixes=True)
         prefixes = []
         self.unreachable_prefixes = []

--- a/lib/python/rosie/ws_client_auth.py
+++ b/lib/python/rosie/ws_client_auth.py
@@ -89,7 +89,8 @@ class GnomekeyringStore(object):
             item_id = res[0]["item_id"]
             self.item_ids[(scheme, host, username)] = (ring_id, item_id)
             return res[0]["password"]
-        except (gnomekeyring.NoMatchError, gnomekeyring.NoKeyringDaemonError):
+        except (gnomekeyring.NoMatchError, gnomekeyring.NoKeyringDaemonError,
+                gnomekeyring.DeniedError):
             return
 
     def store_password(self, scheme, host, username, password):

--- a/lib/python/rosie/ws_client_auth.py
+++ b/lib/python/rosie/ws_client_auth.py
@@ -32,6 +32,7 @@ import re
 import rose.config
 from rose.env import env_var_process
 from rose.popen import RosePopener
+from rose.reporter import Reporter
 from rose.resource import ResourceLocator
 import shlex
 import socket
@@ -53,6 +54,17 @@ class GPGAgentStoreConnectionError(Exception):
 
     def __str__(self):
         return "Cannot connect to gpg-agent: %s" % self.args[0]
+
+
+class RosieStoreRetrievalError(Exception):
+
+    """Raised if a client cannot retrieve info from the password store."""
+
+    def __str__(self):
+        message = "Cannot retrieve username/password: %s" % self.args[0]
+        if self.args[1]:
+            message += ": %s" % self.args[1]
+        return message
 
 
 class GnomekeyringStore(object):
@@ -89,9 +101,12 @@ class GnomekeyringStore(object):
             item_id = res[0]["item_id"]
             self.item_ids[(scheme, host, username)] = (ring_id, item_id)
             return res[0]["password"]
-        except (gnomekeyring.NoMatchError, gnomekeyring.NoKeyringDaemonError,
-                gnomekeyring.DeniedError):
+        except (gnomekeyring.NoMatchError, gnomekeyring.NoKeyringDaemonError):
             return
+        except gnomekeyring.Error as exc:
+            exc_type = "gnomekeyring." + type(exc).__name__
+            exc_string = str(exc)
+            raise RosieStoreRetrievalError(exc_type, exc_string)
 
     def store_password(self, scheme, host, username, password):
         """Return the password of username@root."""
@@ -225,7 +240,8 @@ class RosieWSClientAuthManager(object):
     PROMPT_PASSWORD = "Password for %(username)s at %(prefix)r - %(root)r: "
     STR_CANCELLED = "cancelled by user"
 
-    def __init__(self, prefix, popen=None, prompt_func=None):
+    def __init__(self, prefix, popen=None, prompt_func=None,
+                 event_handler=None):
         self.prefix = prefix
         root = self._get_conf_value("ws")
         if root is None:
@@ -244,6 +260,10 @@ class RosieWSClientAuthManager(object):
             popen = RosePopener()
         self.popen = popen
         self.prompt_func = prompt_func
+        if event_handler is None:
+            self.event_handler = Reporter()
+        else:
+            self.event_handler = event_handler
         res_loc = ResourceLocator.default()
         password_stores_str = res_loc.default().get_conf().get_value(
             keys=["rosie-id", "prefix-password-store." + self.prefix],
@@ -285,7 +305,11 @@ class RosieWSClientAuthManager(object):
             self.username = self._get_conf_value("username")
             if self.username_orig is None:
                 self.username_orig = self.username
-        self._load_password()
+        try:
+            self._load_password()
+        except RosieStoreRetrievalError as exc:
+            self.event_handler(exc)
+            return None
         if (self.username and not self.password) or is_retry:
             self._prompt(is_retry)
         if self.username and self.password:

--- a/lib/python/rosie/ws_client_cli.py
+++ b/lib/python/rosie/ws_client_cli.py
@@ -33,6 +33,7 @@ import sys
 import time
 import traceback
 
+ERR_PREFIX_UNREACHABLE = "Cannot connect to prefix(es) {0}"
 ERR_SYNTAX = "Syntax error: {0}"
 
 PRINT_FORMAT_DEFAULT = "%local %suite %owner %project %title"
@@ -115,6 +116,10 @@ def list_local_suites(argv):
         report(UserSpecificRoses(alternative_roses_dir), prefix=None)
 
     ws_client = RosieWSClient(prefixes=opts.prefixes, event_handler=report)
+    if ws_client.unreachable_prefixes:
+        bad_prefix_string = " ".join(ws_client.unreachable_prefixes)
+        report(RosieWSClientError(
+                   ERR_PREFIX_UNREACHABLE.format(bad_prefix_string)))
     _display_maps(opts, ws_client, ws_client.query_local_copies(opts.user))
 
 

--- a/lib/python/rosie/ws_client_cli.py
+++ b/lib/python/rosie/ws_client_cli.py
@@ -118,8 +118,9 @@ def list_local_suites(argv):
     ws_client = RosieWSClient(prefixes=opts.prefixes, event_handler=report)
     if ws_client.unreachable_prefixes:
         bad_prefix_string = " ".join(ws_client.unreachable_prefixes)
-        report(RosieWSClientError(
-                   ERR_PREFIX_UNREACHABLE.format(bad_prefix_string)))
+        report(
+            RosieWSClientError(
+                ERR_PREFIX_UNREACHABLE.format(bad_prefix_string)))
     _display_maps(opts, ws_client, ws_client.query_local_copies(opts.user))
 
 


### PR DESCRIPTION
This handles an error thrown by `gnomekeyring` in the rosie auth layer when the keyring is locked.
In current master, a nasty traceback is thrown. The new behaviour is to disable prefixes before use (and notify the user about it) if a `hello` call fails. This applies to other auth failures as well.

The `gnomekeyring` situation can be replicated by launching `seahorse` and locking the `login` keyring. Other auth failures can be replicated by setting the wrong username or password.

@matthewrmshin, please review 1.