### PR TITLE
rose task-env: obey calendar mode

### DIFF
--- a/lib/python/rose/date.py
+++ b/lib/python/rose/date.py
@@ -98,11 +98,7 @@ class RoseDateTimeOperator(object):
         else:
             assumed_time_zone = None
 
-        if not calendar_mode:
-            calendar_mode = os.getenv("ROSE_CYCLING_MODE")
-
-        if calendar_mode and calendar_mode in Calendar.MODES:
-            Calendar.default().set_mode(calendar_mode)
+        self.set_calendar_mode(calendar_mode)
 
         self.time_point_dumper = TimePointDumper()
         self.time_point_parser = TimePointParser(
@@ -254,9 +250,27 @@ class RoseDateTimeOperator(object):
         else:
             return sign + str(duration)
 
+    @staticmethod
+    def get_calendar_mode():
+        """Get current calendar mode."""
+        return Calendar.default().mode
+
     def is_offset(self, offset):
         """Return True if the string offset can be parsed as an offset."""
         return (self.REC_OFFSET.match(offset) is not None)
+
+    @staticmethod
+    def set_calendar_mode(calendar_mode=None):
+        """Set calendar mode for subsequent operations.
+
+        Raise KeyError if calendar_mode is invalid.
+
+        """
+        if not calendar_mode:
+            calendar_mode = os.getenv("ROSE_CYCLING_MODE")
+
+        if calendar_mode and calendar_mode in Calendar.MODES:
+            Calendar.default().set_mode(calendar_mode)
 
     def strftime(self, time_point, print_format):
         """Use either the isodatetime or datetime strftime time formatting."""
@@ -379,7 +393,7 @@ def _convert_duration(date_time_oper, opts, args):
     """Implement usage 3 of "rose date", convert ISO8601 duration."""
     time_in_8601 = date_time_oper.duration_parser.parse(args[0])
     time = time_in_8601.get_seconds()
-    options = {'S': time, 'M': time/60, 'H': time/3600}
+    options = {'S': time, 'M': time / 60, 'H': time / 3600}
     if opts.duration_print_format.upper() in options:
         # supplied duration format is valid (upper removes
         # case-sensitivity)

--- a/t/rose-task-env/01-integer-cycling.t
+++ b/t/rose-task-env/01-integer-cycling.t
@@ -17,7 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with Rose. If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
-# Test "rose task-env" in non-cycling mode.
+# Test "rose task-env" in integer cycling mode.
 #-------------------------------------------------------------------------------
 . $(dirname $0)/test_header
 export ROSE_CONF_PATH=

--- a/t/rose-task-env/02-360day-cycling.t
+++ b/t/rose-task-env/02-360day-cycling.t
@@ -1,0 +1,71 @@
+#!/bin/bash
+#-------------------------------------------------------------------------------
+# (C) British Crown Copyright 2012-6 Met Office.
+#
+# This file is part of Rose, a framework for meteorological suites.
+#
+# Rose is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Rose is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Rose. If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test "rose task-env" in 360day calendar mode.
+#-------------------------------------------------------------------------------
+. "$(dirname "$0")/test_header"
+export ROSE_CONF_PATH=
+
+tests 1
+
+RUN_DIR="$(mktemp -d --tmpdir="${HOME}/cylc-run" 'rtb-rose-task-env-02.XXXXXX')"
+NAME="$(basename "${RUN_DIR}")"
+rose suite-run -q -C "${TEST_SOURCE_DIR}/${TEST_KEY_BASE}" --name="${NAME}" \
+    --no-gcontrol --host='localhost' -- --debug
+for CYCLE in \
+    '20200227T0000Z' \
+    '20200228T0000Z' \
+    '20200229T0000Z' \
+    '20200230T0000Z' \
+    '20200301T0000Z' \
+    '20200302T0000Z'
+do
+    echo "${CYCLE}:"
+    sed "s?^${RUN_DIR}??" "${RUN_DIR}/work/${CYCLE}/foo/my-datac.txt"
+done >'expected-my-datac.txt'
+
+file_cmp "${TEST_KEY_BASE}-my-datac" 'expected-my-datac.txt' <<'__TXT__'
+20200227T0000Z:
+/share/cycle/20200226T0000Z
+/share/cycle/20200227T0000Z
+/share/cycle/20200228T0000Z
+20200228T0000Z:
+/share/cycle/20200227T0000Z
+/share/cycle/20200228T0000Z
+/share/cycle/20200229T0000Z
+20200229T0000Z:
+/share/cycle/20200228T0000Z
+/share/cycle/20200229T0000Z
+/share/cycle/20200230T0000Z
+20200230T0000Z:
+/share/cycle/20200229T0000Z
+/share/cycle/20200230T0000Z
+/share/cycle/20200301T0000Z
+20200301T0000Z:
+/share/cycle/20200230T0000Z
+/share/cycle/20200301T0000Z
+/share/cycle/20200302T0000Z
+20200302T0000Z:
+/share/cycle/20200301T0000Z
+/share/cycle/20200302T0000Z
+/share/cycle/20200303T0000Z
+__TXT__
+
+rose suite-clean -q -y "${NAME}"
+exit 0

--- a/t/rose-task-env/02-360day-cycling/app/foo/rose-app.conf
+++ b/t/rose-task-env/02-360day-cycling/app/foo/rose-app.conf
@@ -1,0 +1,2 @@
+[command]
+default=printenv ROSE_DATACP1D ROSE_DATAC ROSE_DATAC__P1D >my-datac.txt

--- a/t/rose-task-env/02-360day-cycling/suite.rc
+++ b/t/rose-task-env/02-360day-cycling/suite.rc
@@ -1,0 +1,18 @@
+#!jinja2
+[cylc]
+    UTC mode = True
+    [[event hooks]]
+        abort on timeout = True
+        timeout = PT1M
+[scheduling]
+    cycling mode = 360day
+    initial cycle point = 20200227
+    final cycle point = 20200302
+    [[dependencies]]
+        [[[P1D]]]
+            graph = foo[-P1D] => foo
+[runtime]
+    [[foo]]
+        env-script = eval $(rose task-env -T P1D -T -P1D)
+        script = rose task-run
+


### PR DESCRIPTION
rose task-env was not working correctly with alternate calendars like
360day, etc. This change fixes #1842.

@benfitzpatrick @arjclark please review.