### PR TITLE
rose_arch: optional target

### DIFF
--- a/doc/rose-rug-task-run.html
+++ b/doc/rose-rug-task-run.html
@@ -531,6 +531,11 @@ opt.jobs=8
     <kbd>[arch:TARGET]</kbd> section would override those in the global
     <kbd>[arch]</kbd> section for the given <var>TARGET</var>.</p>
 
+    <p>A target is considered compulsory, i.e. it must have at least one source,
+    unless it is specified with the syntax <kbd>[arch:(TARGET)]</kbd>. In which
+    case, <var>TARGET</var> is considered optional. The application will skip an
+    optional target that has no actual source.</p>
+
     <p>The application provides some useful functionalities:</p>
 
     <ul>
@@ -595,8 +600,8 @@ opt.jobs=8
       <kbd>source-prefix=PREFIX</kbd> is specified. If a name or glob is given
       in a pair of brackets, e.g. <code>(hello-world.*)</code>, the source is
       considered optional and will not cause a failure if it does not match any
-      source file names. However, a target that ends up with no matching source
-      file will be considered a failure.</dd>
+      source file names. However, a compulsory target that ends up with no
+      matching source file will be considered a failure.</dd>
 
       <dt><kbd>source-edit-format=FORMAT</kbd></dt>
 
@@ -668,6 +673,10 @@ source=hello/worlds/* greeting/worlds/* hi/worlds/*
 [arch:worlds/]
 source=hello/worlds/* (greeting/worlds/*) hi/worlds/*
 
+# Target is optional, sources may all be missing
+[arch:(black-box/)]
+source=(cats.txt) (dogs.txt)
+
 # Auto tar-gzip
 [arch:galaxies.tar.gz]
 source-prefix=hello/
@@ -694,6 +703,47 @@ source=stuffing-*.txt
 
 # ...
 </pre>
+
+    <p>On completion, <code>rose_arch</code> writes a status summary for each
+    target to the standard output, which looks like this:</p>
+
+    <pre>
+0 foo:///fred/my-su173/output0.tar.gz [compress=tar.gz]
++ foo:///fred/my-su173/output1.tar.gz [compress=tar.gz, t(init)=2012-12-02T20:02:20Z, dt(tran)=5s, dt(arch)=10s, ret-code=0]
++	output1/earth.txt (output1/human.txt)
++	output1/venus.txt (output1/woman.txt)
++	output1/mars.txt (output1/man.txt)
+= foo:///fred/my-su173/output2.tar.gz [compress=tar.gz]
+! foo:///fred/my-su173/output3.tar.gz [compress=tar.gz]
+</pre>
+
+    <p>The 1st column is a status symbol, where:</p>
+
+    <dl>
+      <dt>0</dt>
+      <dd>An optional target has no real source, and is skipped</dd>
+
+      <dt>+</dt>
+      <dd>A target is added or updated.</dd>
+
+      <dt>=</dt>
+      <dd>A target is not updated, as it was previously successfully updated
+      with the same sources.</dd>
+
+      <dt>!</dt>
+      <dd>Error updating this target.</dd>
+    </dl>
+
+    <p>If the 1st column and the 2nd column are separated by a space character,
+    the 2nd column is a target. If the 1st column and the 2nd column are
+    separated by a tab character, the 2nd column is a source in the target
+    above.</p>
+
+    <p>For a target line, the 3rd column contains the compress scheme, the
+    initial time, the duration taken to transform the sources, the duration
+    taken to run the archive command and the return code of the archive command.
+    For a source line, the 3rd column contains the original name of the
+    source.</p>
 
     <h2 id="rose-task-run.util.rose_bunch">Built-in Application:rose_bunch</h2>
 

--- a/doc/rose-rug-task-run.html
+++ b/doc/rose-rug-task-run.html
@@ -673,9 +673,9 @@ source=hello/worlds/* greeting/worlds/* hi/worlds/*
 [arch:worlds/]
 source=hello/worlds/* (greeting/worlds/*) hi/worlds/*
 
-# Target is optional, sources may all be missing
+# Target is optional, implied that sources may all be missing
 [arch:(black-box/)]
-source=(cats.txt) (dogs.txt)
+source=cats.txt dogs.txt
 
 # Auto tar-gzip
 [arch:galaxies.tar.gz]

--- a/lib/python/rose/apps/rose_arch.py
+++ b/lib/python/rose/apps/rose_arch.py
@@ -205,7 +205,7 @@ class RoseArchApp(BuiltinApp):
             config, t_node, "source-prefix", default="")
         for source_glob in shlex.split(
                 self._get_conf(config, t_node, "source", compulsory=True)):
-            is_compulsory_source = True
+            is_compulsory_source = is_compulsory_target
             if source_glob.startswith("(") and source_glob.endswith(")"):
                 source_glob = source_glob[1:-1]
                 is_compulsory_source = False

--- a/lib/python/rose/apps/rose_arch.py
+++ b/lib/python/rose/apps/rose_arch.py
@@ -156,6 +156,10 @@ class RoseArchApp(BuiltinApp):
             s_key_tail = env_var_process(s_key_tail)
         except UnboundEnvironmentVariableError as exc:
             raise ConfigValueError([t_key, ""], "", exc)
+        is_compulsory_target = True
+        if s_key_tail.startswith("(") and s_key_tail.endswith(")"):
+            s_key_tail = s_key_tail[1:-1]
+            is_compulsory_target = False
         target = RoseArchTarget(target_prefix + s_key_tail)
         target.command_format = self._get_conf(
             config, t_node, "command-format", compulsory=True)
@@ -229,7 +233,10 @@ class RoseArchApp(BuiltinApp):
                         target.sources[checksum] = RoseArchSource(
                             checksum, name, path)
         if not target.sources:
-            target.status = target.ST_BAD
+            if is_compulsory_target:
+                target.status = target.ST_BAD
+            else:
+                target.status = target.ST_NULL
         target.compress_scheme = self._get_conf(config, t_node, "compress")
         if not target.compress_scheme:
             target_base = target.name
@@ -285,11 +292,13 @@ class RoseArchApp(BuiltinApp):
         if target.status == target.ST_OLD:
             app_runner.handle_event(RoseArchEvent(target))
             return
-        target.command_rc = 1
         dao.insert(target)
-        if target.status == target.ST_BAD:
+        if target.status in (target.ST_BAD, target.ST_NULL):
+            # boolean to int
+            target.command_rc = int(target.status == target.ST_BAD)
             app_runner.handle_event(RoseArchEvent(target))
             return
+        target.command_rc = 1
         work_dir = mkdtemp()
         times = [time()] * 3  # init, transformed, archived
         ret_code = None
@@ -369,6 +378,7 @@ class RoseArchTarget(object):
     ST_OLD = "="
     ST_NEW = "+"
     ST_BAD = "!"
+    ST_NULL = "0"
 
     def __init__(self, name):
         self.name = name

--- a/t/rose-task-run/30-app-arch-opt-source.t
+++ b/t/rose-task-run/30-app-arch-opt-source.t
@@ -22,7 +22,7 @@
 . "$(dirname "$0")/test_header"
 
 #-------------------------------------------------------------------------------
-tests 4
+tests 5
 #-------------------------------------------------------------------------------
 # Run the suite, and wait for it to complete
 export CYLC_CONF_PATH=
@@ -50,6 +50,15 @@ file_cmp "${TEST_KEY}.out" "${TEST_KEY}.out" <<'__FIND__'
 ./archive1.d/2016.txt
 ./archive2.d/2015.txt
 __FIND__
+sed -n 's/^\[INFO\] \([+!=0] [^ ]*\) .*$/\1/p' \
+    "${SUITE_RUN_DIR}/log/job/1/archive"*"/0"*"/job.out" \
+    | sort >'job.out.sorted'
+file_cmp "${TEST_KEY}-job.out.sorted" 'job.out.sorted' <<__LOG__
+! ${SUITE_RUN_DIR}/share/backup/archive2.d/
++ ${SUITE_RUN_DIR}/share/backup/archive1.d/
++ ${SUITE_RUN_DIR}/share/backup/archive2.d/
+0 ${SUITE_RUN_DIR}/share/backup/nobody.d/
+__LOG__
 #-------------------------------------------------------------------------------
 rose suite-clean -q -y "${NAME}"
 exit 0

--- a/t/rose-task-run/30-app-arch-opt-source/app/archive1/rose-app.conf
+++ b/t/rose-task-run/30-app-arch-opt-source/app/archive1/rose-app.conf
@@ -7,3 +7,6 @@ target-prefix=$ROSE_SUITE_DIR/share/backup/
 [arch:archive1.d/]
 source-prefix=work/1/$ROSE_TASK_NAME/
 source=2014.txt (2015.txt) (2016.txt)
+
+[arch:(nobody.d/)]
+source=(no-such-file-or-directory.txt) (deleted.log)

--- a/t/rose-task-run/30-app-arch-opt-source/app/archive1/rose-app.conf
+++ b/t/rose-task-run/30-app-arch-opt-source/app/archive1/rose-app.conf
@@ -9,4 +9,4 @@ source-prefix=work/1/$ROSE_TASK_NAME/
 source=2014.txt (2015.txt) (2016.txt)
 
 [arch:(nobody.d/)]
-source=(no-such-file-or-directory.txt) (deleted.log)
+source=no-such-file-or-directory.txt deleted.log


### PR DESCRIPTION
New syntax to indicate a target may have no source.
New status for target with no source.
doc: optional target and more on rose_arch output.

See also #1707 and #1708.

@arjclark @kaday please review.