### PR TITLE
rose edit: fix other namespace state display on trigger

### DIFF
--- a/lib/python/rose/config_editor/updater.py
+++ b/lib/python/rose/config_editor/updater.py
@@ -378,7 +378,7 @@ class Updater(object):
         for ns in update_nses:
             if ns != namespace:
                 # We don't need another update of namespace.
-                self.update_ns_tree_states(ns)
+                self.update_namespace(ns)
         for var_id in trig_id_val_dict.keys() + updated_ids:
             var = var_id_map.get(var_id)
             if var is None:


### PR DESCRIPTION
`rose edit` currently can get a target namespace (page/panel) ignored state incorrect
following triggering from another page. This is due to the change in #1758 which introduced
a cache for namespace ignored state. The cache needs to be cleared out when appropriate,
but isn't in this situation.

This change does a more thorough update of the target namespace (`update_namespace`
calls `update_ns_tree_states` as well) which clears the namespace ignored state cache and
will also do some more checking, which I think is appropriate. It doesn't appear to have a
noticeable effect on performance - I wouldn't expect it to.

An example `rose-app.conf`:
```ini
[env]
SWEET_STUFF=true

[namelist:food]
biscuits=2
doughnuts=1
steak=1
```

and metadata:
```ini
[env]

[env=SWEET_STUFF]
type=boolean
trigger=namelist:food=biscuits: true;
        namelist:food=doughnuts: true

[namelist:food]

[namelist:food=biscuits]
ns=namelist/food/sweet_stuff
type=integer

[namelist:food=doughnuts]
ns=namelist/food/sweet_stuff
type=integer

[namelist:food=steak]
ns=namelist/food/savoury_stuff
type=integer
```
Changing `env=SWEET_STUFF` to `false` will trigger-ignore `biscuits` and `doughnuts` under the `sweet_stuff` namespace. Since every option within `sweet_stuff` is trigger-ignored, it should itself be trigger-ignored and should be hidden. On current master, it isn't - if you manually reload by refreshing the metadata, it will be. This branch fixes the behaviour.

@matthewrmshin, @arjclark please review.