### PR TITLE
rose edit: upgrade: fix apply button sensitivity, instructions

### DIFF
--- a/lib/python/rose/config_editor/__init__.py
+++ b/lib/python/rose/config_editor/__init__.py
@@ -523,7 +523,9 @@ DIALOG_LABEL_MACRO_WARN_ISSUES = ("warnings: {0}")
 DIALOG_LABEL_NULL_SECTION = "None"
 DIALOG_LABEL_PREFERENCES = ("Please edit your site and user " +
                             "configurations to make changes.")
-DIALOG_LABEL_UPGRADE_ALL = "Show all possible versions"
+DIALOG_LABEL_UPGRADE = (
+    "Click Upgrade Version cells to change target versions.")
+DIALOG_LABEL_UPGRADE_ALL = "Populate all possible versions"
 DIALOG_TIP_SUITE_RUN_HELP = "Read the help for rose suite-run"
 DIALOG_TEXT_MACRO_CHANGED = "changed"
 DIALOG_TEXT_MACRO_ERROR = "error"

--- a/lib/python/rose/config_editor/upgrade_controller.py
+++ b/lib/python/rose/config_editor/upgrade_controller.py
@@ -110,6 +110,10 @@ class UpgradeController(object):
         self.window.vbox.pack_start(
             self.treewindow, expand=True, fill=True,
             padding=rose.config_editor.SPACING_PAGE)
+        label = gtk.Label(rose.config_editor.DIALOG_LABEL_UPGRADE)
+        label.show()
+        self.window.vbox.pack_start(
+            label, padding=rose.config_editor.SPACING_PAGE)
         button_hbox = gtk.HBox()
         button_hbox.show()
         all_versions_toggle_button = gtk.CheckButton(
@@ -223,6 +227,7 @@ class UpgradeController(object):
         for config_name in sorted(self.config_dict.keys()):
             self._update_treemodel_data(config_name)
         self.treeview.set_model(self.treemodel)
+        self._set_ok_to_upgrade()
 
     def _handle_toggle_upgrade(self, cell, path, col_index):
         iter_ = self.treemodel.get_iter(path)


### PR DESCRIPTION
This fixes #1812.

What would really be helpful is if GTK indicated that a cell had a dropdown list with e.g. a small down arrow - as setup on our system, it doesn't, so I've added some text to tell the user what to do. It's not elegant, but it gets the job done.

To reproduce #1812, load e.g. a UM 10.4 app, which is already at the latest major version. Minor versions will be the ones belonging to upgrade macros immediately following UM 10.4.

@kaday, @matthewrmshin please review.