### PR TITLE
rose bunch documentation: Correct typo in example.

### DIFF
--- a/doc/rose-rug-task-run.html
+++ b/doc/rose-rug-task-run.html
@@ -858,8 +858,8 @@ command-format=echo arg1: %(arg1)s, arg2: %(arg2)s, command-instance: %(command-
 fail-handle = abort
 incremental = True
 instances = 4
-limit=2
 names = foo1 bar2 baz3 qux4
+pool-size=2
 
 [bunch-args]
 arg1=1 2 3 4


### PR DESCRIPTION
The example app config is using the original "limit=" setting rather than the "pool-size" setting. This corrects that oversight.

@matthewrmshin - please review - one liner so should only need the one person.