### PR TITLE
t: rosie-create 00: fix random failure

### DIFF
--- a/t/rosie-create/00-basic.t
+++ b/t/rosie-create/00-basic.t
@@ -309,7 +309,7 @@ cat >$PWD/roses/foo-aa001/app/hello/rose-app.conf <<'__ROSE_APP_CONF__'
 [command]
 default=echo Hello
 __ROSE_APP_CONF__
-echo $(($RANDOM % 10)) >$PWD/roses/foo-aa001/etc/number
+echo $((10 + $RANDOM % 10)) >$PWD/roses/foo-aa001/etc/number
 svn ci -q -m 't' $PWD/roses/foo-aa001
 svn up -q $PWD/roses/foo-aa001
 # Issue the copy command


### PR DESCRIPTION
Caused by modifying a file to be comitted with a random number that may
be exactly the same as the original file - which caused the test to fail
with a 1 in 10 chance.

@arjclark please review. (I don't think we need a 2nd.)