### PR TITLE
rose bush: Fix sqlite query for filtering jobs by status.

### DIFF
--- a/lib/python/rose/suite_engine_procs/cylc.py
+++ b/lib/python/rose/suite_engine_procs/cylc.py
@@ -313,7 +313,7 @@ class CylcProcessor(SuiteEngineProcessor):
             for no_status in no_statuses:
                 statuses = self.STATUSES.get(no_status, [])
                 where_exprs.append(
-                    " OR ".join(["status != ?"] * len(statuses)))
+                    " AND ".join(["status != ?"] * len(statuses)))
                 where_args += statuses
         if where_exprs:
             where_expr = " WHERE (" + ") AND (".join(where_exprs) + ")"


### PR DESCRIPTION
Filtering jobs by status in rose bush (2015.11.1) is currently broken. This fixes the query so it will now work.

Can be tested by viewing suite results mot-aa834 in my area and filtering jobs using each checkbutton.

@matthewrmshin please review 1
@kaday please review 2