### PR TITLE
rose edit: speed up adding/deleting sections

### DIFF
--- a/lib/python/rose/config_editor/data.py
+++ b/lib/python/rose/config_editor/data.py
@@ -190,6 +190,8 @@ class ConfigDataManager(object):
         self.trigger_id_trees = {}  # Stores trigger dependencies
         self.trigger_id_value_lookup = {}  # Stores old values of trigger vars
         self.namespace_meta_lookup = {}  # Stores titles etc of namespaces
+        self.namespace_cached_statuses = {
+            'latent': {}, 'ignored': {}}  # Caches ns statuses
         self._config_section_namespace_lookup = {}  # Store section namespaces
         self.locator = rose.resource.ResourceLocator(paths=sys.path)
 

--- a/lib/python/rose/config_editor/data_helper.py
+++ b/lib/python/rose/config_editor/data_helper.py
@@ -443,13 +443,11 @@ class ConfigDataHelper(object):
             cache[namespace] = status
             return rose.config.ConfigNode.STATE_NORMAL
         status = status_counts[0][0]
+        cache[namespace] = status
         if status == rose.variable.IGNORED_BY_USER:
-            cache[namespace] = status
             return rose.config.ConfigNode.STATE_USER_IGNORED
         if status == rose.variable.IGNORED_BY_SYSTEM:
-            cache[namespace] = status
             return rose.config.ConfigNode.STATE_SYST_IGNORED
-        cache[namespace] = status
         return rose.config.ConfigNode.STATE_NORMAL
 
     def get_ns_latent_status(self, namespace):

--- a/lib/python/rose/config_editor/data_helper.py
+++ b/lib/python/rose/config_editor/data_helper.py
@@ -389,6 +389,9 @@ class ConfigDataHelper(object):
 
     def get_ns_ignored_status(self, namespace):
         """Return the ignored status for a namespace's data."""
+        cache = self.data.namespace_cached_statuses['ignored']
+        if namespace in cache:
+            return cache[namespace]
         config_name = self.util.split_full_ns(self.data, namespace)[0]
         config_data = self.data.config[config_name]
         sections = self.get_sections_from_namespace(namespace)
@@ -401,6 +404,7 @@ class ConfigDataHelper(object):
                 continue
             if sect_data.metadata["full_ns"] == namespace:
                 if not sect_data.ignored_reason:
+                    cache[namespace] = status
                     return status
                 for key in sect_data.ignored_reason:
                     default_section_statuses.setdefault(key, 0)
@@ -408,6 +412,7 @@ class ConfigDataHelper(object):
         real_data, latent_data = self.get_data_for_namespace(namespace)
         for var in real_data + latent_data:
             if not var.ignored_reason:
+                cache[namespace] = status
                 return status
             for key in var.ignored_reason:
                 if key == rose.variable.IGNORED_BY_SECTION:
@@ -424,6 +429,7 @@ class ConfigDataHelper(object):
                     variable_statuses[key] += 1
         if not (variable_statuses or sections):
             # No data, so no ignored state.
+            cache[namespace] = status
             return status
         # Now return the most 'popular' ignored status.
         # Choose section statuses if any are default for this namespace.
@@ -434,16 +440,23 @@ class ConfigDataHelper(object):
         status_counts = object_statuses.items()
         status_counts.sort(lambda x, y: cmp(x[1], y[1]))
         if not status_counts:
+            cache[namespace] = status
             return rose.config.ConfigNode.STATE_NORMAL
         status = status_counts[0][0]
         if status == rose.variable.IGNORED_BY_USER:
+            cache[namespace] = status
             return rose.config.ConfigNode.STATE_USER_IGNORED
         if status == rose.variable.IGNORED_BY_SYSTEM:
+            cache[namespace] = status
             return rose.config.ConfigNode.STATE_SYST_IGNORED
+        cache[namespace] = status
         return rose.config.ConfigNode.STATE_NORMAL
 
     def get_ns_latent_status(self, namespace):
         """Return whether a page has no associated content."""
+        cache = self.data.namespace_cached_statuses['latent']
+        if namespace in cache:
+            return cache[namespace]
         config_name = self.util.split_full_ns(self.data, namespace)[0]
         config_data = self.data.config[config_name]
         sections = self.get_sections_from_namespace(namespace)
@@ -454,9 +467,19 @@ class ConfigDataHelper(object):
                     config_data.sections.now[section].metadata["full_ns"])
                 if section_namespace == namespace:
                     # This is a default page for an existing section.
+                    cache[namespace] = False
                     return False
                 for variable in config_data.vars.now.get(section, []):
                     if variable.metadata["full_ns"] == namespace:
                         # This contains an existing variable.
+                        cache[namespace] = False
                         return False
+        cache[namespace] = True
         return True
+
+    def clear_namespace_cached_statuses(self, namespace):
+        """Reset cached latent, ignored, modified statuses for namespace."""
+        if namespace in self.data.namespace_cached_statuses['ignored']:
+            self.data.namespace_cached_statuses['ignored'].pop(namespace)
+        if namespace in self.data.namespace_cached_statuses['latent']:
+            self.data.namespace_cached_statuses['latent'].pop(namespace)

--- a/lib/python/rose/config_editor/nav_panel.py
+++ b/lib/python/rose/config_editor/nav_panel.py
@@ -282,6 +282,9 @@ class PageNavigationPanel(gtk.ScrolledWindow):
         old_total = self.data_store.get_value(row_iter, total_col)
         old_int = self.data_store.get_value(row_iter, int_col)
         diff_int_count = ind_count - old_int
+        if diff_int_count == 0:
+            # No change.
+            return False
         new_total = old_total + diff_int_count
         self.data_store.set_value(row_iter, int_col, ind_count)
         self.data_store.set_value(row_iter, total_col, new_total)

--- a/lib/python/rose/config_editor/panelwidget/summary_data.py
+++ b/lib/python/rose/config_editor/panelwidget/summary_data.py
@@ -291,10 +291,6 @@ class BaseSummaryDataPanel(gtk.VBox):
 
     def get_status_from_data(self, node_data):
         """Return markup corresponding to changes since the last save."""
-        if not hasattr(self, '_cached_data_statuses'):
-            self._cached_data_statuses = {}
-        if node_data in self._cached_data_statuses:
-            return self._cached_data_statuses[node_data]
         text = ""
         mod_markup = rose.config_editor.SUMMARY_DATA_PANEL_MODIFIED_MARKUP
         err_markup = rose.config_editor.SUMMARY_DATA_PANEL_ERROR_MARKUP
@@ -329,7 +325,6 @@ class BaseSummaryDataPanel(gtk.VBox):
                 text += mod_markup
             if node_data.error:
                 text += err_markup
-        self._cached_data_statuses[node_data] = text
         return text
 
     def _refilter(self, widget=None):

--- a/lib/python/rose/config_editor/panelwidget/summary_data.py
+++ b/lib/python/rose/config_editor/panelwidget/summary_data.py
@@ -291,6 +291,10 @@ class BaseSummaryDataPanel(gtk.VBox):
 
     def get_status_from_data(self, node_data):
         """Return markup corresponding to changes since the last save."""
+        if not hasattr(self, '_cached_data_statuses'):
+            self._cached_data_statuses = {}
+        if node_data in self._cached_data_statuses:
+            return self._cached_data_statuses[node_data]
         text = ""
         mod_markup = rose.config_editor.SUMMARY_DATA_PANEL_MODIFIED_MARKUP
         err_markup = rose.config_editor.SUMMARY_DATA_PANEL_ERROR_MARKUP
@@ -325,6 +329,7 @@ class BaseSummaryDataPanel(gtk.VBox):
                 text += mod_markup
             if node_data.error:
                 text += err_markup
+        self._cached_data_statuses[node_data] = text
         return text
 
     def _refilter(self, widget=None):

--- a/lib/python/rose/config_editor/updater.py
+++ b/lib/python/rose/config_editor/updater.py
@@ -165,6 +165,10 @@ class Updater(object):
         """Loop over all namespaces and update."""
         unique_namespaces = self.data.helper.get_all_namespaces(
             only_this_config)
+
+        for ns in unique_namespaces:
+            self.data.helper.clear_namespace_cached_statuses(ns)
+
         if only_this_config is None:
             configs = self.data.config.keys()
         else:
@@ -202,6 +206,7 @@ class Updater(object):
                          skip_sub_data_update=False):
         """Update driver function. Updates the page if open."""
         self.pagelist = self.get_pagelist_func()
+        self.data.helper.clear_namespace_cached_statuses(namespace)
         if namespace in [p.namespace for p in self.pagelist]:
             index = [p.namespace for p in self.pagelist].index(namespace)
             page = self.pagelist[index]


### PR DESCRIPTION
This speeds up `rose edit`, particularly for adding and deleting sections.

When deleting or adding sections in one of the summary panel windows
(including the custom STASH widget) the speed up can be around 2x -
larger or smaller depending on the total number of sections in a configuration.

The change works by caching the slower function calls in the post-change updating,
and by avoiding expensive treeview re-drawing when there's no change.

