### PR TITLE
t: fix breakage by cylc/cylc#1727

### DIFF
--- a/t/rose-task-run/07-app-arch.t
+++ b/t/rose-task-run/07-app-arch.t
@@ -90,7 +90,8 @@ done
 CYCLE=2013010112
 TEST_KEY="$TEST_KEY_BASE-bad-archive-1"
 FILE_PREFIX="$SUITE_RUN_DIR/log/job/$CYCLE/archive_bad_"
-file_cmp "$TEST_KEY.err" "${FILE_PREFIX}1/01/job.err" <<'__ERR__'
+sed '/^\[FAIL\] /!d' "${FILE_PREFIX}1/01/job.err" >"${TEST_KEY}.err"
+file_cmp "${TEST_KEY}.err" "${TEST_KEY}.err" <<'__ERR__'
 [FAIL] foo://2013010112/hello/worlds/planet-n.tar.gz: bad command-format: foo put %(target)s %(source)s: KeyError: 'source'
 [FAIL] ! foo://2013010112/hello/worlds/planet-n.tar.gz [compress=tar.gz]
 [FAIL] !	hello/planet-1.txt (hello/planet-1.txt)
@@ -104,25 +105,29 @@ file_cmp "$TEST_KEY.err" "${FILE_PREFIX}1/01/job.err" <<'__ERR__'
 [FAIL] !	hello/planet-9.txt (hello/planet-9.txt)
 __ERR__
 TEST_KEY="$TEST_KEY_BASE-bad-archive-2"
-file_cmp "$TEST_KEY.err" "${FILE_PREFIX}2/01/job.err" <<'__ERR__'
+sed '/^\[FAIL\] /!d' "${FILE_PREFIX}2/01/job.err" >"${TEST_KEY}.err"
+file_cmp "${TEST_KEY}.err" "${TEST_KEY}.err" <<'__ERR__'
 [FAIL] source=None: missing configuration error: 'source'
 __ERR__
 TEST_KEY="$TEST_KEY_BASE-bad-archive-3"
-file_cmp "$TEST_KEY.err" "${FILE_PREFIX}3/01/job.err" <<'__ERR__'
+sed '/^\[FAIL\] /!d' "${FILE_PREFIX}3/01/job.err" >"${TEST_KEY}.err"
+file_cmp "${TEST_KEY}.err" "${TEST_KEY}.err" <<'__ERR__'
 [FAIL] source=$UNBOUND_PLANET-[1-9].txt: configuration value error: [UNDEFINED ENVIRONMENT VARIABLE] UNBOUND_PLANET
 __ERR__
 TEST_KEY="$TEST_KEY_BASE-bad-archive-4"
-file_cmp "$TEST_KEY.err" "${FILE_PREFIX}4/01/job.err" <<'__ERR__'
+sed '/^\[FAIL\] /!d' "${FILE_PREFIX}4/01/job.err" >"${TEST_KEY}.err"
+file_cmp "${TEST_KEY}.err" "${TEST_KEY}.err" <<'__ERR__'
 [FAIL] [arch:$UNKNOWN_DARK_PLANETS.tar.gz]=: configuration value error: [UNDEFINED ENVIRONMENT VARIABLE] UNKNOWN_DARK_PLANETS
 __ERR__
 TEST_KEY="$TEST_KEY_BASE-bad-archive-5"
-file_cmp "$TEST_KEY.err" "${FILE_PREFIX}5/01/job.err" <<__ERR__
-[FAIL] [arch:inner.tar.gz]source=hello/mercurry.txt: configuration value error: [Errno 2] No such file or directory: '$SUITE_RUN_DIR/share/cycle/2013010112/hello/mercurry.txt'
+sed '/^\[FAIL\] /!d' "${FILE_PREFIX}5/01/job.err" >"${TEST_KEY}.err"
+file_cmp "${TEST_KEY}.err" "${TEST_KEY}.err" <<__ERR__
+[FAIL] [arch:inner.tar.gz]source=hello/mercurry.txt: configuration value error: [Errno 2] No such file or directory: '${SUITE_RUN_DIR}/share/cycle/2013010112/hello/mercurry.txt'
 [FAIL] ! foo://2013010112/hello/worlds/inner.tar.gz [compress=tar.gz]
 [FAIL] !	hello/venus.txt (hello/venus.txt)
 __ERR__
 TEST_KEY="$TEST_KEY_BASE-bad-archive-6"
-sed 's/ \[compress.*\]$//' "$TEST_KEY.err" \
+sed '/^\[FAIL\] /!d; s/ \[compress.*\]$//' "$TEST_KEY.err" \
     "${FILE_PREFIX}6/01/job.err" >"$TEST_KEY.err"
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" <<__ERR__
 [FAIL] foo push foo://2013010112/hello/worlds/mars.txt.gz $SUITE_RUN_DIR/share/cycle/2013010112/hello/mars.txt # return-code=1, stderr=
@@ -131,11 +136,13 @@ file_cmp "$TEST_KEY.err" "$TEST_KEY.err" <<__ERR__
 [FAIL] !	hello/mars.txt (hello/mars.txt)
 __ERR__
 TEST_KEY="$TEST_KEY_BASE-bad-archive-7"
-file_cmp "$TEST_KEY.err" "$SUITE_RUN_DIR/log/job/$CYCLE/archive_bad_7/01/job.err" <<'__ERR__'
+sed '/^\[FAIL\] /!d' "${FILE_PREFIX}7/01/job.err" >"${TEST_KEY}.err"
+file_cmp "${TEST_KEY}.err" "${TEST_KEY}.err" <<'__ERR__'
 [FAIL] foo://2013010112/planet-n.tar.gz: bad rename-format: %(planet?maybedwarfplanet???)s: KeyError: 'planet?maybedwarfplanet???'
 __ERR__
 TEST_KEY="$TEST_KEY_BASE-bad-archive-8"
-file_cmp "$TEST_KEY.err" "$SUITE_RUN_DIR/log/job/$CYCLE/archive_bad_8/01/job.err" <<'__ERR__'
+sed '/^\[FAIL\] /!d' "${FILE_PREFIX}8/01/job.err" >"${TEST_KEY}.err"
+file_cmp "${TEST_KEY}.err" "${TEST_KEY}.err" <<'__ERR__'
 [FAIL] foo://2013010112/planet-n.tar.gz: bad rename-parser: planet-(?P<planet>[MVEJSUN]\w+.txt: error: unbalanced parenthesis
 __ERR__
 TEST_KEY="$TEST_KEY_BASE-bad-archive-9"
@@ -145,10 +152,11 @@ sed '/^\[INFO\] [=!+]/!d;
     "$SUITE_RUN_DIR/log/job/$CYCLE/archive_bad_9/01/job.out" >"$TEST_KEY.out"
 file_cmp "$TEST_KEY.out" \
     "$TEST_SOURCE_DIR/$TEST_KEY_BASE-bad-9.out" "$TEST_KEY.out"
-sed -e 's?\(hello/planet-5.txt\) .*\(/hello/planet-5.txt\)?\1 \2?' \
+sed -e '/^\[FAIL\] /!d' \
+    -e 's?\(hello/planet-5.txt\) .*\(/hello/planet-5.txt\)?\1 \2?' \
     -e 's/ \[compress.*]$//' \
     "$SUITE_RUN_DIR/log/job/$CYCLE/archive_bad_9/01/job.err" >"$TEST_KEY.err"
-file_cmp "$TEST_KEY.err" "$TEST_KEY.err" <<__ERR__
+file_cmp "${TEST_KEY}.err" "${TEST_KEY}.err" <<__ERR__
 [FAIL] ! foo://2013010112/planet-n.tar.gz
 [FAIL] !	hello/dark-matter.txt (hello/dark-matter.txt)
 [FAIL] !	hello/earth.txt (hello/earth.txt)
@@ -178,8 +186,8 @@ file_cmp "$TEST_KEY.err" "$TEST_KEY.err" <<__ERR__
 [FAIL] !	hello/spaceship-9.txt (hello/spaceship-9.txt)
 [FAIL] !	hello/uranus.txt (hello/uranus.txt)
 [FAIL] !	hello/venus.txt (hello/venus.txt)
-[FAIL] my-bad-command $SUITE_RUN_DIR/share/cycle/2013010112/hello/planet-5.txt /hello/planet-5.txt # return-code=1, stderr=
-[FAIL] [my-bad-command] $SUITE_RUN_DIR/share/cycle/2013010112/hello/planet-5.txt /hello/planet-5.txt
+[FAIL] my-bad-command ${SUITE_RUN_DIR}/share/cycle/2013010112/hello/planet-5.txt /hello/planet-5.txt # return-code=1, stderr=
+[FAIL] [my-bad-command] ${SUITE_RUN_DIR}/share/cycle/2013010112/hello/planet-5.txt /hello/planet-5.txt
 __ERR__
 
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
New tests introduced by #1736 is broken by cylc/cylc#1727. (If suite is run in debug mode, cylc now switches on `set -x` for job files) This fixes the problem by filtering the output in `job.err`.

@benfitzpatrick please review. (I think 1 review is enough.)