### PR TITLE
rose documentation: fix metadata for upgrade-dev tut

### DIFF
--- a/doc/etc/rose-rug-advanced-tutorials-upgrade-dev/rose-meta.conf.html
+++ b/doc/etc/rose-rug-advanced-tutorials-upgrade-dev/rose-meta.conf.html
@@ -57,7 +57,7 @@ type=integer
 
 [namelist:materials=outrigger_tree_trunks]
 compulsory=true
-values=1
+values=2
 
 [namelist:materials=paddling_branches]
 range=0:

--- a/doc/rose-rug-advanced-tutorials-upgrade-dev.html
+++ b/doc/rose-rug-advanced-tutorials-upgrade-dev.html
@@ -575,7 +575,7 @@ class MySecondUpgradeMacro(rose.upgrade.MacroUpgrade):
       <p>Let's configure what we want to happen. Create a directory
       <kbd>~/rose-meta/make-boat/etc/0.2/</kbd>, containing a
       <samp>rose-macro-add.conf</samp> file that looks like this:</p>
-      <pre>
+      <pre class="prettyprint lang-rose_conf">
 [namelist:materials]
 l_rudder_branch=.true.
 </pre>

--- a/doc/rose-rug-advanced-tutorials-upgrade-usage.html
+++ b/doc/rose-rug-advanced-tutorials-upgrade-usage.html
@@ -97,7 +97,7 @@
 
       <p>Create a new directory:</p>
       <pre class="shell">
-mkdir -p ~/garden/
+mkdir ~/garden/
 </pre>
 
       <p>containing a <samp>rose-app.conf</samp> file that looks like this:</p>


### PR DESCRIPTION
This fixes #1069 and two other minor documentation flaws.

@arjclark, please review.