### PR TITLE
rose suite-*: more cylc-6.8.0 port file related

### DIFF
--- a/lib/python/rose/bush.py
+++ b/lib/python/rose/bush.py
@@ -57,7 +57,6 @@ class RoseBushService(object):
     SUITES_PER_PAGE = 100
     VIEW_SIZE_MAX = 10 * 1024 * 1024  # 10MB
 
-
     def __init__(self, *args, **kwargs):
         self.exposed = True
         self.suite_engine_proc = SuiteEngineProcessor.get_processor()
@@ -503,7 +502,7 @@ class RoseBushService(object):
                 cherrypy.response.headers["Content-Type"] = mime
                 return cherrypy.lib.static.serve_file(f_name, mime)
             s = open(f_name).read()
-        if mode == None:
+        if mode is None:
             s = jinja2.escape(s)
         try:
             lines = [unicode(line) for line in s.splitlines()]

--- a/lib/python/rose/suite_engine_proc.py
+++ b/lib/python/rose/suite_engine_proc.py
@@ -624,18 +624,6 @@ class SuiteEngineProcessor(object):
         """Return whether or not a suite is registered."""
         raise NotImplementedError()
 
-    def is_suite_running(self, user_name, suite_name, hosts=None):
-        """Return a list of reasons if it looks like suite is running.
-
-        Each reason should be a dict with the following keys:
-        * "host": the host name where the suite appears to be running on.
-        * "reason_key": a key, such as "process-id", "port-file", etc.
-        * "reason_value": the value of the reason, e.g. the process ID, the
-                          path to a port file, etc.
-
-        """
-        raise NotImplementedError()
-
     def job_logs_archive(self, suite_name, items):
         """Archive cycle job logs.
 

--- a/lib/python/rose/suite_engine_proc.py
+++ b/lib/python/rose/suite_engine_proc.py
@@ -217,7 +217,7 @@ class SuiteStillRunningError(Exception):
 class SuiteHostConnectError(Exception):
     """Cannot connect to the suite host."""
 
-    TMPL = "%s: cannot connect to some suite hosts, try again later?\n"
+    TMPL = "%s: cannot connect to some suite hosts, try again later.\n"
     TMPL_HOST = "* %s\n"
 
     def __str__(self):

--- a/lib/python/rose/suite_engine_procs/cylc.py
+++ b/lib/python/rose/suite_engine_procs/cylc.py
@@ -23,15 +23,18 @@ import filecmp
 from fnmatch import fnmatch
 from glob import glob
 import os
+from pipes import quote
 import pwd
 import re
 from random import shuffle
 from rose.fs_util import FileSystemEvent
 from rose.popen import RosePopenError
 from rose.reporter import Event, Reporter
+from rose.resource import ResourceLocator
 from rose.suite_engine_proc import (
-    SuiteEngineProcessor, SuiteScanResult,
+    SuiteEngineProcessor, SuiteHostConnectError, SuiteScanResult,
     SuiteEngineGlobalConfCompatError, TaskProps)
+import shlex
 import signal
 import socket
 import sqlite3
@@ -47,7 +50,7 @@ _PORT_SCAN = "port-scan"
 
 class CylcProcessor(SuiteEngineProcessor):
 
-    """Logic specific to the Cylc suite engine."""
+    """Logic specific to the cylc suite engine."""
 
     CYCLE_ORDERS = {"time_desc": " DESC", "time_asc": " ASC"}
     EVENTS = {"submission succeeded": "submit",
@@ -873,6 +876,126 @@ class CylcProcessor(SuiteEngineProcessor):
 
         return entries, of_n_entries
 
+    def get_suite_run_hosts(self, user_name, suite_name, host_names=None):
+        """Return a list of host(s) where suite_name has running processes."""
+        if user_name is None:
+            user_name = pwd.getpwuid(os.getuid()).pw_name
+        else:
+            try:
+                pwd.getpwnam(user_name)
+            except KeyError:  # invalid user name
+                return []
+
+        # Get suite host name from:
+        # * ~USERID/.cylc/ports/SUITE
+        # * ~USERID/cylc-run/SUITE/log/rose-suite-run.host
+        for func in [self._host_from_port_file, self._host_from_rose_log]:
+            try:
+                file_path, host_name = func(user_name, suite_name)
+            except (IOError, IndexError):
+                # Not running on localhost?
+                # Running on usual hosts with no share FS?
+                # (port file) Suite started with version before cylc-6.8.0?
+                pass
+            else:
+                if host_name:
+                    yes_list, no_list, fail_list = self._suite_hosts_pgrep(
+                        user_name, suite_name, [host_name])
+                    if yes_list:
+                        return [host_name]
+                    elif no_list:
+                        if file_path:
+                            self.fs_util.delete(file_path)
+                        return []
+                    else:  # fail_list
+                        raise SuiteHostConnectError(
+                            suite_name, user_name, [host_name])
+
+        # Look for suite on specified or configured suite hosts
+        if not host_names:
+            conf = ResourceLocator.default().get_conf()
+            host_names = ["localhost"]
+            for key in ["scan-hosts", "hosts"]:
+                names = shlex.split(
+                    conf.get_value(["rose-suite-run", key], ""))
+                if names:
+                    host_names += self.host_selector.expand(names)[0]
+
+        yes_list, _, fail_list = self._suite_hosts_pgrep(
+            user_name, suite_name, host_names)
+        if yes_list:  # If suite running on any host, report them
+            return yes_list
+        elif fail_list:  # Suite may still be running on unconnected hosts
+            raise SuiteHostConnectError(suite_name, user_name, fail_list)
+        else:  # We can be quite sure that suite is not running
+            return []
+
+    @classmethod
+    def _host_from_port_file(cls, user_name, suite_name):
+        """Get host from port file line 2, require cylc-6.8.0+."""
+        file_path = os.path.join(
+            os.path.expanduser("~" + user_name), ".cylc", "ports", suite_name)
+        return file_path, open(file_path).read().splitlines()[1]
+
+    def _host_from_rose_log(self, user_name, suite_name):
+        """Get host from rose-suite-run.host file."""
+        file_path = os.path.join(
+            os.path.expanduser("~" + user_name),
+            self.get_suite_dir_rel(suite_name, "log", "rose-suite-run.host"))
+        return file_path, open(file_path).read().strip()
+
+    def _suite_hosts_pgrep(self, user_name, suite_name, host_names):
+        """Helper for "self.get_suite_run_hosts".
+
+        Return [yes_list, no_list, fail_list] where yes_list contains a list
+        of hosts with processes running suite_name, no_list contains a list of
+        hosts with no processes running suite_name and fail_list contains a
+        list of hosts that we are unable to connect to.
+        """
+        pgrep = [
+            "pgrep", "-f", "-u", user_name,
+            self.PGREP_CYLC_RUN % (suite_name)]
+        host_name_ctx_dict = {}
+        for host_name in host_names:
+            if self.host_selector.is_local_host(host_name) and not user_name:
+                # localhost
+                host_name_ctx_dict[host_name] = (
+                    self.popen.run_bg(*pgrep), True)  # is_local=True
+            else:
+                # alternate host and/or alternate user
+                auth = host_name
+                if user_name:
+                    auth = user_name + "@" + host_name
+                command = self.popen.get_cmd("ssh", "-n", auth, (
+                    " ".join([quote(item) for item in pgrep]) + " || true"))
+                host_name_ctx_dict[host_name] = (
+                    self.popen.run_bg(*command), False)  # is_local=False
+        yes_list = []
+        no_list = []
+        fail_list = []
+        while host_name_ctx_dict:
+            for host_name, ctx in host_name_ctx_dict.items():
+                proc, is_local = ctx
+                ret_code = proc.poll()
+                if ret_code is None:
+                    continue
+                host_name_ctx_dict.pop(host_name)
+                out = proc.communicate()[0]
+                ret_code = proc.wait()
+                if out and out.splitlines()[0].isdigit():
+                    # pgrep has returned some entries
+                    # suite running on host
+                    yes_list.append(host_name)
+                elif is_local or ret_code == 0:
+                    # pgrep has no entry, local or ssh did not fail
+                    # suite not running on host
+                    no_list.append(host_name)
+                else:
+                    # ssh failed
+                    # can't tell if suite running on host or not
+                    fail_list.append(host_name)
+        return yes_list, no_list, fail_list
+
     def get_suite_state_summary(self, user_name, suite_name):
         """Return a the state summary of a user's suite.
 
@@ -1376,26 +1499,6 @@ class CylcProcessor(SuiteEngineProcessor):
     def parse_job_log_rel_path(cls, f_name):
         """Return (cycle, task, submit_num, ext)."""
         return f_name.replace("log/job/", "").split("/", 3)
-
-    def ping(self, suite_name, hosts=None, timeout=10):
-        """Return a list of host names where suite_name is running."""
-        host_proc_dict = {}
-        for host in sorted(self.get_suite_hosts(suite_name, hosts)):
-            proc = self.popen.run_bg(
-                "cylc", "ping", "--host=" + host, suite_name,
-                "--pyro-timeout=" + str(timeout))
-            host_proc_dict[host] = proc
-        ping_ok_hosts = []
-        while host_proc_dict:
-            for host, proc in host_proc_dict.items():
-                ret_code = proc.poll()
-                if ret_code is not None:
-                    host_proc_dict.pop(host)
-                    if ret_code == 0:
-                        ping_ok_hosts.append(host)
-            if host_proc_dict:
-                sleep(0.1)
-        return ping_ok_hosts
 
     @classmethod
     def process_suite_hook_args(cls, *args, **_):

--- a/lib/python/rose/suite_engine_procs/cylc.py
+++ b/lib/python/rose/suite_engine_procs/cylc.py
@@ -119,7 +119,7 @@ class CylcProcessor(SuiteEngineProcessor):
             " CAST(strftime('%s', time_submit) AS NUMERIC)) ASC, " +
             "submit_num DESC, name DESC, cycle DESC"),
     })
-    PGREP_CYLC_RUN = r"python.*cylc-(run|restart)( | .+ )%s( |$)"
+    PGREP_CYLC_RUN = r"python.*/bin/cylc-(run|restart)( | .+ )%s( |$)"
     REASON_KEY_PROC = "process"
     REASON_KEY_FILE = "port-file"
     REC_BUNCH_LOG = re.compile(r"\A(bunch\.)(.+)(\.out|\.err)\Z")

--- a/t/rose-suite-clean/01-running.t
+++ b/t/rose-suite-clean/01-running.t
@@ -37,13 +37,12 @@ ls -ld $HOME/cylc-run/$NAME 1>/dev/null
 poll ! test -e $SUITE_RUN_DIR/log/job/2013010100/my_task_1/01/job
 SUITE_PROC=$(pgrep -u$USER -fl "python.*cylc-run .*\\<$NAME\\>" \
     | awk '{print "[FAIL]     " $0}')
+HOST=$(hostname -f)
 #-------------------------------------------------------------------------------
 TEST_KEY=$TEST_KEY_BASE-running
 run_fail "$TEST_KEY" rose suite-clean -y $NAME
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" <<__ERR__
-[FAIL] Suite "$NAME" may still be running.
-[FAIL] Host "localhost" has process:
-$SUITE_PROC
+[FAIL] Suite "$NAME" has running processes on: $HOST
 [FAIL] Try "rose suite-shutdown --name=$NAME" first?
 __ERR__
 if [[ ! -d $HOME/cylc-run/$NAME ]]; then
@@ -53,9 +52,7 @@ fi
 TEST_KEY=$TEST_KEY_BASE-running-name
 run_fail "$TEST_KEY" rose suite-clean -y -n $NAME
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" <<__ERR__
-[FAIL] Suite "$NAME" may still be running.
-[FAIL] Host "localhost" has process:
-$SUITE_PROC
+[FAIL] Suite "$NAME" has running processes on: $HOST
 [FAIL] Try "rose suite-shutdown --name=$NAME" first?
 __ERR__
 if [[ ! -d $HOME/cylc-run/$NAME ]]; then
@@ -75,6 +72,7 @@ TEST_KEY=$TEST_KEY_BASE-stopped
 run_pass "$TEST_KEY" rose suite-clean -y $NAME
 sed -i '/\/\.cylc\//d' "$TEST_KEY.out"
 file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<__OUT__
+[INFO] delete: $HOME/cylc-run/$NAME/log/rose-suite-run.host
 [INFO] delete: $SUITE_RUN_DIR/
 __OUT__
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null

--- a/t/rose-suite-clean/03-only-2.t
+++ b/t/rose-suite-clean/03-only-2.t
@@ -61,6 +61,7 @@ LANG=C sort "$TEST_KEY.out" >"$TEST_KEY.sorted.out"
 if [[ -n "$JOB_HOST" ]]; then
     # We do not know the relative sort order of $SUITE_RUN_DIR and $JOB_HOST.
     LANG=C sort >"$TEST_KEY.expected.out" <<__OUT__
+[INFO] delete: $HOME/cylc-run/$NAME/log/rose-suite-run.host
 [INFO] delete: $SUITE_RUN_DIR/share/cycle/20000101T0000Z/
 [INFO] delete: $SUITE_RUN_DIR/share/cycle/20100101T0000Z/
 [INFO] delete: $SUITE_RUN_DIR/share/cycle/20200101T0000Z/
@@ -70,6 +71,7 @@ if [[ -n "$JOB_HOST" ]]; then
 __OUT__
 else
     cat >"$TEST_KEY.expected.out" <<__OUT__
+[INFO] delete: $HOME/cylc-run/$NAME/log/rose-suite-run.host
 [INFO] delete: $SUITE_RUN_DIR/share/cycle/20000101T0000Z/
 [INFO] delete: $SUITE_RUN_DIR/share/cycle/20100101T0000Z/
 [INFO] delete: $SUITE_RUN_DIR/share/cycle/20200101T0000Z/

--- a/t/rose-suite-clean/04-only-3.t
+++ b/t/rose-suite-clean/04-only-3.t
@@ -52,6 +52,7 @@ TEST_KEY="$TEST_KEY_BASE-work"
 run_pass "$TEST_KEY" rose suite-clean -y -n "$NAME" --only=work
 sed -i '/\/\.cylc\//d' "$TEST_KEY.out"
 LANG=C sort >"$TEST_KEY.out.expected" <<__OUT__
+[INFO] delete: $HOME/cylc-run/$NAME/log/rose-suite-run.host
 [INFO] delete: $SUITE_RUN_DIR/work
 [INFO] delete: $ROOT_DIR_WORK/cylc-run/$NAME/work/
 __OUT__

--- a/t/rose-suite-clean/05-only-4.t
+++ b/t/rose-suite-clean/05-only-4.t
@@ -52,6 +52,7 @@ TEST_KEY="$TEST_KEY_BASE-work"
 run_pass "$TEST_KEY" rose suite-clean -y -n "$NAME" --only=work/20?00101T0000Z
 sed -i '/\/\.cylc\//d' "$TEST_KEY.out"
 file_cmp  "$TEST_KEY.out" "$TEST_KEY.out" <<__OUT__
+[INFO] delete: $HOME/cylc-run/$NAME/log/rose-suite-run.host
 [INFO] delete: $SUITE_RUN_DIR/work/20000101T0000Z/
 [INFO] delete: $SUITE_RUN_DIR/work/20100101T0000Z/
 [INFO] delete: $SUITE_RUN_DIR/work/20200101T0000Z/

--- a/t/rose-suite-clean/06-only-5.t
+++ b/t/rose-suite-clean/06-only-5.t
@@ -59,6 +59,7 @@ TEST_KEY="$TEST_KEY_BASE-work"
 run_pass "$TEST_KEY" rose suite-clean -y -n "$NAME" --only=work
 sed -i '/\/\.cylc\//d' "$TEST_KEY.out"
 {
+    echo "[INFO] delete: ${HOME}/cylc-run/${NAME}/log/rose-suite-run.host"
     echo "[INFO] delete: $SUITE_RUN_DIR/work/"
     LANG=C sort <<__OUT__
 [INFO] delete: $JOB_HOST:cylc-run/$NAME/work

--- a/t/rose-suite-clean/07-only-6.t
+++ b/t/rose-suite-clean/07-only-6.t
@@ -57,6 +57,7 @@ TEST_KEY="$TEST_KEY_BASE-work"
 run_pass "$TEST_KEY" rose suite-clean -y -n "$NAME" --only=work/20?00101T0000Z
 sed -i '/\/\.cylc\//d' "$TEST_KEY.out"
 file_cmp  "$TEST_KEY.out" "$TEST_KEY.out" <<__OUT__
+[INFO] delete: ${HOME}/cylc-run/${NAME}/log/rose-suite-run.host
 [INFO] delete: $SUITE_RUN_DIR/work/20000101T0000Z/
 [INFO] delete: $SUITE_RUN_DIR/work/20100101T0000Z/
 [INFO] delete: $SUITE_RUN_DIR/work/20200101T0000Z/

--- a/t/rose-suite-restart/01-running.t
+++ b/t/rose-suite-restart/01-running.t
@@ -33,12 +33,12 @@ rose suite-run --debug -q \
 TEST_KEY="${TEST_KEY_BASE}-name"
 run_fail "${TEST_KEY}" rose suite-restart --name="${NAME}"
 file_grep "${TEST_KEY}.err" \
-    "\[FAIL\] Suite \"${NAME}\" may still be running." "${TEST_KEY}.err"
+    "\[FAIL\] Suite \"${NAME}\" has running processes on:" "${TEST_KEY}.err"
 
 TEST_KEY="${TEST_KEY_BASE}-cwd"
 run_fail "${TEST_KEY}" bash -c "cd '${SUITE_RUN_DIR}'; rose suite-restart"
 file_grep "${TEST_KEY}.err" \
-    "\[FAIL\] Suite \"${NAME}\" may still be running." "${TEST_KEY}.err"
+    "\[FAIL\] Suite \"${NAME}\" has running processes on:" "${TEST_KEY}.err"
 #-------------------------------------------------------------------------------
 rm -f "${SUITE_RUN_DIR}/work/1/foo/file"
 timeout 60 \

--- a/t/rose-suite-run/08-pgrep.t
+++ b/t/rose-suite-run/08-pgrep.t
@@ -69,9 +69,7 @@ run_fail "$TEST_KEY" \
     rose suite-run -C $TEST_SOURCE_DIR/$TEST_KEY_BASE --name=$NAME \
     $OPT_HOST --no-gcontrol
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" <<__ERR__
-[FAIL] Suite "$NAME" may still be running.
-[FAIL] Host "${HOST:-localhost}" has process:
-$SUITE_PROC
+[FAIL] Suite "$NAME" has running processes on: ${HOST:-localhost}
 [FAIL] Try "rose suite-shutdown --name=$NAME" first?
 __ERR__
 run_pass "$TEST_KEY.NAME0" \

--- a/t/rose-suite-run/20-pgrep-conflict.t
+++ b/t/rose-suite-run/20-pgrep-conflict.t
@@ -58,16 +58,12 @@ for ARG in '' '--hold'; do
     fi
     if "${IS_NEW_PGREP}"; then
         file_cmp "${TEST_KEY}.err" "${TEST_KEY}.err" <<__ERR__
-[FAIL] Suite "${NAME}" may still be running.
-[FAIL] Host "localhost" has process:
-[FAIL]     ${FAKE_SUITE_PID} python
+[FAIL] Suite "${NAME}" has running processes on: localhost
 [FAIL] Try "rose suite-shutdown --name=${NAME}" first?
 __ERR__
     else
         file_cmp "${TEST_KEY}.err" "${TEST_KEY}.err" <<__ERR__
-[FAIL] Suite "${NAME}" may still be running.
-[FAIL] Host "localhost" has process:
-[FAIL]     ${FAKE_SUITE_PID} python ${TEST_DIR}/cylc-run ${NAME}${ARG_STR}
+[FAIL] Suite "${NAME}" has running processes on: localhost
 [FAIL] Try "rose suite-shutdown --name=${NAME}" first?
 __ERR__
     fi

--- a/t/rose-suite-run/20-pgrep-conflict.t
+++ b/t/rose-suite-run/20-pgrep-conflict.t
@@ -24,7 +24,8 @@ set -eu
 #-------------------------------------------------------------------------------
 tests 20
 #-------------------------------------------------------------------------------
-cat >$TEST_DIR/cylc-run <<'__PYTHON__'
+mkdir "${TEST_DIR}/bin"
+cat >"${TEST_DIR}/bin/cylc-run" <<'__PYTHON__'
 #!/usr/bin/env python
 import time
 time.sleep(60)
@@ -48,7 +49,7 @@ if pgrep -a 'bash' 1>'/dev/null' 2>&1; then
 fi
 for ARG in '' '--hold'; do
     TEST_KEY="${TEST_KEY_BASE}-self-check${ARG}"
-    python "${TEST_DIR}/cylc-run" "${NAME}" ${ARG} 1>'/dev/null' 2>&1 &
+    python "${TEST_DIR}/bin/cylc-run" "${NAME}" ${ARG} 1>'/dev/null' 2>&1 &
     FAKE_SUITE_PID=$!
     run_fail "${TEST_KEY}" rose suite-run -q --no-gcontrol \
         -C "${TEST_SOURCE_DIR}/${TEST_KEY_BASE}" --name="${NAME}" -- --debug
@@ -85,7 +86,8 @@ for ALT_NAME in \
 do
     for ARG in '' '--hold'; do
         TEST_KEY="${TEST_KEY_BASE}-alt-name-${ALT_NAME}${ARG}"
-        python "${TEST_DIR}/cylc-run" "${ALT_NAME}" ${ARG} 1>'/dev/null' 2>&1 &
+        python "${TEST_DIR}/bin/cylc-run" "${ALT_NAME}" ${ARG} \
+            1>'/dev/null' 2>&1 &
         FAKE_SUITE_PID=$!
         run_pass "${TEST_KEY}" rose suite-run -q --no-gcontrol \
             -C "${TEST_SOURCE_DIR}/${TEST_KEY_BASE}" --name="${NAME}" -- --debug

--- a/t/rose-suite-shutdown/00-run-basic.t
+++ b/t/rose-suite-shutdown/00-run-basic.t
@@ -37,7 +37,6 @@ mkdir -p $HOME/cylc-run
 SUITE_RUN_DIR=$(mktemp -d --tmpdir=$HOME/cylc-run 'rose-test-battery.XXXXXX')
 NAME=$(basename $SUITE_RUN_DIR)
 rose suite-run -q -C $TEST_SOURCE_DIR/$TEST_KEY_BASE --name=$NAME --no-gcontrol
-HOST=$(<$SUITE_RUN_DIR/log/rose-suite-run.host)
 #-------------------------------------------------------------------------------
 TEST_KEY=$TEST_KEY_BASE
 sleep 1


### PR DESCRIPTION
Make use of host information in port file to detect running suites.

Delete cylc port file or rose suite host file if the system is able to detect that no process associated with the suite is running on the recorded host. This allows suite-run, suite-clean, etc to proceed if a suite is terminated with a left-over port file.

Close #1829. Fix #1831.