### PR TITLE
rose edit: added ability to specify initial namespaces.

### DIFF
--- a/bin/rose-config-edit
+++ b/bin/rose-config-edit
@@ -21,7 +21,7 @@
 #     rose-config-edit
 #
 # SYNOPSIS
-#     rose-config-edit [OPTIONS]
+#     rose-config-edit [OPTIONS]... [PAGE_PATH]...
 #
 # DESCRIPTION
 #     Launch the GTK+ GUI to edit a suite or application configuration.
@@ -50,6 +50,12 @@
 #        Launch, ignoring any configuration.
 #     --no-metadata
 #        Launch with metadata switched off.
+#
+# ARGUMENTS
+#     PAGE_PATH
+#        One or more paths to open on load, pages may be full or partial
+#        namespaces e.g. 'foo/bar/env' or 'env'.
+#        NOTE: Opens the shortest namespace that matches the provided string.
 #
 # ENVIRONMENT VARIABLES
 #     optional ROSE_META_PATH

--- a/doc/rose-command.html
+++ b/doc/rose-command.html
@@ -843,7 +843,7 @@ ignore{foo}=namelist:bar,namelist:baz
 
     <h3>SYNOPSIS</h3>
 
-    <p><kbd>rose config-edit [OPTIONS]</kbd></p>
+    <p><kbd>rose config-edit [OPTIONS]... [PAGE_PATH]...</kbd></p>
 
     <h3>DESCRIPTION</h3>
 
@@ -892,6 +892,19 @@ ignore{foo}=namelist:bar,namelist:baz
       <dt><kbd>--no-metadata</kbd></dt>
 
       <dd>Launch with metadata switched off.</dd>
+    </dl>
+
+    <h3>ARGUMENTS</h3>
+
+    <dl>
+        <dt><kbd>PAGE_PATH</kbd></dt>
+
+        <dd>
+          One or more paths to open on load, pages may be full or partial
+          namespaces e.g. <var>'foo/bar/env'</var> or <var>'env'</var>.
+          <br/>
+          NOTE: Opens the shortest namespace that matches the provided string.
+        </dd>
     </dl>
 
     <h3>ENVIRONMENT VARIABLES</h3>


### PR DESCRIPTION
Closes #1273 

Namespaces passed as arguments to rose edit will now open on load. Passing partial namespaces is supported, e.g. the namespace `abc/def/foo/bar`, `foo` could be specified using any of: `abc/def/foo` `def/foo` `f/foo` `f/f` `foo` `f`. ~~In the case that multiple namespaces match the provided string the first match is used~~ The shortest namespace that matches will be opened i.e. `/env` before `/foo/bar/env`.

@matthewrmshin Please Review
@benfitzpatrick Please Review