### PR TITLE
rose_prune: remote logs: shuffle hosts

### DIFF
--- a/lib/python/rose/apps/rose_prune.py
+++ b/lib/python/rose/apps/rose_prune.py
@@ -86,6 +86,8 @@ class RosePruneApp(BuiltinApp):
 
         # Prune other directories
         globs = self._get_prune_globs(app_runner, conf_tree)
+        if not globs:
+            return
         suite_engine_proc = app_runner.suite_engine_proc
         hosts = suite_engine_proc.get_suite_jobs_auths(suite_name)
         # A shuffle here should allow the load for doing "rm -rf" to be shared

--- a/lib/python/rose/suite_engine_procs/cylc.py
+++ b/lib/python/rose/suite_engine_procs/cylc.py
@@ -25,6 +25,7 @@ from glob import glob
 import os
 import pwd
 import re
+from random import shuffle
 from rose.fs_util import FileSystemEvent
 from rose.popen import RosePopenError
 from rose.reporter import Event, Reporter
@@ -1212,6 +1213,9 @@ class CylcProcessor(SuiteEngineProcessor):
             if "*" in items:
                 auths = self.get_suite_jobs_auths(suite_name)
                 if auths:
+                    # A shuffle here should allow the load for doing "rm -rf"
+                    # to be shared between job hosts who share a file system.
+                    shuffle(auths)
                     auths_filters.append((auths, [], []))
             else:
                 for item in items:
@@ -1229,6 +1233,10 @@ class CylcProcessor(SuiteEngineProcessor):
                         continue
                     auths = self.get_suite_jobs_auths(suite_name, cycle, name)
                     if auths:
+                        # A shuffle here should allow the load for doing "rm
+                        # -rf" to be shared between job hosts who share a file
+                        # system.
+                        shuffle(auths)
                         includes = []
                         excludes = []
                         if cycle is None and name is None:

--- a/t/rose-task-run/35-app-prune-log-on-hosts-sharing-fs.t
+++ b/t/rose-task-run/35-app-prune-log-on-hosts-sharing-fs.t
@@ -1,0 +1,70 @@
+#!/bin/bash
+#-------------------------------------------------------------------------------
+# (C) British Crown Copyright 2012-6 Met Office.
+#
+# This file is part of Rose, a framework for meteorological suites.
+#
+# Rose is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Rose is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Rose. If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test "rose_prune" built-in application:
+# Prune items in job hosts sharing a common file system (but not with the suite
+# host).
+#-------------------------------------------------------------------------------
+. $(dirname $0)/test_header
+
+JOB_HOSTS="$(rose config --default= 't' 'job-hosts-sharing-fs')"
+JOB_HOST_1="$(awk '{print $1}' <<<"${JOB_HOSTS}")"
+JOB_HOST_2="$(awk '{print $2}' <<<"${JOB_HOSTS}")"
+if [[ -z "${JOB_HOST_1}" || -z "${JOB_HOST_2}" ]]; then
+    skip_all '"[t]job-hosts-sharing-fs" not defined with 2 host names'
+fi
+
+tests 4
+
+export ROSE_CONF_PATH=
+mkdir -p "${HOME}/cylc-run"
+SUITE_RUN_DIR=$(mktemp -d --tmpdir="${HOME}/cylc-run" 'rose-test-battery.XXXXXX')
+NAME="$(basename "${SUITE_RUN_DIR}")"
+#-------------------------------------------------------------------------------
+TEST_KEY="${TEST_KEY_BASE}"
+run_pass "${TEST_KEY}" \
+    rose suite-run -C "${TEST_SOURCE_DIR}/${TEST_KEY_BASE}" --name="${NAME}" \
+    --no-gcontrol --host='localhost' --debug \
+    -S "JOB_HOST_1=\"${JOB_HOST_1}\"" -S "JOB_HOST_2=\"${JOB_HOST_2}\"" \
+    -- --debug
+
+TEST_KEY="${TEST_KEY_BASE}-prune.log"
+grep \
+    "ssh .* \\(${JOB_HOST_1}\\|${JOB_HOST_2}\\).* ls. -d..* 19700101T0000Z" \
+    "${SUITE_RUN_DIR}/prune.log" >'prune-ssh.log'
+run_pass "${TEST_KEY}-prune-ssh-wc-l" test "$(wc -l <'prune-ssh.log')" -eq 2
+
+if head -n 1 'prune-ssh.log' | grep ".* ${JOB_HOST_1} .*"; then
+    run_pass "${TEST_KEY}-delete-1" \
+        grep -q "delete: ${JOB_HOST_1}:log/job/19700101T0000Z" \
+        "${SUITE_RUN_DIR}/prune.log"
+    run_fail "${TEST_KEY}-delete-2" \
+        grep -q "delete: ${JOB_HOST_2}:log/job/19700101T0000Z" \
+        "${SUITE_RUN_DIR}/prune.log"
+else
+    run_pass "${TEST_KEY}-delete-2" \
+        grep -q "delete: ${JOB_HOST_2}:log/job/19700101T0000Z" \
+        "${SUITE_RUN_DIR}/prune.log"
+    run_fail "${TEST_KEY}-delete-1" \
+        grep -q "delete: ${JOB_HOST_1}:log/job/19700101T0000Z" \
+        "${SUITE_RUN_DIR}/prune.log"
+fi
+#-------------------------------------------------------------------------------
+rose suite-clean -q -y "${NAME}"
+exit 0

--- a/t/rose-task-run/35-app-prune-log-on-hosts-sharing-fs/app/pruner/rose-app.conf
+++ b/t/rose-task-run/35-app-prune-log-on-hosts-sharing-fs/app/pruner/rose-app.conf
@@ -1,0 +1,5 @@
+meta=rose_prune/HEAD
+mode=rose_prune
+
+[prune]
+prune-remote-logs-at=-P20Y

--- a/t/rose-task-run/35-app-prune-log-on-hosts-sharing-fs/suite.rc
+++ b/t/rose-task-run/35-app-prune-log-on-hosts-sharing-fs/suite.rc
@@ -1,0 +1,29 @@
+#!jinja2
+[cylc]
+    UTC mode=True
+    abort if any task fails = True
+    [[event hooks]]
+        abort on timeout = True
+        timeout=PT1M
+[scheduling]
+    initial cycle point=1970
+    final cycle point=1990
+    [[dependencies]]
+        [[[P20Y]]]
+            graph="T[-P20Y]:succeed-all & pruner[-P20Y] & T:succeed-all => pruner"
+
+[runtime]
+    [[T]]
+        script=true
+    [[t1]]
+        inherit = T
+        [[[remote]]]
+            host = {{JOB_HOST_1}}
+    [[t2]]
+        inherit = T
+        [[[remote]]]
+            host = {{JOB_HOST_2}}
+    [[pruner]]
+        script="""
+rose task-run -v -v --debug | tee -a "${CYLC_SUITE_RUN_DIR}/prune.log"
+"""


### PR DESCRIPTION
A shuffle should allow the load for doing `rm -rf` to be shared between
job hosts who share a file system.

Close #1796.