### PR TITLE
rosie go: better gpg-agent cache expiry handling

### DIFF
--- a/lib/python/rosie/ws_client_auth.py
+++ b/lib/python/rosie/ws_client_auth.py
@@ -211,9 +211,15 @@ class GPGAgentStore(object):
         gpg_socket.send("GET_PASSPHRASE --data %s rosie:%s:%s X X %s\n" % (
             no_ask_option, scheme, host, prompt))
         reply = self._socket_receive(gpg_socket, "^(?!OK)[^ ]+ .*\n")
-        for line in reply.splitlines():
+        replylines = reply.splitlines()
+        for line in replylines:
             if line.startswith("D"):
                 return line.split(None, 1)[1]
+        if not no_ask and not any([
+                line.startswith("INQUIRE") for line in replylines]):
+            # Prompted for a password, didn't get one.
+            raise RosieStoreRetrievalError(
+                "gpg-agent", reply.replace("OK\n", "").replace("\n", " "))
         return None
 
     def prompt_password(self, prompt, scheme, host, username):
@@ -375,8 +381,6 @@ class RosieWSClientAuthManager(object):
         icon_path = ResourceLocator.default().locate("images/rosie-icon.png")
         if is_retry:
             username = ""
-            if self.username:
-                username = ""
 
             prompt = self.PROMPT_USERNAME % {
                 "prefix": self.prefix, "root": self.root}
@@ -400,17 +404,23 @@ class RosieWSClientAuthManager(object):
             prompt = self.PROMPT_PASSWORD % {"prefix": self.prefix,
                                              "root": self.root,
                                              "username": self.username}
+            password = None
             if hasattr(self.password_store, "prompt_password"):
-                password = self.password_store.prompt_password(
-                    prompt, self.scheme, self.host, self.username)
-            elif self.popen.which("zenity") and os.getenv("DISPLAY"):
-                password = self.popen.run(
-                    "zenity", "--entry", "--hide-text",
-                    "--title=Rosie",
-                    "--window-icon=" + icon_path,
-                    "--text=" + prompt)[1].strip()
-            else:
-                password = getpass(prompt)
+                try:
+                    password = self.password_store.prompt_password(
+                        prompt, self.scheme, self.host, self.username)
+                except RosieStoreRetrievalError as exc:
+                    self.event_handler(exc)
+
+            if not password:
+                if self.popen.which("zenity") and os.getenv("DISPLAY"):
+                    password = self.popen.run(
+                        "zenity", "--entry", "--hide-text",
+                        "--title=Rosie",
+                        "--window-icon=" + icon_path,
+                        "--text=" + prompt)[1].strip()
+                else:
+                    password = getpass(prompt)
             if not password:
                 raise KeyboardInterrupt(self.STR_CANCELLED)
             if password and password != self.password:


### PR DESCRIPTION
This fixes #1790.

When a password is not present in `gpg-agent`, and when `gpg-agent` prompting is off (our usual default), then report an error and then fall through gracefully to our manual prompting and allow `rosie` to continue.

Replicate by launching `gpg-agent` without entering any password on a server, then launching e.g. `rosie hello` with a remote prefix. The current master will silently break, and this branch will report a gpg-agent error on the terminal and then launch a prompt.

`rosie` and `gpg-agent` continue to work as they did before in the absence of `--batch` option to `gpg-agent` (i.e. when it is allowed to launch its own prompts).

@kaday, @matthewrmshin please review.