### PR TITLE
Allow manual overriding of project in rose-stem

### DIFF
--- a/bin/rose-stem
+++ b/bin/rose-stem
@@ -32,15 +32,20 @@
 # EXAMPLES
 #     rose stem --group=developer
 #     rose stem --source=/path/to/source --source=/other/source --group=mygroup
+#     rose stem --source=foo=/path/to/source --source=bar=fcm:bar_tr@head
 #
 # OPTIONS
 #     All options of "rose suite-run" are supported. Additional options are:
 #
-#     --source=SOURCE, -s SOURCE
+#     --source=SOURCE, -s SOURCE, --source=PROJECT=SOURCE, -s PROJECT=SOURCE
 #         Specify a source tree to include in a rose-stem suite. The first
 #         source tree must be a working copy as the location of the suite and
 #         fcm-make config files are taken from it. Further source trees can be
-#         added with additional --source arguments.
+#         added with additional --source arguments. The project which is 
+#         associated with a given source is normally automatically determined
+#         using FCM, however the project can be specified by putting the 
+#         project name as the first part of this argument separated by an
+#         equals sign as in the third example above.
 #         Defaults to '.' if not specified.
 #     --group=GROUP[,GROUP2[,...]], -g GROUP[,GROUP2[,...]]
 #         Specify a group name to run. Additional groups can be specified

--- a/doc/rose-command.html
+++ b/doc/rose-command.html
@@ -1746,6 +1746,7 @@ launcher-preopts.mpiexec=-n $NPROC
     <pre>
     rose stem --group=developer
     rose stem --source=/path/to/source --source=/other/source --group=mygroup
+    rose stem --source=foo=/path/to/source --source=bar=fcm:bar_tr@head
 </pre>
 
     <h3>OPTIONS</h3>All options of <a href="#rose-suite-run">rose suite-run</a>
@@ -1757,7 +1758,11 @@ launcher-preopts.mpiexec=-n $NPROC
       <dd>Specify a source tree to include in a rose-stem suite. The first
       source tree must be a working copy as the location of the suite and
       <kbd>fcm-make</kbd> config files are taken from it. Further source trees
-      can be added with additional --source arguments. Defaults to '.' if not
+      can be added with additional --source arguments.  The project which is 
+      associated with a given source is normally automatically determined
+      using FCM, however the project can be specified by putting the 
+      project name as the first part of this argument separated by an
+      equals sign as in the third example above. Defaults to '.' if not
       specified.</dd>
 
       <dt><kbd>--group=GROUP[,GROUP2[,...]], -g GROUP[,GROUP2[,...]]</kbd></dt>

--- a/doc/rose-rug-stem.html
+++ b/doc/rose-rug-stem.html
@@ -218,6 +218,24 @@ rose stem --source=.
     </div>
 
     <div class="slide">
+      <h3 class="alwayshidden">Source IV</h3>
+
+      <p>The project to which a source tree belongs is normally automatically 
+      determined using FCM commands. However, in the case where the source
+      tree is not a valid FCM URL, or where you wish to assign it to another
+      project, you can specify this using the <code>--source</code> argument:
+      </p>
+      <pre>
+rose stem --source=foo=/path/to/source
+</pre>
+
+      <p>assigns the URL <code>/path/to/source</code> to the <samp>foo</samp>
+      project, so the variables <samp>SOURCE_FOO</samp> and 
+      <samp>SOURCE_FOO_BASE</samp> will be set to <code>/path/to/source</code>.
+      </p>
+    </div>
+
+    <div class="slide">
       <h2>The <code>--group</code> argument</h2>
 
       <p>The group argument is used to provide a Pythonic list of groups in the

--- a/lib/python/rose/stem.py
+++ b/lib/python/rose/stem.py
@@ -261,9 +261,19 @@ class StemRunner(object):
             * revision number
         """
 
-        project = ''
+        project = None
+        if re.search(r'=', item):
+            elements = item.split('=')
+            project = elements[0]
+            item = elements[1]
+
         if re.search(r'^\.', item):
             item = os.path.abspath(os.path.join(os.getcwd(), item))
+
+        if project is not None:
+            print "[WARN] Forcing project for '{0}' to be '{1}'".format(item, 
+                                                             project)
+            return project, item, item, '', ''
 
         source_dict = self._get_base_dir(item)
         project = self._get_project_from_url(source_dict)

--- a/lib/python/rose/stem.py
+++ b/lib/python/rose/stem.py
@@ -262,17 +262,17 @@ class StemRunner(object):
         """
 
         project = None
-        if re.search(r'=', item):
-            elements = item.split('=')
-            project = elements[0]
-            item = elements[1]
+        try:
+            project, item = item.split("=", 1)
+        except ValueError:
+            pass
 
         if re.search(r'^\.', item):
             item = os.path.abspath(os.path.join(os.getcwd(), item))
 
         if project is not None:
-            print "[WARN] Forcing project for '{0}' to be '{1}'".format(item, 
-                                                             project)
+            print "[WARN] Forcing project for '{0}' to be '{1}'".format(
+                item, project)
             return project, item, item, '', ''
 
         source_dict = self._get_base_dir(item)

--- a/t/rose-stem/00-run-basic.t
+++ b/t/rose-stem/00-run-basic.t
@@ -50,7 +50,7 @@ cp $TEST_SOURCE_DIR/00-run-basic/rose-suite.conf $WORKINGCOPY/rose-stem
 touch $WORKINGCOPY/rose-stem/rose-suite.conf
 #We should now have a valid rose-stem suite.
 #-------------------------------------------------------------------------------
-N_TESTS=32
+N_TESTS=41
 tests $N_TESTS
 #-------------------------------------------------------------------------------
 #Test for successful execution
@@ -71,6 +71,32 @@ file_grep $TEST_KEY "SOURCE_FOO_BASE=$WORKINGCOPY\$" $OUTPUT
 TEST_KEY=$TEST_KEY_BASE-basic-source-rev
 file_grep $TEST_KEY "SOURCE_FOO_REV=\$" $OUTPUT
 TEST_KEY=$TEST_KEY_BASE-basic-source-mirror
+file_grep $TEST_KEY "SOURCE_FOO_MIRROR=fcm:foo.xm/trunk@1\$" $OUTPUT
+#-------------------------------------------------------------------------------
+# Test using manual project override
+TEST_KEY=$TEST_KEY_BASE-project-override
+run_pass "$TEST_KEY" \
+   rose stem --group=earl_grey --task=milk,sugar --group=spoon,cup,milk \
+             --source=bar=$WORKINGCOPY --source=fcm:foo.x_tr@head \
+             --no-gcontrol --name $SUITENAME -- --debug
+#Test output
+OUTPUT=$HOME/cylc-run/$SUITENAME/log/job/1/my_task_1/01/job.out
+TEST_KEY=$TEST_KEY_BASE-basic-groups-to-run
+file_grep $TEST_KEY "RUN_NAMES=\[earl_grey, milk, sugar, spoon, cup, milk\]" \
+          $OUTPUT
+TEST_KEY=$TEST_KEY_BASE-project-override-source-foo
+file_grep $TEST_KEY "SOURCE_FOO=fcm:foo.x_tr@head" $OUTPUT
+TEST_KEY=$TEST_KEY_BASE-project-override-source-bar
+file_grep $TEST_KEY "SOURCE_BAR=$WORKINGCOPY" $OUTPUT
+TEST_KEY=$TEST_KEY_BASE-project-override-source-base-foo
+file_grep $TEST_KEY "SOURCE_FOO_BASE=fcm:foo.x_tr" $OUTPUT
+TEST_KEY=$TEST_KEY_BASE-project-override-source-base-bar
+file_grep $TEST_KEY "SOURCE_BAR_BASE=$WORKINGCOPY\$" $OUTPUT
+TEST_KEY=$TEST_KEY_BASE-project-override-source-rev-foo
+file_grep $TEST_KEY "SOURCE_FOO_REV=@1" $OUTPUT
+TEST_KEY=$TEST_KEY_BASE-project-override-source-rev-bar
+file_grep $TEST_KEY "SOURCE_BAR_REV=\$" $OUTPUT
+TEST_KEY=$TEST_KEY_BASE-project-override-source-mirror
 file_grep $TEST_KEY "SOURCE_FOO_MIRROR=fcm:foo.xm/trunk@1\$" $OUTPUT
 #-------------------------------------------------------------------------------
 # Second test, using suite redirection

--- a/t/rose-stem/00-run-basic/suite.rc
+++ b/t/rose-stem/00-run-basic/suite.rc
@@ -24,6 +24,11 @@ echo TEA={{TEA}}
 {%- if MILK is defined %}
 echo MILK={{MILK}}
 {%- endif %}
+{%- if SOURCE_BAR is defined%}
+echo SOURCE_BAR={{SOURCE_BAR}}
+echo SOURCE_BAR_BASE={{SOURCE_BAR_BASE}}
+echo SOURCE_BAR_REV={{SOURCE_BAR_REV}}
+{%- endif %}
 
 """
         [[[event hooks]]]


### PR DESCRIPTION
Currently rose-stem requires the source trees to be valid FCM locations, however this is mostly for determining the project name. This change allows the user to manually specify this and so negate the need for the source trees to be under FCM. Some functionality (namely the mirror URL) won't work, but otherwise this seems fine.

I've added documentation, and some tests to make sure this works, and I'm testing it with the UM suite at the moment.