### PR TITLE
rose_arch: improve exception message on no source

### DIFF
--- a/lib/python/rose/apps/rose_arch.py
+++ b/lib/python/rose/apps/rose_arch.py
@@ -212,9 +212,9 @@ class RoseArchApp(BuiltinApp):
             paths = glob(source_prefix + source_glob)
             if not paths:
                 exc = OSError(errno.ENOENT, os.strerror(errno.ENOENT),
-                              source_glob)
-                app_runner.handle_event(
-                    ConfigValueError([t_key, "source"], source_glob, exc))
+                              source_prefix + source_glob)
+                app_runner.handle_event(ConfigValueError(
+                    [t_key, "source"], source_glob, exc))
                 if is_compulsory_source:
                     target.status = target.ST_BAD
                 continue

--- a/t/rose-task-run/07-app-arch.t
+++ b/t/rose-task-run/07-app-arch.t
@@ -106,8 +106,8 @@ file_cmp "$TEST_KEY.err" "${FILE_PREFIX}4/01/job.err" <<'__ERR__'
 [FAIL] [arch:$UNKNOWN_DARK_PLANETS.tar.gz]=: configuration value error: [UNDEFINED ENVIRONMENT VARIABLE] UNKNOWN_DARK_PLANETS
 __ERR__
 TEST_KEY="$TEST_KEY_BASE-bad-archive-5"
-file_cmp "$TEST_KEY.err" "${FILE_PREFIX}5/01/job.err" <<'__ERR__'
-[FAIL] [arch:inner.tar.gz]source=hello/mercurry.txt: configuration value error: [Errno 2] No such file or directory: 'hello/mercurry.txt'
+file_cmp "$TEST_KEY.err" "${FILE_PREFIX}5/01/job.err" <<__ERR__
+[FAIL] [arch:inner.tar.gz]source=hello/mercurry.txt: configuration value error: [Errno 2] No such file or directory: '$SUITE_RUN_DIR/share/cycle/2013010112/hello/mercurry.txt'
 __ERR__
 TEST_KEY="$TEST_KEY_BASE-bad-archive-6"
 file_cmp "$TEST_KEY.err" "${FILE_PREFIX}6/01/job.err" <<__ERR__


### PR DESCRIPTION
When a source glob fails to return a valid file, return the full path of
the glob including the source prefix in the exception message.

@arjclark @kaday please review.

Problem reported by @malcolmbrooks.