### PR TITLE
rose edit: keyboard shortcuts for multi section summary panel

### DIFF
--- a/lib/python/rose/config_editor/__init__.py
+++ b/lib/python/rose/config_editor/__init__.py
@@ -72,6 +72,8 @@ ACCEL_BROWSER = "<Ctrl>B"
 ACCEL_SUITE_RUN = "<Ctrl>R"
 ACCEL_TERMINAL = "<Ctrl>T"
 ACCEL_HELP_GUI = "F1"
+ACCEL_REMOVE = "Delete"
+ACCEL_IGNORE = "<Ctrl>I"
 
 # Menu or panel strings
 ADD_MENU_BLANK = "Add blank variable"

--- a/lib/python/rose/gtk/util.py
+++ b/lib/python/rose/gtk/util.py
@@ -470,13 +470,17 @@ class TooltipTreeView(gtk.TreeView):
 
     """
 
-    def __init__(self, model=None, get_tooltip_func=None):
+    def __init__(self, model=None, get_tooltip_func=None,
+                 multiple_selection=False):
         super(TooltipTreeView, self).__init__(model)
         self.get_tooltip = get_tooltip_func
         self.set_has_tooltip(True)
         self._last_tooltip_path = None
         self._last_tooltip_column = None
         self.connect('query-tooltip', self._handle_tooltip)
+        if multiple_selection:
+            self.set_rubber_banding(True)
+            self.get_selection().set_mode(gtk.SELECTION_MULTIPLE)
 
     def _handle_tooltip(self, view, x, y, kbd_ctx, tip):
         """Handle creating a tooltip for the treeview."""


### PR DESCRIPTION
closes #1710 

- Added functionality to delete / ignore sections using `Delete` and `Ctrl + I` respectively.
- Enabled multiple selection for BaseSummaryDataPanel

@benfitzpatrick Please Review
@matthewrmshin Please Review