### PR TITLE
rose_prune: shuffle job hosts

### DIFF
--- a/etc/rose.conf.example
+++ b/etc/rose.conf.example
@@ -422,6 +422,10 @@
 #  job-host-with-share-fast-dest-root=PATH
 ## E.g.:
 #  job-host-with-share-fast-dest-root=/var/run/$USER
+## 2 job hosts sharing a file system, but not with localhost
+#  job-hosts-sharing-fs=HOST1 HOST2
+## E.g.:
+#  job-hosts-sharing-fs=my-hpc01 my-hpc02
 #
 ## Options for "prove" when calling "rose test-battery" with no arguments.
 ## (default="-j9 -s")

--- a/lib/python/rose/apps/rose_prune.py
+++ b/lib/python/rose/apps/rose_prune.py
@@ -20,6 +20,7 @@
 """Builtin application: rose_prune: suite housekeeping application."""
 
 import os
+from random import shuffle
 from rose.app_run import BuiltinApp, ConfigValueError
 from rose.date import RoseDateTimeOperator
 from rose.env import env_var_process, UnboundEnvironmentVariableError
@@ -87,6 +88,9 @@ class RosePruneApp(BuiltinApp):
         globs = self._get_prune_globs(app_runner, conf_tree)
         suite_engine_proc = app_runner.suite_engine_proc
         hosts = suite_engine_proc.get_suite_jobs_auths(suite_name)
+        # A shuffle here should allow the load for doing "rm -rf" to be shared
+        # between job hosts who share a file system.
+        shuffle(hosts)
         suite_dir_rel = suite_engine_proc.get_suite_dir_rel(suite_name)
         form_dict = {"d": suite_dir_rel, "g": " ".join(globs)}
         sh_cmd_head = r"set -e; cd %(d)s; " % form_dict

--- a/t/rose-task-run/34-app-prune-hosts-sharing-fs.t
+++ b/t/rose-task-run/34-app-prune-hosts-sharing-fs.t
@@ -1,0 +1,70 @@
+#!/bin/bash
+#-------------------------------------------------------------------------------
+# (C) British Crown Copyright 2012-6 Met Office.
+#
+# This file is part of Rose, a framework for meteorological suites.
+#
+# Rose is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Rose is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Rose. If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test "rose_prune" built-in application:
+# Prune items in job hosts sharing a common file system (but not with the suite
+# host).
+#-------------------------------------------------------------------------------
+. $(dirname $0)/test_header
+
+JOB_HOSTS="$(rose config --default= 't' 'job-hosts-sharing-fs')"
+JOB_HOST_1="$(awk '{print $1}' <<<"${JOB_HOSTS}")"
+JOB_HOST_2="$(awk '{print $2}' <<<"${JOB_HOSTS}")"
+if [[ -z "${JOB_HOST_1}" || -z "${JOB_HOST_2}" ]]; then
+    skip_all '"[t]job-hosts-sharing-fs" not defined with 2 host names'
+fi
+
+tests 4
+
+export ROSE_CONF_PATH=
+mkdir -p "${HOME}/cylc-run"
+SUITE_RUN_DIR=$(mktemp -d --tmpdir="${HOME}/cylc-run" 'rose-test-battery.XXXXXX')
+NAME="$(basename "${SUITE_RUN_DIR}")"
+#-------------------------------------------------------------------------------
+TEST_KEY="${TEST_KEY_BASE}"
+run_pass "${TEST_KEY}" \
+    rose suite-run -C "${TEST_SOURCE_DIR}/${TEST_KEY_BASE}" --name="${NAME}" \
+    --no-gcontrol --host='localhost' --debug \
+    -S "JOB_HOST_1=\"${JOB_HOST_1}\"" -S "JOB_HOST_2=\"${JOB_HOST_2}\"" \
+    -- --debug
+
+TEST_KEY="${TEST_KEY_BASE}-prune.log"
+grep \
+    "ssh .* \\(${JOB_HOST_1}\\|${JOB_HOST_2}\\) .* share/cycle/19700101T0000Z;" \
+    "${SUITE_RUN_DIR}/prune.log" >'prune-ssh.log'
+run_pass "${TEST_KEY}-prune-ssh-wc-l" test "$(wc -l <'prune-ssh.log')" -eq 2
+
+if head -n 1 'prune-ssh.log' | grep ".* ${JOB_HOST_1} .*"; then
+    run_pass "${TEST_KEY}-delete-1" \
+        grep -q "delete: ${JOB_HOST_1}:share/cycle/19700101T0000Z" \
+        "${SUITE_RUN_DIR}/prune.log"
+    run_fail "${TEST_KEY}-delete-2" \
+        grep -q "delete: ${JOB_HOST_2}:share/cycle/19700101T0000Z" \
+        "${SUITE_RUN_DIR}/prune.log"
+else
+    run_pass "${TEST_KEY}-delete-2" \
+        grep -q "delete: ${JOB_HOST_2}:share/cycle/19700101T0000Z" \
+        "${SUITE_RUN_DIR}/prune.log"
+    run_fail "${TEST_KEY}-delete-1" \
+        grep -q "delete: ${JOB_HOST_1}:share/cycle/19700101T0000Z" \
+        "${SUITE_RUN_DIR}/prune.log"
+fi
+#-------------------------------------------------------------------------------
+rose suite-clean -q -y "${NAME}"
+exit 0

--- a/t/rose-task-run/34-app-prune-hosts-sharing-fs/app/pruner/rose-app.conf
+++ b/t/rose-task-run/34-app-prune-hosts-sharing-fs/app/pruner/rose-app.conf
@@ -1,0 +1,5 @@
+meta=rose_prune/HEAD
+mode=rose_prune
+
+[prune]
+prune{share/cycle}=-P20Y

--- a/t/rose-task-run/34-app-prune-hosts-sharing-fs/suite.rc
+++ b/t/rose-task-run/34-app-prune-hosts-sharing-fs/suite.rc
@@ -1,0 +1,32 @@
+#!jinja2
+[cylc]
+    UTC mode=True
+    abort if any task fails = True
+    [[event hooks]]
+        abort on timeout = True
+        timeout=PT1M
+[scheduling]
+    initial cycle point=1970
+    final cycle point=1990
+    [[dependencies]]
+        [[[P20Y]]]
+            graph="T[-P20Y]:succeed-all & pruner[-P20Y] & T:succeed-all => pruner"
+
+[runtime]
+    [[T]]
+        script="""
+eval $(rose task-env)
+echo "Whatever!" >"${ROSE_DATAC}/${ROSE_TASK_NAME}.txt"
+"""
+    [[t1]]
+        inherit = T
+        [[[remote]]]
+            host = {{JOB_HOST_1}}
+    [[t2]]
+        inherit = T
+        [[[remote]]]
+            host = {{JOB_HOST_2}}
+    [[pruner]]
+        script="""
+rose task-run -v -v --debug | tee -a "${CYLC_SUITE_RUN_DIR}/prune.log"
+"""


### PR DESCRIPTION
To allow job hosts who share a file system to share the load for doing
an `rm -fr` command.

Use `task_jobs`, if available, to get list of job hosts. This is more efficient than using the `task_events` table.