### PR TITLE
rose edit: fix left hand tree panel error icons for macros

### DIFF
--- a/lib/python/rose/config_editor/updater.py
+++ b/lib/python/rose/config_editor/updater.py
@@ -131,7 +131,7 @@ class Updater(object):
                 self.update_ns_sub_data(only_this_namespace)
 
     def refresh_ids(self, config_name, setting_ids, is_loading=False,
-                    are_errors_done=False, skip_update=True):
+                    are_errors_done=False, skip_update=False):
         """Refresh and redraw settings if needed."""
         self.pagelist = self.get_pagelist_func()
         nses_to_do = []
@@ -158,7 +158,9 @@ class Updater(object):
                 nses_to_do.append(ns)
         if not skip_update:
             for ns in nses_to_do:
-                self.update_namespace(ns, is_loading=is_loading)
+                self.update_namespace(ns, is_loading=is_loading,
+                                      skip_sub_data_update=True)
+            self.update_ns_sub_data(nses_to_do)
 
     def update_all(self, only_this_config=None, is_loading=False,
                    skip_checking=False, skip_sub_data_update=False):
@@ -246,12 +248,17 @@ class Updater(object):
         if not skip_sub_data_update:
             self.update_ns_sub_data(page.namespace)
 
-    def update_ns_sub_data(self, namespace=None):
+    def update_ns_sub_data(self, namespaces=None):
         """Update any relevant summary data on another page."""
+        if type(namespaces) is not list:
+            namespaces = [namespaces]
         for page in self.pagelist:
-            if (namespace is not None and
-                    not namespace.startswith(page.namespace) and
-                    namespace != page.namespace):
+            for namespace in namespaces:
+                if (namespace is None or
+                        namespace.startswith(page.namespace)):
+                    break
+            else:
+                # No namespaces matched this page, skip
                 continue
             page.sub_data = self.data.helper.get_sub_data_for_namespace(
                 page.namespace)


### PR DESCRIPTION
This fixes a problem where errors flagged by macros (including `fail-if`) were not displaying
in the left hand tree panel in `rose edit`. This is fairly longstanding - since Rose `2015.08.0`!

You can test it by e.g. deliberately violating a fail-if condition in an app. There will be an error for the variable on a page, but not on the left hand page panel. In this branch, it will work OK.

The change switches on the `refresh_ids` update of namespaces and `sub_data` which is the
duplicate-sections-summary-panel information - e.g.  the UM STASH widget. This now correctly
displays the errors.

To mitigate the effect of updating the sub data more often, which would cause a big slowdown,
I've consolidated it so that it only gets called once per `refresh_ids` call rather than once per
affected namespace.

@matthewrmshin, @kaday please review.