### PR TITLE
rosa svn-pre-commit: should now stop trunk replace

### DIFF
--- a/lib/python/rosie/svn_pre_commit.py
+++ b/lib/python/rosie/svn_pre_commit.py
@@ -272,10 +272,6 @@ class RosieSvnPreCommitHook(object):
                         BadChange(status, path, BadChange.VALUE, reports_str))
                     continue
 
-            # New suite trunk: ignore the rest
-            if (self.ST_ADD, path_head + "trunk/") in changes:
-                continue
-
             # Can only remove trunk information file with suite
             if status == self.ST_DELETE and path_tail == self.TRUNK_INFO_FILE:
                 if (self.ST_DELETE, path_head) not in changes:
@@ -288,6 +284,10 @@ class RosieSvnPreCommitHook(object):
                 if (self.ST_DELETE, path_head) not in changes:
                     bad_changes.append(
                         BadChange(status, path, BadChange.NO_TRUNK))
+                continue
+
+            # New suite trunk: ignore the rest
+            if (self.ST_ADD, path_head + "trunk/") in changes:
                 continue
 
             # See whether author has permission to make changes

--- a/t/rosa-svn-pre-commit/01-rosie-create.t
+++ b/t/rosa-svn-pre-commit/01-rosie-create.t
@@ -21,7 +21,7 @@
 #-------------------------------------------------------------------------------
 . $(dirname $0)/test_header
 #-------------------------------------------------------------------------------
-tests 16
+tests 18
 #-------------------------------------------------------------------------------
 mkdir repos
 svnadmin create repos/foo
@@ -102,6 +102,23 @@ A   a/a/0/0/1/
 A   a/a/0/0/1/trunk/
 U   a/a/0/0/1/trunk/rose-suite.info
 __CHANGED__
+#-------------------------------------------------------------------------------
+TEST_KEY="$TEST_KEY_BASE-replace-trunk"
+mkdir -p 'wc'
+svn checkout -q --depth 'empty' "${SVN_URL}" 'wc/foo'
+svn update -q --parents 'wc/foo/a/a/0/0/1'
+svn rm -q 'wc/foo/a/a/0/0/1/trunk'
+svn cp -q "${SVN_URL}/a/a/0/0/0/trunk" 'wc/foo/a/a/0/0/1/trunk'
+cat >'wc/foo/a/a/0/0/1/trunk/rose-suite.info' <<__INFO__
+access-list=*
+owner=ivy
+project=hello
+title=greeting to a list of people
+__INFO__
+run_fail "${TEST_KEY}" \
+    svn ci --no-auth-cache -q -m'foo-aa001: override' --username 'ivy' 'wc/foo'
+file_grep "${TEST_KEY}.err" \
+    '\[FAIL\] SUITE MUST HAVE TRUNK: D   a/a/0/0/1/trunk/' "${TEST_KEY}.err"
 #-------------------------------------------------------------------------------
 TEST_KEY=$TEST_KEY_BASE-meta-empty
 cat >rose-suite.info <<__INFO__


### PR DESCRIPTION
A suite trunk replaces gives you something like this in an `svnlook changed`:

```
D   s/u/1/7/3/trunk/
A   s/u/1/7/3/trunk/
U   s/u/1/7/3/trunk/rose-suite.info
```

The delete check was ignored, because it thought the changeset was to add a new suite.

@benfitzpatrick @arjclark please review.