### PR TITLE
rose edit: macros: allow importing other modules from same directory

### DIFF
--- a/lib/python/rose/macro.py
+++ b/lib/python/rose/macro.py
@@ -568,7 +568,7 @@ def load_meta_macro_modules(meta_files, module_prefix=None):
         if (not meta_dir.endswith(MACRO_DIRNAME) or
                 not meta_file.endswith(MACRO_EXT)):
             continue
-        sys.path.append(meta_dir)
+        sys.path.insert(0, meta_dir)
         macro_name = os.path.basename(meta_file).rpartition(MACRO_EXT)[0]
         if module_prefix is None:
             as_name = macro_name
@@ -579,7 +579,7 @@ def load_meta_macro_modules(meta_files, module_prefix=None):
         except Exception:
             rose.reporter.Reporter()(
                 MacroLoadError(meta_file, traceback.format_exc()))
-        sys.path.pop()
+        sys.path.pop(0)
     modules.sort()
     return modules
 

--- a/lib/python/rose/macro.py
+++ b/lib/python/rose/macro.py
@@ -568,6 +568,7 @@ def load_meta_macro_modules(meta_files, module_prefix=None):
         if (not meta_dir.endswith(MACRO_DIRNAME) or
                 not meta_file.endswith(MACRO_EXT)):
             continue
+        sys.path.append(meta_dir)
         macro_name = os.path.basename(meta_file).rpartition(MACRO_EXT)[0]
         if module_prefix is None:
             as_name = macro_name
@@ -578,6 +579,7 @@ def load_meta_macro_modules(meta_files, module_prefix=None):
         except Exception:
             rose.reporter.Reporter()(
                 MacroLoadError(meta_file, traceback.format_exc()))
+        sys.path.pop()
     modules.sort()
     return modules
 


### PR DESCRIPTION
When a macro imports another module from the same directory as itself, the import
will fail in `rose edit` but succeed in `rose macro`, due to a slightly different treatment of
the module names (via the variable `as_name` in the code).

When importing a macro, we should add its base directory to the PATH.

@matthewrmshin, please review.
@r-sharp and @scwhitehouse, please track this issue.