### PR TITLE
rose bush: jobs: no frill display of cylc-suite.db

### DIFF
--- a/lib/python/rose/suite_engine_procs/cylc.py
+++ b/lib/python/rose/suite_engine_procs/cylc.py
@@ -403,7 +403,11 @@ class CylcProcessor(SuiteEngineProcessor):
             prefix += user_name
         user_suite_dir = os.path.expanduser(os.path.join(
             prefix, self.get_suite_dir_rel(suite_name)))
-        current_cycles = os.listdir(os.path.join(user_suite_dir, "log", "job"))
+        try:
+            current_cycles = os.listdir(
+                os.path.join(user_suite_dir, "log", "job"))
+        except OSError:
+            current_cycles = []
         targzip_cycles = []
         for name in glob(os.path.join(user_suite_dir, "log", "job-*.tar.gz")):
             targzip_cycles.append(os.path.basename(name)[4:-7])

--- a/t/rose-bush/00-basic.t
+++ b/t/rose-bush/00-basic.t
@@ -89,6 +89,7 @@ for METHOD in 'cycles' 'jobs'; do
     file_grep "${TEST_KEY}.out" 'HTTP/.* 404 Not Found' "${TEST_KEY}.out"
 done
 
+TEST_KEY="${TEST_KEY_BASE}-200-curl-cycles"
 run_pass "${TEST_KEY}" \
     curl "${TEST_ROSE_WS_URL}/cycles/${USER}/${SUITE_NAME}?form=json"
 rose_ws_json_greps "${TEST_KEY}.out" "${TEST_KEY}.out" \
@@ -110,6 +111,7 @@ rose_ws_json_greps "${TEST_KEY}.out" "${TEST_KEY}.out" \
     "[('of_n_entries',), 2]" \
     "[('entries', {'cycle': '20000101T0000Z'}, 'n_states', 'success',), 2]"
 
+TEST_KEY="${TEST_KEY_BASE}-200-curl-jobs"
 run_pass "${TEST_KEY}" \
     curl "${TEST_ROSE_WS_URL}/jobs/${USER}/${SUITE_NAME}?form=json"
 FOO0="{'cycle': '20000101T0000Z', 'name': 'foo0', 'submit_num': 1}"
@@ -162,7 +164,7 @@ SUITE_NAME2="$(basename "${SUITE_DIR2}")"
 cp -pr "${SUITE_DIR}/cylc-suite.db" "${SUITE_DIR2}/"
 run_pass "${TEST_KEY}-bare" \
     curl "${TEST_ROSE_WS_URL}/jobs/${USER}/${SUITE_NAME2}?form=json"
-rose_ws_json_greps "${TEST_KEY}.out" "${TEST_KEY}.out" \
+rose_ws_json_greps "${TEST_KEY}-bare.out" "${TEST_KEY}-bare.out" \
     "[('suite',), '${SUITE_NAME2}']"
 
 for FILE in \

--- a/t/rose-bush/00-basic.t
+++ b/t/rose-bush/00-basic.t
@@ -24,7 +24,7 @@ if ! python -c 'import cherrypy' 2>'/dev/null'; then
     skip_all '"cherrypy" not installed'
 fi
 
-tests 49
+tests 51
 
 ROSE_CONF_PATH= rose_ws_init 'rose' 'bush'
 if [[ -z "${TEST_ROSE_WS_PORT}" ]]; then
@@ -156,6 +156,15 @@ rose_ws_json_greps "${TEST_KEY}.out" "${TEST_KEY}.out" \
     "[('entries', ${FOO1}, 'logs', 'job.txt.05', 'seq_key'), 'job.txt.*']" \
     "[('entries', ${FOO1}, 'logs', 'job.txt.10', 'seq_key'), 'job.txt.*']"
 
+# A suite run directory with only a "cylc-suite.db", and nothing else
+SUITE_DIR2="$(mktemp -d --tmpdir="${HOME}/cylc-run" "rtb-rose-bush-00-XXXXXXXX")"
+SUITE_NAME2="$(basename "${SUITE_DIR2}")"
+cp -pr "${SUITE_DIR}/cylc-suite.db" "${SUITE_DIR2}/"
+run_pass "${TEST_KEY}-bare" \
+    curl "${TEST_ROSE_WS_URL}/jobs/${USER}/${SUITE_NAME2}?form=json"
+rose_ws_json_greps "${TEST_KEY}.out" "${TEST_KEY}.out" \
+    "[('suite',), '${SUITE_NAME2}']"
+
 for FILE in \
     'log/suite/log' \
     'log/job/20000101T0000Z/foo0/01/job' \
@@ -184,5 +193,6 @@ file_grep "${TEST_KEY}.out" 'HTTP/.* 404 Not Found' "${TEST_KEY}.out"
 # Tidy up
 rose_ws_kill
 cylc unregister "${SUITE_NAME}" 1>'/dev/null' 2>&1
-rm -fr "${SUITE_DIR}" "${HOME}/.cylc/ports/${SUITE_NAME}" 2>'/dev/null'
+rm -fr "${SUITE_DIR}" "${SUITE_DIR2}" "${HOME}/.cylc/ports/${SUITE_NAME}" \
+    2>'/dev/null'
 exit 0


### PR DESCRIPTION
Previously, it was failing if it was unable to find `log/job/` in the suite
running directory.