### PR TITLE
rose_arch: fix incorrect behaviour on retry.

### DIFF
--- a/lib/python/rose/apps/rose_arch.py
+++ b/lib/python/rose/apps/rose_arch.py
@@ -292,13 +292,13 @@ class RoseArchApp(BuiltinApp):
         if target.status == target.ST_OLD:
             app_runner.handle_event(RoseArchEvent(target))
             return
-        dao.insert(target)
         if target.status in (target.ST_BAD, target.ST_NULL):
             # boolean to int
             target.command_rc = int(target.status == target.ST_BAD)
             app_runner.handle_event(RoseArchEvent(target))
             return
         target.command_rc = 1
+        dao.insert(target)
         work_dir = mkdtemp()
         times = [time()] * 3  # init, transformed, archived
         ret_code = None

--- a/t/rose-task-run/36-app-arch-interrupted.t
+++ b/t/rose-task-run/36-app-arch-interrupted.t
@@ -1,0 +1,50 @@
+#!/bin/bash
+#-------------------------------------------------------------------------------
+# (C) British Crown Copyright 2012-6 Met Office.
+#
+# This file is part of Rose, a framework for meteorological suites.
+#
+# Rose is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Rose is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Rose. If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test "rose_arch" built-in application, interrupted archiving.
+#-------------------------------------------------------------------------------
+. "$(dirname "$0")/test_header"
+
+#-------------------------------------------------------------------------------
+tests 3
+#-------------------------------------------------------------------------------
+# Run the suite, and wait for it to complete
+export CYLC_CONF_PATH=
+export ROSE_CONF_PATH=
+mkdir -p "${HOME}/cylc-run"
+SUITE_RUN_DIR="$(mktemp -d "${HOME}/cylc-run/rose-test-battery.XXXXXX")"
+NAME="$(basename "${SUITE_RUN_DIR}")"
+rose suite-run -q -C "${TEST_SOURCE_DIR}/${TEST_KEY_BASE}" --name="${NAME}" \
+    --no-gcontrol --host=localhost -- --debug
+#-------------------------------------------------------------------------------
+TEST_KEY="${TEST_KEY_BASE}-job.status"
+file_grep "${TEST_KEY}-archive-01" \
+    'CYLC_JOB_EXIT=EXIT' \
+    "${SUITE_RUN_DIR}/log/job/1/archive/01/job.status"
+file_grep "${TEST_KEY}-archive-02" \
+    'CYLC_JOB_EXIT=SUCCEEDED' \
+    "${SUITE_RUN_DIR}/log/job/1/archive/02/job.status"
+TEST_KEY="${TEST_KEY_BASE}-find"
+(cd "${SUITE_RUN_DIR}/share" && find . -type f) | sort >"${TEST_KEY}.out"
+file_cmp "${TEST_KEY}.out" "${TEST_KEY}.out" <<'__FIND__'
+./new_whatever
+__FIND__
+#-------------------------------------------------------------------------------
+rose suite-clean -q -y "${NAME}"
+exit 0

--- a/t/rose-task-run/36-app-arch-interrupted/app/archive/rose-app.conf
+++ b/t/rose-task-run/36-app-arch-interrupted/app/archive/rose-app.conf
@@ -1,0 +1,9 @@
+mode=rose_arch
+
+[arch]
+command-format=sleep 10; cp %(sources)s %(target)s
+target-prefix=$ROSE_SUITE_DIR/share/
+
+[arch:new_whatever]
+source-prefix=work/1/$ROSE_TASK_NAME/
+source=whatever

--- a/t/rose-task-run/36-app-arch-interrupted/suite.rc
+++ b/t/rose-task-run/36-app-arch-interrupted/suite.rc
@@ -1,0 +1,24 @@
+#!jinja2
+[cylc]
+    UTC mode = True
+    [[event hooks]]
+        timeout = PT1M
+        abort on timeout = True
+[scheduling]
+    [[dependencies]]
+        graph = archive
+
+[runtime]
+    [[archive]]
+        script = """
+touch whatever
+if (( $CYLC_TASK_TRY_NUMBER == 1 )); then
+    rose task-run -v -v --debug &
+    TASK_RUN_PID=$!
+    sleep 5
+    kill $TASK_RUN_PID
+    exit 1
+fi
+rose task-run -v -v --debug
+"""
+        retry delays = PT5S


### PR DESCRIPTION
If the previous attempt to archive was killed, a subsequent retry will
do nothing. This is due to the premature insertion of the target in the
rose_arch database.

If the target is inserted after the command_rc attribute is set to 1, an
kill of the previous attempt should act like a fail.

I've also moved the db insertion to after the
`if target.status in (target.ST_BAD, target.ST_NULL):` block - I think it
should retry bad or null jobs each time, and it doesn't look like it does that -
am I wrong?

@matthewrmshin @kaday please review.