### PR TITLE
rose demo metadata suite: fix metadata errors

### DIFF
--- a/demo/rose-config-edit/demo_meta/app/06-complex-rule/meta/rose-meta.conf
+++ b/demo/rose-config-edit/demo_meta/app/06-complex-rule/meta/rose-meta.conf
@@ -113,13 +113,13 @@ type=integer
 type=integer
 
 [simple:scalar_test=control_sum_1]
-type=integer
+type=real
 
 [simple:scalar_test=control_sum_2]
-type=integer
+type=real
 
 [simple:scalar_test=control_sum_3]
-type=integer
+type=real
 
 [simple:scalar_test=test_var_div_zero_fail]
 fail-if=24 % this == 0

--- a/demo/rose-config-edit/demo_meta/app/06-complex-rule/meta/rose-meta.conf
+++ b/demo/rose-config-edit/demo_meta/app/06-complex-rule/meta/rose-meta.conf
@@ -103,7 +103,22 @@ description=Fail if element 2 is not '0A' and element 4 is '0A'
 fail-if=this(2) != "'0A'" and this(4) == "'0A'"
 length=:
 
-[simple:scalar_test=control_less_than]
+[simple:scalar_test=control_lt]
+type=integer
+
+[simple:scalar_test=control_mult_1]
+type=integer
+
+[simple:scalar_test=control_mult_2]
+type=integer
+
+[simple:scalar_test=control_sum_1]
+type=integer
+
+[simple:scalar_test=control_sum_2]
+type=integer
+
+[simple:scalar_test=control_sum_3]
 type=integer
 
 [simple:scalar_test=test_var_div_zero_fail]

--- a/demo/rose-config-edit/demo_meta/app/15-sort-key/meta/rose-meta.conf
+++ b/demo/rose-config-edit/demo_meta/app/15-sort-key/meta/rose-meta.conf
@@ -1,16 +1,12 @@
 [env=BARBAR]
-fail-if=this > jinja2:suite_rc=bar_max
 
 [env=BAR]
-fail-if=this > jinja2:suite_rc=bar_max
 sort-key=a1
 
 [env=FOO]
-fail-if=this > jinja2:suite_rc=bar_max
 sort-key=a0
 
 [env=FOOBAR]
-fail-if=this > jinja2:suite_rc=bar_max
 sort-key=a10
 
 [00alpha]

--- a/demo/rose-config-edit/demo_meta/app/15-sort-key/rose-app.conf
+++ b/demo/rose-config-edit/demo_meta/app/15-sort-key/rose-app.conf
@@ -4,9 +4,6 @@ BAR=5
 FOO=4
 FOOBAR=6
 
-[jinja2:suite_rc]
-bar_max=2
-
 [00alpha]
 
 [00beta]


### PR DESCRIPTION
This fixes metadata-check errors in the `demo/rose-config-edit/demo_meta` suite.

These pop up if you load the suite in `rose edit` and load all apps.