### PR TITLE
rose macro: fix nested triggers for duplicate section options

### DIFF
--- a/lib/python/rose/macros/trigger.py
+++ b/lib/python/rose/macros/trigger.py
@@ -138,7 +138,6 @@ class TriggerMacro(rose.macro.MacroBaseRoseEdit):
         skipped.
 
         """
-        has_ignored_parent = True
         config_sections = self._get_config_sections(config_data)
         config_sections_duplicate_map = self._get_duplicate_config_sections(
             config_data, config_sections=config_sections)
@@ -151,10 +150,11 @@ class TriggerMacro(rose.macro.MacroBaseRoseEdit):
             start_ids = alt_ids
         id_stack = []
         for start_id in start_ids:
+            has_ignored_parent = True
             if (start_id in self.enabled_dict and
                     start_id not in self.ignored_dict):
                 has_ignored_parent = False
-            if not sum([start_id in v for v in
+            if not sum([var_id in v for v in
                         self.trigger_family_lookup.values()]):
                 has_ignored_parent = False
             section, option = self._get_section_option_from_id(start_id)

--- a/lib/python/rose/macros/trigger.py
+++ b/lib/python/rose/macros/trigger.py
@@ -121,6 +121,8 @@ class TriggerMacro(rose.macro.MacroBaseRoseEdit):
         """Update enabled and ignored ids starting with var_id.
 
         var_id - a setting id to start the triggering update at.
+        If an id has duplicates (e.g. is part of a duplicate section),
+        update all duplicate ids.
         config_data - a rose.config.ConfigNode or a dictionary that
         looks like this:
         {"sections":
@@ -133,9 +135,6 @@ class TriggerMacro(rose.macro.MacroBaseRoseEdit):
             }
         }
         meta_config - a rose.config.ConfigNode.
-        only_these_sections (default None) - a list of sections to
-        examine. If specified, checking for other sections will be
-        skipped.
 
         """
         config_sections = self._get_config_sections(config_data)
@@ -148,24 +147,31 @@ class TriggerMacro(rose.macro.MacroBaseRoseEdit):
         )
         if alt_ids:
             start_ids = alt_ids
+        # For each id in our starting list, figure out if it itself is
+        # already effectively trigger-ignored.
         id_stack = []
         for start_id in start_ids:
-            has_ignored_parent = True
+            is_ignored = True
             if (start_id in self.enabled_dict and
                     start_id not in self.ignored_dict):
-                has_ignored_parent = False
+                # Definitely enabled.
+                is_ignored = False
             if not sum([var_id in v for v in
                         self.trigger_family_lookup.values()]):
-                has_ignored_parent = False
+                # Not triggered by anything, so must be enabled.
+                is_ignored = False
             section, option = self._get_section_option_from_id(start_id)
             is_node_present = self._get_config_has_id(config_data, start_id)
             if section in self.ignored_dict and option is not None:
-                has_ignored_parent = True
-            has_ignored_parent = has_ignored_parent or not is_node_present
-            id_stack.append((start_id, has_ignored_parent))
+                # Parent section of an option is ignored, so option is.
+                is_ignored = True
+            # If the id is missing, anything it triggers should be ignored.
+            is_ignored = is_ignored or not is_node_present
+            id_stack.append((start_id, is_ignored))
         update_id_list = []
         while id_stack:
             this_id, has_ignored_parent = id_stack[0]
+            # For each id, examine its duplicates (if any) and all children.
             alt_ids = self._get_id_duplicates(
                 this_id, config_data, meta_config,
                 config_sections_duplicate_map=config_sections_duplicate_map

--- a/t/rose-macro/10-trigger-check.t
+++ b/t/rose-macro/10-trigger-check.t
@@ -38,7 +38,7 @@ atrig = 2
 btrig = 3
 __CONFIG__
 #-------------------------------------------------------------------------------
-tests 21
+tests 24
 #-------------------------------------------------------------------------------
 # Check trigger checking - this is nearly cyclic but should be fine.
 TEST_KEY=$TEST_KEY_BASE-ok
@@ -968,6 +968,42 @@ duplicate=true
 [namelist:bar=wibble]
 
 [namelist:bar=wobble]
+__META_CONFIG__
+run_pass "$TEST_KEY" rose macro --config=../config rose.macros.DefaultValidators
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+teardown
+#-------------------------------------------------------------------------------
+# Check multiply-nested triggering inside a duplicate namelist's options.
+TEST_KEY=$TEST_KEY_BASE-dupl-namelist-within
+setup
+init <<'__CONFIG__'
+[namelist:baz(1)]
+a=1
+b=2
+c=4
+
+[namelist:baz(2)]
+a=0
+!!b=2
+!!c=4
+
+[namelist:baz(3)]
+a=1
+b=2
+c=4
+__CONFIG__
+init_meta <<__META_CONFIG__
+[namelist:baz]
+duplicate=true
+
+[namelist:baz=a]
+trigger=namelist:baz=b: 1;
+
+[namelist:baz=b]
+trigger=namelist:baz=c: 2;
+
+[namelist:baz=c]
 __META_CONFIG__
 run_pass "$TEST_KEY" rose macro --config=../config rose.macros.DefaultValidators
 file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null


### PR DESCRIPTION
The logic for triggering options in duplicate namelists is not right.

When an option is enabled in one duplicate section but ignored in another,
a child of the latter option can get the wrong parent status and can be marked as 'enabled'.
This can only happen in duplicate sections where there are at least 2 levels of triggering.

There are actually 2 errors fixed here:
 * `has_ignored_parent` was set outside the code loop over duplicate ids, so changing it to `False` affected the remainder of the loop
 * the duplicate id was used to check if anything triggered it in `trigger_family_lookup`, but actually
 we need to use the non-duplicate (root) id (e.g. `namelist:foo=bar` rather than `namelist:foo(1)=bar`).

The current master fails the new test with:
```
[V] rose.macros.DefaultValidators: issues: 1
    namelist:baz(2)=c=4
        State should be enabled
```
which is not right. Otherwise the tests didn't cover this situation.

Unfortunately, a lot of real world apps may not have correct triggers due to this (known examples are domain namelists in the UM), so users would need to fix their configurations on usage of Rose with this fix. I'm marking it as `soon` for the moment so we can discuss it.