### PR TITLE
app-upgrade: Allow multi depth metadata directories to work with upgrade macros

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,6 +35,7 @@ below:
 * Matt Pryor (Met Office, UK)
 * Oliver Sanders (Met Office, UK)
 * Jon Seddon (Met Office, UK)
+* Harry Shepherd (Met Office, UK)
 * Matt Shin (Met Office, UK)
 * Stuart Whitehouse (Met Office, UK)
 * Steve Wardle (Met Office, UK)

--- a/doc/rose-configuration-metadata.html
+++ b/doc/rose-configuration-metadata.html
@@ -974,16 +974,16 @@ CHOCOLATE/rose-meta/
 CHOCOLATE/rose-meta/choc-dark/
 CHOCOLATE/rose-meta/choc-milk/
     </pre>
-    <p>and the system <code>CAFFINE</code> may have a hybrid structure, with
+    <p>and the system <code>CAFFEINE</code> may have a hybrid structure, with
     both flat and hierarchical components:</p>
 <pre class="prettyprint lang-rose_conf">
-CAFFINE/doc/
+CAFFEINE/doc/
 ...
-CAFFINE/rose-meta/caffine-guarana
-CAFFINE/rose-meta/caffine-coffee/cappuccino
-CAFFINE/rose-meta/caffine-coffee/latte
-CAFFINE/rose-meta/caffine-tea/yorkshire
-CAFFINE/rose-meta/caffine-tea/lapsang
+CAFFEINE/rose-meta/caffeine-guarana/
+CAFFEINE/rose-meta/caffeine-coffee/cappuccino/
+CAFFEINE/rose-meta/caffeine-coffee/latte/
+CAFFEINE/rose-meta/caffeine-tea/yorkshire/
+CAFFEINE/rose-meta/caffeine-tea/lapsang/
 </pre>
     <p>and a site configuration with:</p>
     <pre class="prettyprint lang-rose_conf">
@@ -993,15 +993,15 @@ meta-path=/path/to/rose-meta
     <p>We would expect the following directories in
     <samp>/path/to/rose-meta</samp>:</p>
     <pre class="prettyprint lang-rose_conf">
-/path/to/rose-meta/caffine-guarana/
-/path/to/rose-meta/caffine-coffee/
-/path/to/rose-meta/caffine-tea/
+/path/to/rose-meta/caffeine-guarana/
+/path/to/rose-meta/caffeine-coffee/
+/path/to/rose-meta/caffeine-tea/
 /path/to/rose-meta/choc-dark/
 /path/to/rose-meta/choc-milk/
 </pre>
-    <p>with <code>caffine-coffee</code> containing subdirectories
+    <p>with <code>caffeine-coffee</code> containing subdirectories
     <code>cappuccino</code> and <code>latte</code>, and
-    <code>caffine-tea</code> containing <code>yorkshire</code> and
+    <code>caffeine-tea</code> containing <code>yorkshire</code> and
     <code>lapsang</code>
 
     <h2 id="appendix-upgrade">Appendix: Upgrade and Versions</h2>

--- a/doc/rose-configuration-metadata.html
+++ b/doc/rose-configuration-metadata.html
@@ -965,26 +965,26 @@ ${APP}/versions.py # i.e. the upgrade macros
     a collection of regularly-updated subdirectories from all of the relevant
     projects' <samp>rose-meta</samp> directories.</p>
 
-    <p>For example, for a system <code>COFFEE</code>, with the following
-    directory structure:</p>
-    <pre class="prettyprint lang-rose_conf">
-COFFEE/doc/
-...
-COFFEE/rose-meta/
-COFFEE/rose-meta/coffee-cappuccino/
-COFFEE/rose-meta/coffee-latte/
-COFFEE/rose-meta/coffee-mocha/
-</pre>
-
-    <p>and the system <code>CHOCOLATE</code>:</p>
+    <p>For example, a system <code>CHOCOLATE</code> may have a flat metadata
+    structure within the repository:</p>
     <pre class="prettyprint lang-rose_conf">
 CHOCOLATE/doc/
 ...
 CHOCOLATE/rose-meta/
 CHOCOLATE/rose-meta/choc-dark/
 CHOCOLATE/rose-meta/choc-milk/
+    </pre>
+    <p>and the system <code>CAFFINE</code> may have a hybrid structure, with
+    both flat and hierarchical components:</p>
+<pre class="prettyprint lang-rose_conf">
+CAFFINE/doc/
+...
+CAFFINE/rose-meta/caffine-guarana
+CAFFINE/rose-meta/caffine-coffee/cappuccino
+CAFFINE/rose-meta/caffine-coffee/latte
+CAFFINE/rose-meta/caffine-tea/yorkshire
+CAFFINE/rose-meta/caffine-tea/lapsang
 </pre>
-
     <p>and a site configuration with:</p>
     <pre class="prettyprint lang-rose_conf">
 meta-path=/path/to/rose-meta
@@ -993,12 +993,16 @@ meta-path=/path/to/rose-meta
     <p>We would expect the following directories in
     <samp>/path/to/rose-meta</samp>:</p>
     <pre class="prettyprint lang-rose_conf">
-/path/to/rose-meta/coffee-cappuccino/
-/path/to/rose-meta/coffee-latte/
-/path/to/rose-meta/coffee-mocha/
+/path/to/rose-meta/caffine-guarana/
+/path/to/rose-meta/caffine-coffee/
+/path/to/rose-meta/caffine-tea/
 /path/to/rose-meta/choc-dark/
 /path/to/rose-meta/choc-milk/
 </pre>
+    <p>with <code>caffine-coffee</code> containing subdirectories
+    <code>cappuccino</code> and <code>latte</code>, and
+    <code>caffine-tea</code> containing <code>yorkshire</code> and
+    <code>lapsang</code>
 
     <h2 id="appendix-upgrade">Appendix: Upgrade and Versions</h2>
 

--- a/doc/rose-configuration-metadata.html
+++ b/doc/rose-configuration-metadata.html
@@ -1052,11 +1052,16 @@ meta-path=/path/to/rose-meta
 #!cfg
 # Refer to the HEAD version
 # (typically you wouldn't do this since no upgrade process is possible)
+# For flat metadata
 meta=my-command
+# For hierarchical metadata
+meta=/path/to/metadata/my-command/HEAD
 
-# Refer to a named or tagged version
+# Refer to a named or tagged version in the flat metadata
 meta=my-command/8.3
 meta=my-command/t123
+# Refer to a named or tagged version in the hierarchical metadata
+meta=/path/to/metadata/my-command/8.3
 </pre>
 
     <p>If a version is defined then the Rose utilities will first look for the
@@ -1065,6 +1070,9 @@ meta=my-command/t123
     indicate that the configuration metadata being used requires upgrade macros
     to be run. If the version defined does not correspond to a tagged version
     then a warning will be given.</p>
+
+    <p> Please note that if a hierarchical structure for the metadata is being
+    used, the <code>HEAD</code> tag must be specified explictly.</p>
 
     <h3 id="appendix-upgrade:named">When to create named versions</h3>
 

--- a/doc/rose-rug-metadata.html
+++ b/doc/rose-rug-metadata.html
@@ -113,6 +113,16 @@ meta=rose-demo-upgrade/27.1
       <samp>meta-path</samp> user/site config setting. The example above, for a
       <samp>meta-path</samp> of <samp>/project/rose-meta/</samp>, would be
       stored at <samp>/project/rose-meta/rose-demo-upgrade/27.1/</samp>.</p>
+
+      <p> We are not limited to a flat structure for our centrally-stored
+      metadata. For example, if we wanted to take our example above and
+      adopt a tree structure for all our <samp>rose-demo</samp> apps, the
+      <samp>meta</samp> tag may be:</p>
+<pre class="prettyprint lang-rose_conf">
+meta=rose-demo/upgrade/27.1
+</pre>
+      <p>and so the metadata would be stored at
+      <samp>/project/rose-meta/rose-demo/upgrade/27.1/</samp>.</p>
     </div>
 
     <div class="slide">

--- a/lib/python/rose/macro.py
+++ b/lib/python/rose/macro.py
@@ -467,15 +467,15 @@ def load_meta_path(config=None, directory=None, is_upgrade=False,
         meta_keys = ["rose-all"]
     else:
         key = opt_node.value
-        split_key = os.path.split(key)
-        if not split_key[0]:
-            key = os.path.join(key, rose.META_DEFAULT_VN_DIR)
+        split_key = key.split('/')
+        if len(split_key) == 1:
+            key = '/'.join([key, rose.META_DEFAULT_VN_DIR])
         meta_keys = [key]
+        split_key = split_key if len(split_key) == 1 else split_key[:-1]
         if is_upgrade:
-            meta_keys = [os.path.split(key)[0]]
+            meta_keys = ['/'.join(split_key)]
         else:
-            default_key = os.path.join(os.path.split(key)[0],
-                                       rose.META_DEFAULT_VN_DIR)
+            default_key = '/'.join(split_key + [rose.META_DEFAULT_VN_DIR])
             if default_key != key:
                 meta_keys.append(default_key)
     for i, meta_key in enumerate(meta_keys):

--- a/lib/python/rose/macro.py
+++ b/lib/python/rose/macro.py
@@ -467,14 +467,15 @@ def load_meta_path(config=None, directory=None, is_upgrade=False,
         meta_keys = ["rose-all"]
     else:
         key = opt_node.value
-        if "/" not in key:
-            key = key + "/" + rose.META_DEFAULT_VN_DIR
+        split_key = os.path.split(key)
+        if not split_key[0]:
+            key = os.path.join(key, rose.META_DEFAULT_VN_DIR)
         meta_keys = [key]
         if is_upgrade:
-            meta_keys = [key.split("/")[0]]
+            meta_keys = [os.path.split(key)[0]]
         else:
-            default_key = (key.rsplit("/", 1)[0] + "/" +
-                           rose.META_DEFAULT_VN_DIR)
+            default_key = os.path.join(os.path.split(key)[0],
+                                       rose.META_DEFAULT_VN_DIR)
             if default_key != key:
                 meta_keys.append(default_key)
     for i, meta_key in enumerate(meta_keys):

--- a/t/rose-app-upgrade/11-upgrade-basic-tree.t
+++ b/t/rose-app-upgrade/11-upgrade-basic-tree.t
@@ -1,0 +1,775 @@
+#!/bin/bash
+#-------------------------------------------------------------------------------
+# (C) British Crown Copyright 2012-6 Met Office.
+#
+# This file is part of Rose, a framework for meteorological suites.
+#
+# Rose is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Rose is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Rose. If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test "rose app-upgrade" for real macros.
+#-------------------------------------------------------------------------------
+. $(dirname $0)/test_header
+#-------------------------------------------------------------------------------
+tests 80
+
+#-------------------------------------------------------------------------------
+# Check basic upgrading.
+init <<'__CONFIG__'
+meta=test_tree/test-app-upgrade/0.1
+
+[env]
+A=4
+__CONFIG__
+setup
+init_meta test_tree/test-app-upgrade 0.1 0.2 0.3 0.4 0.5 1.0
+init_macro test_tree/test-app-upgrade <<'__MACRO__'
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+
+import rose.upgrade
+
+
+class Upgrade01to02(rose.upgrade.MacroUpgrade):
+
+    """Upgrade from 0.1 to 0.2."""
+
+    BEFORE_TAG = "0.1"
+    AFTER_TAG = "0.2"
+
+    def upgrade(self, config, meta_config=None):
+        self.add_setting(config, ["env", "Z"], "1",
+                         info="only one Z")
+        return config, self.reports
+
+
+class Upgrade02to03(rose.upgrade.MacroUpgrade):
+
+    """Upgrade from 0.2 to 0.3."""
+
+    BEFORE_TAG = "0.2"
+    AFTER_TAG = "0.3"
+
+    def upgrade(self, config, meta_config=None):
+        self.ignore_setting(config, ["env", "A"])
+        return config, self.reports
+
+
+class Upgrade03to04(rose.upgrade.MacroUpgrade):
+
+    """Upgrade from 0.3 to 0.4."""
+
+    BEFORE_TAG = "0.3"
+    AFTER_TAG = "0.4"
+
+    def upgrade(self, config, meta_config=None):
+        self.enable_setting(config, ["env", "A"])
+        return config, self.reports
+
+
+class Upgrade04to05(rose.upgrade.MacroUpgrade):
+
+    """Upgrade from 0.4 to 0.5."""
+
+    BEFORE_TAG = "0.4"
+    AFTER_TAG = "0.5"
+
+    def upgrade(self, config, meta_config=None):
+        self.remove_setting(config, ["env", "A"])
+        return config, self.reports
+
+
+class Upgrade05to051(rose.upgrade.MacroUpgrade):
+
+    """Upgrade from 0.5 to 0.5.1."""
+
+    BEFORE_TAG = "0.5"
+    AFTER_TAG = "0.5.1"
+
+    def upgrade(self, config, meta_config=None):
+        self.add_setting(config, ["env", "C"], "8")
+        return config, self.reports
+
+
+class Upgrade051to10(rose.upgrade.MacroUpgrade):
+
+    """Upgrade from 0.5.1 to 1.0."""
+
+    BEFORE_TAG = "0.5.1"
+    AFTER_TAG = "1.0"
+
+    def upgrade(self, config, meta_config=None):
+        self.change_setting_value(config, ["env", "Z"], "5")
+        return config, self.reports
+__MACRO__
+
+#-----------------------------------------------------------------------------
+TEST_KEY=$TEST_KEY_BASE-upgrade-add-start-version
+# Check correct start version
+run_pass "$TEST_KEY" rose app-upgrade --non-interactive \
+ --meta-path=../rose-meta/ -C ../config
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<'__OUTPUT__'
+= 0.1
+  0.2
+  0.3
+  0.4
+  0.5
+* 1.0
+__OUTPUT__
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+#-----------------------------------------------------------------------------
+TEST_KEY=$TEST_KEY_BASE-upgrade-add-start-version-all
+# Check correct start version
+run_pass "$TEST_KEY" rose app-upgrade --non-interactive \
+ --meta-path=../rose-meta/ -C ../config --all-versions
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<'__OUTPUT__'
+= 0.1
+  0.2
+  0.3
+  0.4
+  0.5
+  0.5.1
+* 1.0
+__OUTPUT__
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+
+#-----------------------------------------------------------------------------
+TEST_KEY=$TEST_KEY_BASE-upgrade-add
+# Check adding
+run_pass "$TEST_KEY" rose app-upgrade --non-interactive \
+ --meta-path=../rose-meta/ -C ../config 0.2
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<'__OUTPUT__'
+[U] Upgrade_0.1-0.2: changes: 2
+    env=Z=1
+        only one Z
+    =meta=test_tree/test-app-upgrade/0.2
+        Upgraded from 0.1 to 0.2
+__OUTPUT__
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+file_cmp "$TEST_KEY.file" ../config/rose-app.conf <<'__CONFIG__'
+meta=test_tree/test-app-upgrade/0.2
+
+[env]
+A=4
+Z=1
+__CONFIG__
+
+#-----------------------------------------------------------------------------
+TEST_KEY=$TEST_KEY_BASE-upgrade-add-end-version
+# Check correct end version
+run_pass "$TEST_KEY" rose app-upgrade --non-interactive \
+ --meta-path=../rose-meta/ -C ../config
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<'__OUTPUT__'
+= 0.2
+  0.3
+  0.4
+  0.5
+* 1.0
+__OUTPUT__
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+
+#-------------------------------------------------------------------------------
+# Check the next step in the upgrade
+TEST_KEY=$TEST_KEY_BASE-upgrade-ignore
+init <<'__CONFIG__'
+meta=test_tree/test-app-upgrade/0.2
+
+[env]
+A=4
+Z=1
+__CONFIG__
+run_pass "$TEST_KEY" rose app-upgrade -y \
+ --meta-path=../rose-meta/ -C ../config/ 0.3
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<'__OUTPUT__'
+[U] Upgrade_0.2-0.3: changes: 2
+    env=A=4
+        enabled -> user-ignored
+    =meta=test_tree/test-app-upgrade/0.3
+        Upgraded from 0.2 to 0.3
+__OUTPUT__
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+file_cmp "$TEST_KEY.file" ../config/rose-app.conf <<'__CONFIG__'
+meta=test_tree/test-app-upgrade/0.3
+
+[env]
+!A=4
+Z=1
+__CONFIG__
+
+#-----------------------------------------------------------------------------
+TEST_KEY=$TEST_KEY_BASE-upgrade-ignore-end-version
+# Check correct end version
+run_pass "$TEST_KEY" rose app-upgrade -y \
+ --meta-path=../rose-meta/ -C ../config/
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<'__OUTPUT__'
+= 0.3
+  0.4
+  0.5
+* 1.0
+__OUTPUT__
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+
+#-------------------------------------------------------------------------------
+# Check the next step in the upgrade
+TEST_KEY=$TEST_KEY_BASE-upgrade-enable
+init <<'__CONFIG__'
+meta=test_tree/test-app-upgrade/0.3
+
+[env]
+!A=4
+Z=1
+__CONFIG__
+run_pass "$TEST_KEY" rose app-upgrade -y \
+ --meta-path=../rose-meta/ -C ../config/ 0.4
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<'__OUTPUT__'
+[U] Upgrade_0.3-0.4: changes: 2
+    env=A=4
+        user-ignored -> enabled
+    =meta=test_tree/test-app-upgrade/0.4
+        Upgraded from 0.3 to 0.4
+__OUTPUT__
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+file_cmp "$TEST_KEY.file" ../config/rose-app.conf <<'__CONFIG__'
+meta=test_tree/test-app-upgrade/0.4
+
+[env]
+A=4
+Z=1
+__CONFIG__
+
+#-----------------------------------------------------------------------------
+TEST_KEY=$TEST_KEY_BASE-upgrade-enable-end-version
+# Check correct end version
+run_pass "$TEST_KEY" rose app-upgrade --meta-path=../rose-meta/ -C ../config/
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<'__OUTPUT__'
+= 0.4
+  0.5
+* 1.0
+__OUTPUT__
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+
+#-------------------------------------------------------------------------------
+# Check the next step in the upgrade
+TEST_KEY=$TEST_KEY_BASE-upgrade-remove
+init <<'__CONFIG__'
+meta=test_tree/test-app-upgrade/0.4
+
+[env]
+A=4
+Z=1
+__CONFIG__
+run_pass "$TEST_KEY" rose app-upgrade -y \
+ --meta-path=../rose-meta/ -C ../config/ 0.5
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<'__OUTPUT__'
+[U] Upgrade_0.4-0.5: changes: 2
+    env=A=None
+        Removed
+    =meta=test_tree/test-app-upgrade/0.5
+        Upgraded from 0.4 to 0.5
+__OUTPUT__
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+file_cmp "$TEST_KEY.file" ../config/rose-app.conf <<'__CONFIG__'
+meta=test_tree/test-app-upgrade/0.5
+
+[env]
+Z=1
+__CONFIG__
+
+#-----------------------------------------------------------------------------
+TEST_KEY=$TEST_KEY_BASE-upgrade-remove-end-version
+# Check correct end version
+run_pass "$TEST_KEY" rose app-upgrade \
+ --meta-path=../rose-meta/ -C ../config/
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<'__OUTPUT__'
+= 0.5
+* 1.0
+__OUTPUT__
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+
+#-----------------------------------------------------------------------------
+TEST_KEY=$TEST_KEY_BASE-upgrade-remove-end-version-all
+# Check correct end version - all versions
+run_pass "$TEST_KEY" rose app-upgrade \
+ --meta-path=../rose-meta/ -C ../config/ -a
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<'__OUTPUT__'
+= 0.5
+  0.5.1
+* 1.0
+__OUTPUT__
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+
+#-------------------------------------------------------------------------------
+# Check the next minor step in the upgrade
+TEST_KEY=$TEST_KEY_BASE-upgrade-change-minor
+init <<'__CONFIG__'
+meta=test_tree/test-app-upgrade/0.5
+
+[env]
+Z=1
+__CONFIG__
+run_pass "$TEST_KEY" rose app-upgrade -y \
+ --meta-path=../rose-meta/ -C ../config/ 0.5.1
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<'__OUTPUT__'
+[U] Upgrade_0.5-0.5.1: changes: 2
+    env=C=8
+        Added with value '8'
+    =meta=test_tree/test-app-upgrade/0.5.1
+        Upgraded from 0.5 to 0.5.1
+__OUTPUT__
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+file_cmp "$TEST_KEY.file" ../config/rose-app.conf <<'__CONFIG__'
+meta=test_tree/test-app-upgrade/0.5.1
+
+[env]
+C=8
+Z=1
+__CONFIG__
+
+#-----------------------------------------------------------------------------
+TEST_KEY=$TEST_KEY_BASE-upgrade-change-minor-end-version
+# Check correct end version
+run_pass "$TEST_KEY" rose app-upgrade \
+ --meta-path=../rose-meta/ -C ../config/
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<'__OUTPUT__'
+= 0.5.1
+* 1.0
+__OUTPUT__
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+
+#-------------------------------------------------------------------------------
+# Check the next minor step in the upgrade
+TEST_KEY=$TEST_KEY_BASE-upgrade-change-minor-all
+init <<'__CONFIG__'
+meta=test_tree/test-app-upgrade/0.5
+
+[env]
+Z=1
+__CONFIG__
+run_pass "$TEST_KEY" rose app-upgrade -y \
+ --meta-path=../rose-meta/ -C ../config/ -a 0.5.1
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<'__OUTPUT__'
+[U] Upgrade_0.5-0.5.1: changes: 2
+    env=C=8
+        Added with value '8'
+    =meta=test_tree/test-app-upgrade/0.5.1
+        Upgraded from 0.5 to 0.5.1
+__OUTPUT__
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+file_cmp "$TEST_KEY.file" ../config/rose-app.conf <<'__CONFIG__'
+meta=test_tree/test-app-upgrade/0.5.1
+
+[env]
+C=8
+Z=1
+__CONFIG__
+
+#-----------------------------------------------------------------------------
+TEST_KEY=$TEST_KEY_BASE-upgrade-change-minor-end-version-all
+# Check correct end version
+run_pass "$TEST_KEY" rose app-upgrade \
+ --meta-path=../rose-meta/ -C ../config/
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<'__OUTPUT__'
+= 0.5.1
+* 1.0
+__OUTPUT__
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+
+#-------------------------------------------------------------------------------
+# Check the next step in the upgrade
+TEST_KEY=$TEST_KEY_BASE-upgrade-change
+init <<'__CONFIG__'
+meta=test_tree/test-app-upgrade/0.5.1
+
+[env]
+Z=1
+__CONFIG__
+run_pass "$TEST_KEY" rose app-upgrade -y \
+ --meta-path=../rose-meta/ -C ../config/ 1.0
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<'__OUTPUT__'
+[U] Upgrade_0.5.1-1.0: changes: 2
+    env=Z=5
+        Value: '1' -> '5'
+    =meta=test_tree/test-app-upgrade/1.0
+        Upgraded from 0.5.1 to 1.0
+__OUTPUT__
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+file_cmp "$TEST_KEY.file" ../config/rose-app.conf <<'__CONFIG__'
+meta=test_tree/test-app-upgrade/1.0
+
+[env]
+Z=5
+__CONFIG__
+
+#-----------------------------------------------------------------------------
+TEST_KEY=$TEST_KEY_BASE-upgrade-change-end-version
+# Check correct end version
+run_pass "$TEST_KEY" rose app-upgrade \
+ --meta-path=../rose-meta/ -C ../config/
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<'__OUTPUT__'
+= 1.0
+__OUTPUT__
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+
+#-----------------------------------------------------------------------------
+# Upgrade across versions
+TEST_KEY=$TEST_KEY_BASE-upgrade-multiple
+init <<'__CONFIG__'
+meta=test_tree/test-app-upgrade/0.1
+
+[env]
+A=4
+__CONFIG__
+run_pass "$TEST_KEY" rose app-upgrade -y \
+ --meta-path=../rose-meta/ -C ../config/ 1.0
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<'__OUTPUT__'
+[U] Upgrade_0.1-1.0: changes: 7
+    env=Z=1
+        only one Z
+    env=A=4
+        enabled -> user-ignored
+    env=A=4
+        user-ignored -> enabled
+    env=A=None
+        Removed
+    env=C=8
+        Added with value '8'
+    env=Z=5
+        Value: '1' -> '5'
+    =meta=test_tree/test-app-upgrade/1.0
+        Upgraded from 0.1 to 1.0
+__OUTPUT__
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+file_cmp "$TEST_KEY.file" ../config/rose-app.conf <<'__CONFIG__'
+meta=test_tree/test-app-upgrade/1.0
+
+[env]
+C=8
+Z=5
+__CONFIG__
+
+#-------------------------------------------------------------------------------
+# Check broken chain upgrading.
+TEST_KEY=$TEST_KEY_BASE-upgrade-broken-chain
+init <<'__CONFIG__'
+meta=test_tree/test-app-upgrade/0.1
+
+[env]
+A=4
+__CONFIG__
+setup
+init_meta test_tree/test-app-upgrade 0.1 0.2 0.3 0.4 0.5
+init_macro test_tree/test-app-upgrade <<'__MACRO__'
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+
+import rose.upgrade
+
+
+class Upgrade01to02(rose.upgrade.MacroUpgrade):
+
+    """Upgrade from 0.1 to 0.2."""
+
+    BEFORE_TAG = "0.1"
+    AFTER_TAG = "0.2"
+
+    def upgrade(self, config, meta_config=None):
+        return config, self.reports
+
+
+class Upgrade02to03(rose.upgrade.MacroUpgrade):
+
+    """Upgrade from 0.2 to 0.3."""
+
+    BEFORE_TAG = "0.2"
+    AFTER_TAG = "0.3"
+
+    def upgrade(self, config, meta_config=None):
+        return config, self.reports
+
+
+class Upgrade04to05(rose.upgrade.MacroUpgrade):
+
+    """Upgrade from 0.4 to 0.5."""
+
+    BEFORE_TAG = "0.4"
+    AFTER_TAG = "0.5"
+
+    def upgrade(self, config, meta_config=None):
+        return config, self.reports
+__MACRO__
+
+run_fail "$TEST_KEY" rose app-upgrade -y \
+ --meta-path=../rose-meta/ -C ../config/ 0.5
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" <<'__ERROR__'
+[FAIL] 0.5: invalid version.
+__ERROR__
+
+#-------------------------------------------------------------------------------
+# Check broken upgrading to same version.
+
+TEST_KEY=$TEST_KEY_BASE-upgrade-same-version
+
+run_fail "$TEST_KEY" rose app-upgrade -y \
+ --meta-path=../rose-meta/ -C ../config/ 0.1
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" <<'__ERROR__'
+[FAIL] 0.1: already at this version.
+__ERROR__
+
+teardown
+
+#-------------------------------------------------------------------------------
+# Check broken chain upgrading.
+TEST_KEY=$TEST_KEY_BASE-upgrade-broken-chain-before-break
+init <<'__CONFIG__'
+meta=test_tree/test-app-upgrade/0.1
+
+[env]
+A=4
+__CONFIG__
+setup
+init_meta test_tree/test-app-upgrade 0.1 0.2 0.3 0.4 0.5
+init_macro test_tree/test-app-upgrade <<'__MACRO__'
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+
+import rose.upgrade
+
+
+class Upgrade01to02(rose.upgrade.MacroUpgrade):
+
+    """Upgrade from 0.1 to 0.2."""
+
+    BEFORE_TAG = "0.1"
+    AFTER_TAG = "0.2"
+
+    def upgrade(self, config, meta_config=None):
+        self.add_setting(config, ["env", "Z"], "1",
+                         info="only one Z")
+        return config, self.reports
+
+
+class Upgrade02to03(rose.upgrade.MacroUpgrade):
+
+    """Upgrade from 0.2 to 0.3."""
+
+    BEFORE_TAG = "0.2"
+    AFTER_TAG = "0.3"
+
+    def upgrade(self, config, meta_config=None):
+        self.ignore_setting(config, ["env", "A"])
+        return config, self.reports
+
+
+class Upgrade04to05(rose.upgrade.MacroUpgrade):
+
+    """Upgrade from 0.4 to 0.5."""
+
+    BEFORE_TAG = "0.4"
+    AFTER_TAG = "0.5"
+
+    def upgrade(self, config, meta_config=None):
+        self.remove_setting(config, ["env", "A"])
+        return config, self.reports
+__MACRO__
+
+run_pass "$TEST_KEY" rose app-upgrade -y \
+ --meta-path=../rose-meta/ -C ../config/ 0.3
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<'__OUTPUT__'
+[U] Upgrade_0.1-0.3: changes: 3
+    env=Z=1
+        only one Z
+    env=A=4
+        enabled -> user-ignored
+    =meta=test_tree/test-app-upgrade/0.3
+        Upgraded from 0.1 to 0.3
+__OUTPUT__
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+file_cmp "$TEST_KEY.file" ../config/rose-app.conf <<'__CONFIG__'
+meta=test_tree/test-app-upgrade/0.3
+
+[env]
+!A=4
+Z=1
+__CONFIG__
+teardown
+#-------------------------------------------------------------------------------
+# Check broken chain upgrading.
+TEST_KEY=$TEST_KEY_BASE-upgrade-broken-chain-after-break
+init <<'__CONFIG__'
+meta=test_tree/test-app-upgrade/0.4
+
+[env]
+!A=4
+B=2
+Z=1
+__CONFIG__
+setup
+init_meta test_tree/test-app-upgrade 0.1 0.5
+init_macro test_tree/test-app-upgrade <<'__MACRO__'
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+
+import rose.upgrade
+
+
+class Upgrade01to02(rose.upgrade.MacroUpgrade):
+
+    """Upgrade from 0.1 to 0.2."""
+
+    BEFORE_TAG = "0.1"
+    AFTER_TAG = "0.2"
+
+    def upgrade(self, config, meta_config=None):
+        self.add_setting(config, ["env", "Z"], "1",
+                         info="only one Z")
+        return config, self.reports
+
+
+class Upgrade02to03(rose.upgrade.MacroUpgrade):
+
+    """Upgrade from 0.2 to 0.3."""
+
+    BEFORE_TAG = "0.2"
+    AFTER_TAG = "0.3"
+
+    def upgrade(self, config, meta_config=None):
+        self.ignore_setting(config, ["env", "A"])
+        return config, self.reports
+
+
+class Upgrade04to05(rose.upgrade.MacroUpgrade):
+
+    """Upgrade from 0.4 to 0.5."""
+
+    BEFORE_TAG = "0.4"
+    AFTER_TAG = "0.5"
+
+    def upgrade(self, config, meta_config=None):
+        self.remove_setting(config, ["env", "A"])
+        return config, self.reports
+__MACRO__
+
+run_pass "$TEST_KEY" rose app-upgrade -y \
+ --meta-path=../rose-meta/ -C ../config/ 0.5
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<'__OUTPUT__'
+[U] Upgrade_0.4-0.5: changes: 2
+    env=A=None
+        Removed
+    =meta=test_tree/test-app-upgrade/0.5
+        Upgraded from 0.4 to 0.5
+__OUTPUT__
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+file_cmp "$TEST_KEY.file" ../config/rose-app.conf <<'__CONFIG__'
+meta=test_tree/test-app-upgrade/0.5
+
+[env]
+B=2
+Z=1
+__CONFIG__
+teardown
+#-------------------------------------------------------------------------------
+# Check file-based upgrading.
+TEST_KEY=$TEST_KEY_BASE-upgrade-patch-files
+init <<'__CONFIG__'
+meta=test_tree/test-app-upgrade/0.1
+
+[env]
+A=4
+
+[namelist:qwerty]
+uiop=asdf
+
+[namelist:something]
+foo=bar
+__CONFIG__
+setup
+init_meta test_tree/test-app-upgrade 0.1 0.2
+init_macro test_tree/test-app-upgrade <<'__MACRO__'
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+
+import rose.upgrade
+
+
+class Upgrade01to02(rose.upgrade.MacroUpgrade):
+
+    """Upgrade from 0.1 to 0.2."""
+
+    BEFORE_TAG = "0.1"
+    AFTER_TAG = "0.2"
+
+    def upgrade(self, config, meta_config=None):
+        self.act_from_files(config)
+        return config, self.reports
+__MACRO__
+
+init_resource_file test_tree/test-app-upgrade 0.1 rose-macro-add.conf <<'__CONFIG__'
+[env]
+B=5
+
+[namelist:new]
+spam=eggs
+__CONFIG__
+init_resource_file test_tree/test-app-upgrade 0.1 rose-macro-remove.conf <<'__CONFIG__'
+[env]
+A=5
+
+[namelist:qwerty]
+
+[namelist:something]
+foo=bar
+__CONFIG__
+
+run_pass "$TEST_KEY" rose app-upgrade -y \
+ --meta-path=../rose-meta/ -C ../config/ 0.2
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<'__OUTPUT__'
+[U] Upgrade_0.1-0.2: changes: 8
+    env=B=5
+        Added with value '5'
+    namelist:new=None=None
+        Added
+    namelist:new=spam=eggs
+        Added with value 'eggs'
+    env=A=None
+        Removed
+    namelist:something=foo=None
+        Removed
+    namelist:qwerty=uiop=None
+        Removed
+    namelist:qwerty=None=None
+        Removed
+    =meta=test_tree/test-app-upgrade/0.2
+        Upgraded from 0.1 to 0.2
+__OUTPUT__
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+file_cmp "$TEST_KEY.file" ../config/rose-app.conf <<'__CONFIG__'
+meta=test_tree/test-app-upgrade/0.2
+
+[env]
+B=5
+
+[namelist:new]
+spam=eggs
+
+[namelist:something]
+__CONFIG__
+teardown
+#-------------------------------------------------------------------------------
+exit

--- a/t/rose-app-upgrade/12-downgrade-basic-tree.t
+++ b/t/rose-app-upgrade/12-downgrade-basic-tree.t
@@ -1,0 +1,659 @@
+#!/bin/bash
+#-------------------------------------------------------------------------------
+# (C) British Crown Copyright 2012-6 Met Office.
+#
+# This file is part of Rose, a framework for meteorological suites.
+#
+# Rose is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Rose is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Rose. If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test "rose app-upgrade --downgrade" for real macros.
+#-------------------------------------------------------------------------------
+. $(dirname $0)/test_header
+#-------------------------------------------------------------------------------
+tests 63
+
+#-------------------------------------------------------------------------------
+# Check basic downgrading.
+init <<'__CONFIG__'
+meta=test_tree/test-app-upgrade/1.0
+
+[env]
+Z=5
+__CONFIG__
+setup
+init_meta test_tree/test-app-upgrade 0.1 0.2 0.3 0.4 0.5
+init_macro test_tree/test-app-upgrade <<'__MACRO__'
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+
+import rose.upgrade
+
+
+class Upgrade01to02(rose.upgrade.MacroUpgrade):
+
+    """Upgrade from 0.1 to 0.2."""
+
+    BEFORE_TAG = "0.1"
+    AFTER_TAG = "0.2"
+
+    def downgrade(self, config, meta_config=None):
+        self.remove_setting(config, ["env", "Z"],
+                            info="removed Z")
+        return config, self.reports
+
+    def upgrade(self, config, meta_config=None):
+        self.add_setting(config, ["env", "Z"], "1",
+                         info="only one Z")
+        return config, self.reports
+
+
+class Upgrade02to03(rose.upgrade.MacroUpgrade):
+
+    """Upgrade from 0.2 to 0.3."""
+
+    BEFORE_TAG = "0.2"
+    AFTER_TAG = "0.3"
+
+    def downgrade(self, config, meta_config=None):
+        self.enable_setting(config, ["env", "A"])
+        return config, self.reports
+
+    def upgrade(self, config, meta_config=None):
+        self.ignore_setting(config, ["env", "A"])
+        return config, self.reports
+
+
+class Upgrade03to04(rose.upgrade.MacroUpgrade):
+
+    """Upgrade from 0.3 to 0.4."""
+
+    BEFORE_TAG = "0.3"
+    AFTER_TAG = "0.4"
+
+    def downgrade(self, config, meta_config=None):
+        self.ignore_setting(config, ["env", "A"])
+        return config, self.reports
+
+    def upgrade(self, config, meta_config=None):
+        self.enable_setting(config, ["env", "A"])
+        return config, self.reports
+
+
+class Upgrade04to041(rose.upgrade.MacroUpgrade):
+
+    """Upgrade from 0.4 to 0.4.1."""
+
+    BEFORE_TAG = "0.4"
+    AFTER_TAG = "0.4.1"
+
+    def downgrade(self, config, meta_config=None):
+        self.add_setting(config, ["env", "A"], "4")
+        return config, self.reports
+
+    def upgrade(self, config, meta_config=None):
+        self.remove_setting(config, ["env", "A"])
+        return config, self.reports
+
+
+class Upgrade041to10(rose.upgrade.MacroUpgrade):
+
+    """Upgrade from 0.4.1 to 1.0."""
+
+    BEFORE_TAG = "0.4.1"
+    AFTER_TAG = "1.0"
+
+    def downgrade(self, config, meta_config=None):
+        self.change_setting_value(config, ["env", "Z"], "1")
+        return config, self.reports
+
+    def upgrade(self, config, meta_config=None):
+        self.change_setting_value(config, ["env", "Z"], "5")
+        return config, self.reports
+__MACRO__
+
+#-----------------------------------------------------------------------------
+TEST_KEY=$TEST_KEY_BASE-downgrade-change-start-version
+# Check correct start version
+run_pass "$TEST_KEY" rose app-upgrade --downgrade \
+ --meta-path=../rose-meta/ -C ../config
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<'__OUTPUT__'
+* 0.1
+  0.2
+  0.3
+  0.4
+= 1.0
+__OUTPUT__
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+
+#-----------------------------------------------------------------------------
+TEST_KEY=$TEST_KEY_BASE-downgrade-change-start-version-all
+# Check correct start version
+run_pass "$TEST_KEY" rose app-upgrade --downgrade \
+ --meta-path=../rose-meta/ -C ../config --all-versions
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<'__OUTPUT__'
+* 0.1
+  0.2
+  0.3
+  0.4
+  0.4.1
+= 1.0
+__OUTPUT__
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+
+#-----------------------------------------------------------------------------
+TEST_KEY=$TEST_KEY_BASE-downgrade-change
+# Check changing within a downgrade
+run_pass "$TEST_KEY" rose app-upgrade --downgrade \
+ --non-interactive --meta-path=../rose-meta/ -C ../config -a 0.4.1
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<'__OUTPUT__'
+[D] Downgrade_1.0-0.4.1: changes: 2
+    env=Z=1
+        Value: '5' -> '1'
+    =meta=test_tree/test-app-upgrade/0.4.1
+        Downgraded from 1.0 to 0.4.1
+__OUTPUT__
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+file_cmp "$TEST_KEY.file" ../config/rose-app.conf <<'__CONFIG__'
+meta=test_tree/test-app-upgrade/0.4.1
+
+[env]
+Z=1
+__CONFIG__
+
+#-----------------------------------------------------------------------------
+TEST_KEY=$TEST_KEY_BASE-downgrade-change-end-version
+# Check correct end version
+run_pass "$TEST_KEY" rose app-upgrade --downgrade \
+ --non-interactive --meta-path=../rose-meta/ -C ../config
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<'__OUTPUT__'
+* 0.1
+  0.2
+  0.3
+  0.4
+= 0.4.1
+__OUTPUT__
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+
+#-------------------------------------------------------------------------------
+# Check the next step in the downgrade
+TEST_KEY=$TEST_KEY_BASE-downgrade-add
+init <<'__CONFIG__'
+meta=test_tree/test-app-upgrade/0.4.1
+
+[env]
+Z=1
+__CONFIG__
+run_pass "$TEST_KEY" rose app-upgrade --downgrade \
+ -y --meta-path=../rose-meta/ -C ../config/ 0.4
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<'__OUTPUT__'
+[D] Downgrade_0.4.1-0.4: changes: 2
+    env=A=4
+        Added with value '4'
+    =meta=test_tree/test-app-upgrade/0.4
+        Downgraded from 0.4.1 to 0.4
+__OUTPUT__
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+file_cmp "$TEST_KEY.file" ../config/rose-app.conf <<'__CONFIG__'
+meta=test_tree/test-app-upgrade/0.4
+
+[env]
+A=4
+Z=1
+__CONFIG__
+
+#-----------------------------------------------------------------------------
+TEST_KEY=$TEST_KEY_BASE-downgrade-add-end-version
+# Check correct end version
+run_pass "$TEST_KEY" rose app-upgrade --downgrade \
+ -y --meta-path=../rose-meta/ -C ../config/
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<'__OUTPUT__'
+* 0.1
+  0.2
+  0.3
+= 0.4
+__OUTPUT__
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+
+#-------------------------------------------------------------------------------
+# Check the next step in the downgrade
+TEST_KEY=$TEST_KEY_BASE-downgrade-ignore
+init <<'__CONFIG__'
+meta=test_tree/test-app-upgrade/0.4
+
+[env]
+A=4
+Z=1
+__CONFIG__
+run_pass "$TEST_KEY" rose app-upgrade --downgrade \
+ -y --meta-path=../rose-meta/ -C ../config/ 0.3
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<'__OUTPUT__'
+[D] Downgrade_0.4-0.3: changes: 2
+    env=A=4
+        enabled -> user-ignored
+    =meta=test_tree/test-app-upgrade/0.3
+        Downgraded from 0.4 to 0.3
+__OUTPUT__
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+file_cmp "$TEST_KEY.file" ../config/rose-app.conf <<'__CONFIG__'
+meta=test_tree/test-app-upgrade/0.3
+
+[env]
+!A=4
+Z=1
+__CONFIG__
+
+#-----------------------------------------------------------------------------
+TEST_KEY=$TEST_KEY_BASE-downgrade-ignore-enable-end-version
+# Check correct end version
+run_pass "$TEST_KEY" rose app-upgrade --downgrade \
+ --meta-path=../rose-meta/ -C ../config/
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<'__OUTPUT__'
+* 0.1
+  0.2
+= 0.3
+__OUTPUT__
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+
+#-------------------------------------------------------------------------------
+# Check the next step in the downgrade
+TEST_KEY=$TEST_KEY_BASE-downgrade-enable
+init <<'__CONFIG__'
+meta=test_tree/test-app-upgrade/0.3
+
+[env]
+!A=4
+Z=1
+__CONFIG__
+run_pass "$TEST_KEY" rose app-upgrade --downgrade \
+ -y --meta-path=../rose-meta/ -C ../config/ 0.2
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<'__OUTPUT__'
+[D] Downgrade_0.3-0.2: changes: 2
+    env=A=4
+        user-ignored -> enabled
+    =meta=test_tree/test-app-upgrade/0.2
+        Downgraded from 0.3 to 0.2
+__OUTPUT__
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+file_cmp "$TEST_KEY.file" ../config/rose-app.conf <<'__CONFIG__'
+meta=test_tree/test-app-upgrade/0.2
+
+[env]
+A=4
+Z=1
+__CONFIG__
+
+#-----------------------------------------------------------------------------
+TEST_KEY=$TEST_KEY_BASE-downgrade-enable-end-version
+# Check correct end version
+run_pass "$TEST_KEY" rose app-upgrade --downgrade \
+ --meta-path=../rose-meta/ -C ../config/
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<'__OUTPUT__'
+* 0.1
+= 0.2
+__OUTPUT__
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+
+#-------------------------------------------------------------------------------
+# Check the next step in the upgrade
+TEST_KEY=$TEST_KEY_BASE-downgrade-remove
+init <<'__CONFIG__'
+meta=test_tree/test-app-upgrade/0.2
+
+[env]
+A=4
+Z=1
+__CONFIG__
+run_pass "$TEST_KEY" rose app-upgrade --downgrade \
+ -y --meta-path=../rose-meta/ -C ../config/ 0.1
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<'__OUTPUT__'
+[D] Downgrade_0.2-0.1: changes: 2
+    env=Z=None
+        removed Z
+    =meta=test_tree/test-app-upgrade/0.1
+        Downgraded from 0.2 to 0.1
+__OUTPUT__
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+file_cmp "$TEST_KEY.file" ../config/rose-app.conf <<'__CONFIG__'
+meta=test_tree/test-app-upgrade/0.1
+
+[env]
+A=4
+__CONFIG__
+
+#-----------------------------------------------------------------------------
+TEST_KEY=$TEST_KEY_BASE-downgrade-remove-end-version
+# Check correct end version
+run_pass "$TEST_KEY" rose app-upgrade --downgrade \
+ --meta-path=../rose-meta/ -C ../config/
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<'__OUTPUT__'
+= 0.1
+__OUTPUT__
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+
+#-----------------------------------------------------------------------------
+# Downgrade across versions
+TEST_KEY=$TEST_KEY_BASE-downgrade-multiple
+init <<'__CONFIG__'
+meta=test_tree/test-app-upgrade/1.0
+
+[env]
+Z=5
+__CONFIG__
+run_pass "$TEST_KEY" rose app-upgrade --downgrade \
+ -y --meta-path=../rose-meta/ -C ../config/ 0.1
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<'__OUTPUT__'
+[D] Downgrade_1.0-0.1: changes: 6
+    env=Z=1
+        Value: '5' -> '1'
+    env=A=4
+        Added with value '4'
+    env=A=4
+        enabled -> user-ignored
+    env=A=4
+        user-ignored -> enabled
+    env=Z=None
+        removed Z
+    =meta=test_tree/test-app-upgrade/0.1
+        Downgraded from 1.0 to 0.1
+__OUTPUT__
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+file_cmp "$TEST_KEY.file" ../config/rose-app.conf <<'__CONFIG__'
+meta=test_tree/test-app-upgrade/0.1
+
+[env]
+A=4
+__CONFIG__
+
+#-------------------------------------------------------------------------------
+# Check broken chain downgrading.
+TEST_KEY=$TEST_KEY_BASE-downgrade-broken-chain
+init <<'__CONFIG__'
+meta=test_tree/test-app-upgrade/0.5
+
+[env]
+A=4
+__CONFIG__
+setup
+init_meta test_tree/test-app-upgrade 0.1 0.2 0.3 0.4 0.5
+init_macro test_tree/test-app-upgrade <<'__MACRO__'
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+
+import rose.upgrade
+
+
+class Upgrade01to02(rose.upgrade.MacroUpgrade):
+
+    """Upgrade from 0.1 to 0.2."""
+
+    BEFORE_TAG = "0.1"
+    AFTER_TAG = "0.2"
+
+    def upgrade(self, config, meta_config=None):
+        return config, self.reports
+
+
+class Upgrade02to03(rose.upgrade.MacroUpgrade):
+
+    """Upgrade from 0.2 to 0.3."""
+
+    BEFORE_TAG = "0.2"
+    AFTER_TAG = "0.3"
+
+    def upgrade(self, config, meta_config=None):
+        return config, self.reports
+
+
+class Upgrade04to05(rose.upgrade.MacroUpgrade):
+
+    """Upgrade from 0.4 to 0.5."""
+
+    BEFORE_TAG = "0.4"
+    AFTER_TAG = "0.5"
+
+    def upgrade(self, config, meta_config=None):
+        return config, self.reports
+__MACRO__
+
+run_fail "$TEST_KEY" rose app-upgrade --downgrade \
+ -y --meta-path=../rose-meta/ -C ../config/ 0.1
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" <<'__ERROR__'
+[FAIL] 0.1: invalid version.
+__ERROR__
+teardown
+
+#-------------------------------------------------------------------------------
+# Check broken chain downgrading.
+TEST_KEY=$TEST_KEY_BASE-downgrade-broken-chain-before-break
+init <<'__CONFIG__'
+meta=test_tree/test-app-upgrade/0.3
+
+[env]
+!A=4
+Z=1
+__CONFIG__
+setup
+init_meta test_tree/test-app-upgrade 0.1 0.2 0.3 0.4 0.5
+init_macro test_tree/test-app-upgrade <<'__MACRO__'
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+
+import rose.upgrade
+
+
+class Upgrade01to02(rose.upgrade.MacroUpgrade):
+
+    """Upgrade from 0.1 to 0.2."""
+
+    BEFORE_TAG = "0.1"
+    AFTER_TAG = "0.2"
+
+    def downgrade(self, config, meta_config=None):
+        self.remove_setting(config, ["env", "Z"],
+                            info="no more Zs")
+        return config, self.reports
+
+    def upgrade(self, config, meta_config=None):
+        self.add_setting(config, ["env", "Z"], "1",
+                         info="only one Z")
+        return config, self.reports
+
+
+class Upgrade02to03(rose.upgrade.MacroUpgrade):
+
+    """Upgrade from 0.2 to 0.3."""
+
+    BEFORE_TAG = "0.2"
+    AFTER_TAG = "0.3"
+
+    def downgrade(self, config, meta_config=None):
+        self.enable_setting(config, ["env", "A"])
+        return config, self.reports
+
+    def upgrade(self, config, meta_config=None):
+        self.ignore_setting(config, ["env", "A"])
+        return config, self.reports
+
+
+class Upgrade04to05(rose.upgrade.MacroUpgrade):
+
+    """Upgrade from 0.4 to 0.5."""
+
+    BEFORE_TAG = "0.4"
+    AFTER_TAG = "0.5"
+
+    def downgrade(self, config, meta_config=None):
+        self.add_setting(config, ["env", "A"], "4")
+        return config, self.reports
+
+    def upgrade(self, config, meta_config=None):
+        self.remove_setting(config, ["env", "A"])
+        return config, self.reports
+__MACRO__
+
+run_pass "$TEST_KEY" rose app-upgrade --downgrade \
+ -y --meta-path=../rose-meta/ -C ../config/ 0.1
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<'__OUTPUT__'
+[D] Downgrade_0.3-0.1: changes: 3
+    env=A=4
+        user-ignored -> enabled
+    env=Z=None
+        no more Zs
+    =meta=test_tree/test-app-upgrade/0.1
+        Downgraded from 0.3 to 0.1
+__OUTPUT__
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+file_cmp "$TEST_KEY.file" ../config/rose-app.conf <<'__CONFIG__'
+meta=test_tree/test-app-upgrade/0.1
+
+[env]
+A=4
+__CONFIG__
+#-------------------------------------------------------------------------------
+# Check broken chain upgrading.
+TEST_KEY=$TEST_KEY_BASE-downgrade-broken-chain-after-break
+init <<'__CONFIG__'
+meta=test_tree/test-app-upgrade/0.5
+
+[env]
+B=2
+Z=1
+__CONFIG__
+
+run_pass "$TEST_KEY" rose app-upgrade --downgrade \
+ -y --meta-path=../rose-meta/ -C ../config/ 0.4
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<'__OUTPUT__'
+[D] Downgrade_0.5-0.4: changes: 2
+    env=A=4
+        Added with value '4'
+    =meta=test_tree/test-app-upgrade/0.4
+        Downgraded from 0.5 to 0.4
+__OUTPUT__
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+file_cmp "$TEST_KEY.file" ../config/rose-app.conf <<'__CONFIG__'
+meta=test_tree/test-app-upgrade/0.4
+
+[env]
+A=4
+B=2
+Z=1
+__CONFIG__
+teardown
+#-------------------------------------------------------------------------------
+init <<'__CONFIG__'
+meta=test_tree/test-app-upgrade/0.2
+
+[env]
+B=5
+
+[namelist:new]
+spam=eggs
+
+[namelist:something]
+__CONFIG__
+setup
+init_meta test_tree/test-app-upgrade 0.1 0.2
+init_macro test_tree/test-app-upgrade <<'__MACRO__'
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+
+import rose.upgrade
+
+
+class Upgrade01to02(rose.upgrade.MacroUpgrade):
+
+    """Upgrade from 0.1 to 0.2."""
+
+    BEFORE_TAG = "0.1"
+    AFTER_TAG = "0.2"
+
+    def downgrade(self, config, meta_config=None):
+        self.act_from_files(config, downgrade=True)
+        return config, self.reports
+
+    def upgrade(self, config, meta_config=None):
+        self.act_from_files(config)
+        return config, self.reports
+__MACRO__
+
+init_resource_file test_tree/test-app-upgrade 0.1 rose-macro-add.conf <<'__CONFIG__'
+[env]
+B=5
+
+[namelist:new]
+spam=eggs
+__CONFIG__
+init_resource_file test_tree/test-app-upgrade 0.1 rose-macro-remove.conf <<'__CONFIG__'
+[env]
+A=5
+
+[namelist:qwerty]
+
+[namelist:something]
+foo=bar
+__CONFIG__
+
+#-----------------------------------------------------------------------------
+# Check correct start version
+TEST_KEY=$TEST_KEY_BASE-downgrade-patch-files-start-version
+run_pass "$TEST_KEY" rose app-upgrade --downgrade \
+ --meta-path=../rose-meta/ -C ../config/
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<'__OUTPUT__'
+* 0.1
+= 0.2
+__OUTPUT__
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+
+#-----------------------------------------------------------------------------
+# Check file-based upgrading.
+TEST_KEY=$TEST_KEY_BASE-downgrade-patch-files
+run_pass "$TEST_KEY" rose app-upgrade --downgrade \
+ -y --meta-path=../rose-meta/ -C ../config/ 0.1
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<'__OUTPUT__'
+[D] Downgrade_0.2-0.1: changes: 6
+    env=A=5
+        Added with value '5'
+    namelist:something=foo=bar
+        Added with value 'bar'
+    namelist:qwerty=None=None
+        Added
+    env=B=None
+        Removed
+    namelist:new=spam=None
+        Removed
+    =meta=test_tree/test-app-upgrade/0.1
+        Downgraded from 0.2 to 0.1
+__OUTPUT__
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+file_cmp "$TEST_KEY.file" ../config/rose-app.conf <<'__CONFIG__'
+meta=test_tree/test-app-upgrade/0.1
+
+[env]
+A=5
+
+[namelist:new]
+
+[namelist:qwerty]
+
+[namelist:something]
+foo=bar
+__CONFIG__
+teardown
+#-------------------------------------------------------------------------------
+exit

--- a/t/rose-macro/23-import-tree.t
+++ b/t/rose-macro/23-import-tree.t
@@ -39,7 +39,7 @@ __CONFIG__
 # Set up main metadata.
 init_rose_meta dessert/baked-alaska vn1.0 HEAD
 init_rose_meta_content dessert/baked-alaska vn1.0 <<'__META_CONFIG__'
-import=rose-demo-baked-alaska-icecream/vn1.0 rose-demo-baked-alaska-sponge/vn1.0
+import=baked-alaska-icecream/vanilla/vn1.0 baked-alaska-sponge/vn1.0
 
 [env=MERINGUE_NICENESS]
 title=Meringue Niceness (version 1)
@@ -51,8 +51,8 @@ values=vanilla
 __META_CONFIG__
 
 # Set up imported metadata (1)
-init_rose_meta baked-alaska-icecream vn1.0 HEAD
-init_rose_meta_content baked-alaska-icecream vn1.0 <<'__META_CONFIG__'
+init_rose_meta baked-alaska-icecream/vanilla vn1.0 HEAD
+init_rose_meta_content baked-alaska-icecream/vanilla vn1.0 <<'__META_CONFIG__'
 [env=ICECREAM_TEMPERATURE]
 range=-20:0
 title=Icecream Temperature (celsius) (version 1)

--- a/t/rose-macro/23-import-tree.t
+++ b/t/rose-macro/23-import-tree.t
@@ -1,0 +1,153 @@
+#!/bin/bash
+#-------------------------------------------------------------------------------
+# (C) British Crown Copyright 2012-6 Met Office.
+#
+# This file is part of Rose, a framework for meteorological suites.
+#
+# Rose is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Rose is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Rose. If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test "rose macro" in built-in duplicate checking mode.
+#-------------------------------------------------------------------------------
+. $(dirname $0)/test_header
+#-------------------------------------------------------------------------------
+tests 12
+#-------------------------------------------------------------------------------
+# Check basic import works.
+TEST_KEY=$TEST_KEY_BASE-basic-runs
+setup
+init <<'__CONFIG__'
+meta=dessert/baked-alaska/vn1.0
+
+[env]
+ICECREAM_FLAVOUR=vanilla
+ICECREAM_TEMPERATURE=-1
+MERINGUE_NICENESS=0
+SPONGE_DENSITY=0.1
+__CONFIG__
+
+# Set up main metadata.
+init_rose_meta dessert/baked-alaska vn1.0 HEAD
+init_rose_meta_content dessert/baked-alaska vn1.0 <<'__META_CONFIG__'
+import=rose-demo-baked-alaska-icecream/vn1.0 rose-demo-baked-alaska-sponge/vn1.0
+
+[env=MERINGUE_NICENESS]
+title=Meringue Niceness (version 1)
+range=-20:20
+type=integer
+
+[env=ICECREAM_FLAVOUR]
+values=vanilla
+__META_CONFIG__
+
+# Set up imported metadata (1)
+init_rose_meta baked-alaska-icecream vn1.0 HEAD
+init_rose_meta_content baked-alaska-icecream vn1.0 <<'__META_CONFIG__'
+[env=ICECREAM_TEMPERATURE]
+range=-20:0
+title=Icecream Temperature (celsius) (version 1)
+type=integer
+
+[env=ICECREAM_FLAVOUR]
+title=Icecream Flavour
+values=chocolate,vanilla,strawberry
+__META_CONFIG__
+
+# Set up imported metadata (2)
+init_rose_meta baked-alaska-sponge vn1.0 HEAD
+init_rose_meta_content baked-alaska-sponge vn1.0 <<'__META_CONFIG__'
+[env=SPONGE_DENSITY]
+range=0:1
+title=Sponge Density (g cm^-3) (version 1)
+type=real
+__META_CONFIG__
+
+# Check that it runs OK.
+run_pass "$TEST_KEY" rose macro -M $TEST_DIR/rose-meta --config=../config rose.macros.DefaultValidators
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+
+#-------------------------------------------------------------------------------
+TEST_KEY=$TEST_KEY_BASE-basic-correct-metadata
+# Check that it gets the correct metadata.
+init <<'__CONFIG__'
+meta=dessert/baked-alaska/vn1.0
+
+[env]
+ICECREAM_FLAVOUR=chocolate
+ICECREAM_TEMPERATURE=1
+MERINGUE_NICENESS=50
+SPONGE_DENSITY=20.0
+__CONFIG__
+run_fail "$TEST_KEY" rose macro -M $TEST_DIR/rose-meta --config=../config rose.macros.DefaultValidators
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" <<'__ERR__'
+[V] rose.macros.DefaultValidators: issues: 4
+    env=ICECREAM_FLAVOUR=chocolate
+        Value chocolate should be vanilla
+    env=ICECREAM_TEMPERATURE=1
+        Value 1 is not in the range criteria: -20:0
+    env=MERINGUE_NICENESS=50
+        Value 50 is not in the range criteria: -20:20
+    env=SPONGE_DENSITY=20.0
+        Value 20.0 is not in the range criteria: 0:1
+__ERR__
+#-------------------------------------------------------------------------------
+# Check that it gets the correct custom macros.
+TEST_KEY=$TEST_KEY_BASE-basic-custom-macro-list
+init_rose_meta_macro baked-alaska-sponge vn1.0 desoggy.py <<'__MACRO__'
+# -*- coding: utf-8 -*-
+
+import rose.macro
+
+
+class SpongeDeSoggifier(rose.macro.MacroBase):
+
+    """De-soggifies the sponge."""
+
+    SOGGY_FIX_TEXT = "de-soggified"
+
+    def transform(self, config, meta_config=None):
+        """Reduce the density of the sponge."""
+        sponge_density = config.get_value(["env", "SPONGE_DENSITY"])
+        if sponge_density is not None and float(sponge_density) > 0.5:
+            # 1 g cm^-3 is pure water, so this is pretty soggy.
+            config.set(["env", "SPONGE_DENSITY"], "0.3")
+            self.add_report(
+                "env", "SPONGE_DENSITY", "0.3", self.SOGGY_FIX_TEXT)
+        return config, self.reports
+__MACRO__
+run_pass "$TEST_KEY" rose macro -M $TEST_DIR/rose-meta --config=../config
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<'__OUT__'
+[V] rose.macros.DefaultValidators
+    # Runs all the default checks, such as compulsory checking.
+[T] desoggy.SpongeDeSoggifier
+    # De-soggifies the sponge.
+[T] rose.macros.DefaultTransforms
+    # Runs all the default fixers, such as trigger fixing.
+__OUT__
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+#-------------------------------------------------------------------------------
+# Run the custom macro.
+TEST_KEY=$TEST_KEY_BASE-basic-custom-macro-run
+# Check that it gets the correct metadata.
+run_pass "$TEST_KEY" rose macro -y -M $TEST_DIR/rose-meta --config=../config desoggy.SpongeDeSoggifier
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<'__OUT__'
+[T] desoggy.SpongeDeSoggifier: changes: 1
+    env=SPONGE_DENSITY=0.3
+        de-soggified
+__OUT__
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+teardown
+#-------------------------------------------------------------------------------
+exit


### PR DESCRIPTION
Close #1862 
* Allow for upgrade macros to work when the meta-data directory structure has a greater depth than 1 level
* Add platform agnostic python bulletins around the above code change.