### PR TITLE
Rose bunch: evaluate environment varibles in settings and args

### DIFF
--- a/lib/python/rose/apps/rose_bunch.py
+++ b/lib/python/rose/apps/rose_bunch.py
@@ -113,15 +113,15 @@ class RoseBunchApp(BuiltinApp):
         self.invocation_names = conf_tree.node.get_value([self.BUNCH_SECTION,
                                                          "names"])
         if self.invocation_names:
-            self.invocation_names = shlex.split(self.invocation_names)
+            self.invocation_names = shlex.split(
+                os.path.expandvars(self.invocation_names))
             if len(set(self.invocation_names)) != len(self.invocation_names):
                 raise ConfigValueError([self.BUNCH_SECTION, "names"],
                                        self.invocation_names,
                                        "names must be unique")
 
-        self.fail_mode = conf_tree.node.get_value([self.BUNCH_SECTION,
-                                                  "fail-mode"],
-                                                  self.TYPE_CONTINUE_ON_FAIL)
+        self.fail_mode = os.path.expandvars(conf_tree.node.get_value(
+            [self.BUNCH_SECTION, "fail-mode"], self.TYPE_CONTINUE_ON_FAIL))
 
         if self.fail_mode not in self.FAIL_MODE_TYPES:
             raise ConfigValueError([self.BUNCH_SECTION, "fail-mode"],
@@ -131,11 +131,15 @@ class RoseBunchApp(BuiltinApp):
         self.incremental = conf_tree.node.get_value([self.BUNCH_SECTION,
                                                     "incremental"],
                                                     "true")
+        if self.incremental:
+            self.incremental = os.path.expandvars(self.incremental)
 
         multi_args = conf_tree.node.get_value([self.ARGS_SECTION], {})
+        for key, val in multi_args.items():
+            multi_args[key].value = os.path.expandvars(val.value)
 
-        self.command_format = conf_tree.node.get_value([self.BUNCH_SECTION,
-                                                       "command-format"])
+        self.command_format = os.path.expandvars(
+            conf_tree.node.get_value([self.BUNCH_SECTION, "command-format"]))
 
         if not self.command_format:
             raise CompulsoryConfigValueError([self.BUNCH_SECTION,
@@ -149,7 +153,7 @@ class RoseBunchApp(BuiltinApp):
 
         if instances:
             try:
-                instances = range(int(instances))
+                instances = range(int(os.path.expandvars(instances)))
             except ValueError:
                 raise ConfigValueError([self.BUNCH_SECTION,
                                         "command-instances"],
@@ -188,7 +192,7 @@ class RoseBunchApp(BuiltinApp):
         max_procs = conf_tree.node.get_value([self.BUNCH_SECTION, "pool-size"])
 
         if max_procs:
-            self.MAX_PROCS = int(max_procs)
+            self.MAX_PROCS = int(os.path.expandvars(max_procs))
         else:
             self.MAX_PROCS = arglength
 

--- a/lib/python/rose/apps/rose_bunch.py
+++ b/lib/python/rose/apps/rose_bunch.py
@@ -114,13 +114,13 @@ class RoseBunchApp(BuiltinApp):
                                                          "names"])
         if self.invocation_names:
             self.invocation_names = shlex.split(
-                os.path.expandvars(self.invocation_names))
+                rose.env.env_var_process(self.invocation_names))
             if len(set(self.invocation_names)) != len(self.invocation_names):
                 raise ConfigValueError([self.BUNCH_SECTION, "names"],
                                        self.invocation_names,
                                        "names must be unique")
 
-        self.fail_mode = os.path.expandvars(conf_tree.node.get_value(
+        self.fail_mode = rose.env.env_var_process(conf_tree.node.get_value(
             [self.BUNCH_SECTION, "fail-mode"], self.TYPE_CONTINUE_ON_FAIL))
 
         if self.fail_mode not in self.FAIL_MODE_TYPES:
@@ -132,13 +132,13 @@ class RoseBunchApp(BuiltinApp):
                                                     "incremental"],
                                                     "true")
         if self.incremental:
-            self.incremental = os.path.expandvars(self.incremental)
+            self.incremental = rose.env.env_var_process(self.incremental)
 
         multi_args = conf_tree.node.get_value([self.ARGS_SECTION], {})
         for key, val in multi_args.items():
-            multi_args[key].value = os.path.expandvars(val.value)
+            multi_args[key].value = rose.env.env_var_process(val.value)
 
-        self.command_format = os.path.expandvars(
+        self.command_format = rose.env.env_var_process(
             conf_tree.node.get_value([self.BUNCH_SECTION, "command-format"]))
 
         if not self.command_format:
@@ -153,7 +153,7 @@ class RoseBunchApp(BuiltinApp):
 
         if instances:
             try:
-                instances = range(int(os.path.expandvars(instances)))
+                instances = range(int(rose.env.env_var_process(instances)))
             except ValueError:
                 raise ConfigValueError([self.BUNCH_SECTION,
                                         "command-instances"],
@@ -192,7 +192,7 @@ class RoseBunchApp(BuiltinApp):
         max_procs = conf_tree.node.get_value([self.BUNCH_SECTION, "pool-size"])
 
         if max_procs:
-            self.MAX_PROCS = int(os.path.expandvars(max_procs))
+            self.MAX_PROCS = int(rose.env.env_var_process(max_procs))
         else:
             self.MAX_PROCS = arglength
 

--- a/t/rose-task-run/31-app-bunch.t
+++ b/t/rose-task-run/31-app-bunch.t
@@ -21,7 +21,7 @@
 #-------------------------------------------------------------------------------
 . $(dirname $0)/test_header
 #-------------------------------------------------------------------------------
-tests 40
+tests 47
 #-------------------------------------------------------------------------------
 # Run the suite, and wait for it to complete
 export ROSE_CONF_PATH=
@@ -124,6 +124,31 @@ TEST_KEY_PREFIX=names
 FILE=$LOG_DIR/$APP/01/job.out
 for KEY in foo bar baz qux; do
     file_grep $TEST_KEY_PREFIX-ran-$KEY "\[OK\] $KEY" $FILE
+done
+#-------------------------------------------------------------------------------
+#-------------------------------------------------------------------------------
+# Testing names works ok
+#-------------------------------------------------------------------------------
+APP=bunch_env_pass
+#-------------------------------------------------------------------------------
+TEST_KEY_PREFIX=env_vars
+FILE_PREFIX=$LOG_DIR/$APP/01/job
+#-------------------------------------------------------------------------------
+# First run files
+#-------------------------------------------------------------------------------
+file_grep $TEST_KEY_PREFIX-ran-0 "\[OK\] 0" $FILE_PREFIX.out
+file_grep $TEST_KEY_PREFIX-fail-1 "\[FAIL\] 1" $FILE_PREFIX.err
+file_grep $TEST_KEY_PREFIX-ran-2 "\[OK\] 2" $FILE_PREFIX.out
+#-------------------------------------------------------------------------------
+# Second run files
+#-------------------------------------------------------------------------------
+FILE=$LOG_DIR/$APP/02/job.err
+file_grep $TEST_KEY_PREFIX-fail-1 "\[FAIL\] 1" $FILE
+#-------------------------------------------------------------------------------
+FILE_DIR=$LOG_DIR/$APP/01/
+for KEY in $(seq 0 2); do
+    file_grep $TEST_KEY_PREFIX-cmd_eval_ran-$KEY \
+        "a comment" $FILE_DIR/bunch.$KEY.out
 done
 #-------------------------------------------------------------------------------
 rose suite-clean -q -y $NAME

--- a/t/rose-task-run/31-app-bunch/app/bunch_env_pass/rose-app.conf
+++ b/t/rose-task-run/31-app-bunch/app/bunch_env_pass/rose-app.conf
@@ -1,0 +1,11 @@
+mode=rose_bunch
+meta=rose_bunch
+
+[bunch-args]
+arg1=$ARG1
+
+[bunch]
+command-format=echo $COMMENT; %(arg1)s
+incremental=$INCREMENTAL
+fail-mode=$FAIL_MODE
+pool-size=$POOL_SIZE

--- a/t/rose-task-run/31-app-bunch/suite.rc
+++ b/t/rose-task-run/31-app-bunch/suite.rc
@@ -35,5 +35,15 @@
         inherit = BUNCH_TASKS
     [[bunch_names]]
         inherit = BUNCH_TASKS
+    [[bunch_env_pass]]
+        inherit = BUNCH_TASKS
+        retry delays = PT1S
+        [[[environment]]]
+            ARG1=true false true
+            COMMENT=a comment
+            FAIL_MODE=continue
+            INCREMENTAL=true
+            POOL_SIZE=1
+            
     [[dummy]]
         command scripting = true


### PR DESCRIPTION
This allows rose bunch to evaluate environment variables passed through to its settings and args sections - particularly useful for how some of our suites are written. Adds in tests for this behaviour too.

@matthewrmshin please review 1
@kaday please review 2