### PR TITLE
rose bunch: remove any existing database entries if first submit

### DIFF
--- a/lib/python/rose/apps/rose_bunch.py
+++ b/lib/python/rose/apps/rose_bunch.py
@@ -342,7 +342,7 @@ class RoseBunchDAO(object):
     def create_tables(self):
         """Create tables as appropriate"""
         existing = []
-        first_run = os.environ["CYLC_TASK_SUBMIT_NUMBER"] == "1"
+        first_run = os.environ.get("CYLC_TASK_SUBMIT_NUMBER") == "1"
 
         for row in self.conn.execute("SELECT name FROM sqlite_master " +
                                      "WHERE type=='table'"):

--- a/lib/python/rose/apps/rose_bunch.py
+++ b/lib/python/rose/apps/rose_bunch.py
@@ -342,10 +342,15 @@ class RoseBunchDAO(object):
     def create_tables(self):
         """Create tables as appropriate"""
         existing = []
+        first_run = os.environ["CYLC_TASK_SUBMIT_NUMBER"] == "1"
 
         for row in self.conn.execute("SELECT name FROM sqlite_master " +
                                      "WHERE type=='table'"):
             existing.append(row[0])
+
+        if first_run:
+            for tablename in existing:
+                self.conn.execute("""DELETE FROM """ + tablename)
 
         self.new_run = not existing
 

--- a/t/rose-task-run/37-app-bunch-rm-old.t
+++ b/t/rose-task-run/37-app-bunch-rm-old.t
@@ -1,0 +1,79 @@
+#!/bin/bash
+#-------------------------------------------------------------------------------
+# (C) British Crown Copyright 2012-6 Met Office.
+#
+# This file is part of Rose, a framework for meteorological suites.
+#
+# Rose is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Rose is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Rose. If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test rose_bunch built-in application.
+#-------------------------------------------------------------------------------
+. $(dirname $0)/test_header
+#-------------------------------------------------------------------------------
+tests 14
+#-------------------------------------------------------------------------------
+# Run the suite, and wait for it to complete
+export ROSE_CONF_PATH=
+TEST_KEY=$TEST_KEY_BASE
+mkdir -p $HOME/cylc-run
+SUITE_RUN_DIR=$(mktemp -d --tmpdir=$HOME/cylc-run 'rose-test-battery.XXXXXX')
+NAME=$(basename $SUITE_RUN_DIR)
+run_pass "$TEST_KEY" \
+    rose suite-run -C $TEST_SOURCE_DIR/$TEST_KEY_BASE --name=$NAME \
+    --no-gcontrol --host=localhost -- --debug
+#-------------------------------------------------------------------------------
+CYCLE=20100101T0000Z
+LOG_DIR="$SUITE_RUN_DIR/log/job/$CYCLE"
+#-------------------------------------------------------------------------------
+# Testing successful runs
+#-------------------------------------------------------------------------------
+APP=buncher
+#-------------------------------------------------------------------------------
+# Confirm launching set of commands
+TEST_KEY_PREFIX=launch-ok
+FILE=$LOG_DIR/$APP/NN/job.out
+for ARGVALUE in 0 1 2 3; do
+    TEST_KEY=$TEST_KEY_PREFIX-$ARGVALUE
+    file_grep $TEST_KEY \
+    "\[INFO\] [0-9]*-[0-9]*-[0-9]*T[0-9]*:[0-9]*:[0-9]*+[0:9]* $ARGVALUE: added to pool"\
+     $FILE
+done
+#-------------------------------------------------------------------------------
+# Check output to separate files is correct
+TEST_KEY_PREFIX=check-logs
+FILE_PREFIX=$LOG_DIR/$APP/NN
+for ARGVALUE in 0 1 2 3; do
+    TEST_KEY=$TEST_KEY_PREFIX-$ARGVALUE
+    file_grep $TEST_KEY \
+        "arg1: $(expr $ARGVALUE + 1)" $FILE_PREFIX/bunch.$ARGVALUE.out
+done
+#-------------------------------------------------------------------------------
+# Run suite a second time
+run_pass "$TEST_KEY" \
+    rose suite-run -C $TEST_SOURCE_DIR/$TEST_KEY_BASE --name=$NAME \
+    --no-gcontrol --host=localhost -- --debug
+#-------------------------------------------------------------------------------
+# Confirm launching set of commands
+TEST_KEY_PREFIX=launch-ok-2nd-run
+FILE=$LOG_DIR/$APP/NN/job.out
+for ARGVALUE in 0 1 2 3; do
+    TEST_KEY=$TEST_KEY_PREFIX-$ARGVALUE
+    file_grep $TEST_KEY \
+    "\[INFO\] [0-9]*-[0-9]*-[0-9]*T[0-9]*:[0-9]*:[0-9]*+[0:9]* $ARGVALUE: added to pool"\
+     $FILE
+done
+#-------------------------------------------------------------------------------
+
+rose suite-clean -q -y $NAME
+exit 0

--- a/t/rose-task-run/37-app-bunch-rm-old/app/buncher/rose-app.conf
+++ b/t/rose-task-run/37-app-bunch-rm-old/app/buncher/rose-app.conf
@@ -1,0 +1,10 @@
+mode=rose_bunch
+meta=rose_bunch
+
+[bunch-args]
+arg1=1 2 3 4
+
+[bunch]
+command-format=echo arg1: %(arg1)s
+command-instances = 4
+pool-size=1

--- a/t/rose-task-run/37-app-bunch-rm-old/suite.rc
+++ b/t/rose-task-run/37-app-bunch-rm-old/suite.rc
@@ -1,0 +1,25 @@
+#!jinja2
+[cylc]
+    UTC mode=True
+    [[event hooks]]
+        timeout handler = rose suite-hook --shutdown
+        timeout         = PT1M
+[scheduling]
+    initial cycle point = 20100101T00Z
+    final cycle point   = 20100101T00Z
+    [[dependencies]]
+        [[[ T00 ]]]
+            graph="""buncher"""
+
+[runtime]
+    [[root]]
+        command scripting=rose task-run -v -v --debug
+        [[[event hooks]]]
+            succeeded handler          = rose suite-hook
+            failed handler             = rose suite-hook
+            submission failed handler  = rose suite-hook --shutdown
+            submission timeout handler = rose suite-hook
+            execution timeout handler  = rose suite-hook
+            submission timeout         = PT1M
+            execution timeout          = PT1M
+    [[buncher]]


### PR DESCRIPTION
Caters for a bug encountered in an odd situation.

If someone runs a bunch task in a suite and then later runs the suite and that same bunch task again (as a new first run), without having cleared out the work directory rose bunch will skip tasks it ran previously.

This fixes the bug. Test added here that should fail on master.

@benfitzpatrick - please review 1
@matthewrmshin - please review 2