### PR TITLE
rose bush: job-entry: always display host

### DIFF
--- a/lib/html/template/rose-bush/job-entry.html
+++ b/lib/html/template/rose-bush/job-entry.html
@@ -136,11 +136,15 @@
         <div class="span3">
           <small>
             <!-- entry: host, submit_method and submit_method_id -->
-            {% if entry.host and entry.submit_method and entry.submit_method_id -%}
+            {% if entry.host -%}
               <i class="icon-map-marker" title="Location"></i>
               {{entry.host}}:
-              {{entry.submit_method}}
-              {{entry.submit_method_id}}
+              {% if entry.submit_method -%}
+                {{entry.submit_method}}
+                {% if entry.submit_method_id -%}
+                  {{entry.submit_method_id}}
+                {% endif -%}
+              {% endif -%}
             {% endif -%}
           </small>
         </div>


### PR DESCRIPTION
As long as host is set, that is, and regardless of whether submit method
and submit method ID are set or not.

(To test, run a suite with a task that uses the wrong host for a job submission method, causing a submission failure. On master, the relevant Rose Bush job entry will not display the value of the host. On this branch, the relevant Rose Bush entry will now display the value of the host.)

@benfitzpatrick please review. (1 enough?)