### PR TITLE
rose suite-run --reload: allow suite title change

### DIFF
--- a/lib/python/rose/suite_engine_proc.py
+++ b/lib/python/rose/suite_engine_proc.py
@@ -391,7 +391,8 @@ class SuiteEngineProcessor(object):
         """Run suite engine dependent logic (at end of "rose suite-clean")."""
         raise NotImplementedError()
 
-    def cmp_suite_conf(self, suite_name, strict_mode=False, debug_mode=False):
+    def cmp_suite_conf(
+            self, suite_name, run_mode, strict_mode=False, debug_mode=False):
         """Compare current suite configuration with that in the previous run.
 
         An implementation of this method should:

--- a/lib/python/rose/suite_engine_procs/cylc.py
+++ b/lib/python/rose/suite_engine_procs/cylc.py
@@ -170,7 +170,8 @@ class CylcProcessor(SuiteEngineProcessor):
             if os.path.islink(path) and not os.path.exists(path):
                 self.fs_util.delete(path)
 
-    def cmp_suite_conf(self, suite_name, strict_mode=False, debug_mode=False):
+    def cmp_suite_conf(
+            self, suite_name, run_mode, strict_mode=False, debug_mode=False):
         """Parse and compare current "suite.rc" with that in the previous run.
 
         (Re-)register and validate the "suite.rc" file.
@@ -185,7 +186,8 @@ class CylcProcessor(SuiteEngineProcessor):
         if out:
             suite_dir_old = out.strip()
         suite_passphrase = os.path.join(suite_dir, "passphrase")
-        self.clean_hook(suite_name)
+        if run_mode != "reload":
+            self.clean_hook(suite_name)
         if suite_dir_old != suite_dir or not os.path.exists(suite_passphrase):
             self.popen.run_simple("cylc", "unregister", suite_name)
             suite_dir_old = None

--- a/lib/python/rose/suite_run.py
+++ b/lib/python/rose/suite_run.py
@@ -293,7 +293,7 @@ class SuiteRunner(Runner):
         # Ask suite engine to parse suite configuration
         # and determine if it is up to date (unchanged)
         suite_conf_unchanged = self.suite_engine_proc.cmp_suite_conf(
-            suite_name, opts.strict_mode, opts.debug_mode)
+            suite_name, opts.run_mode, opts.strict_mode, opts.debug_mode)
 
         if opts.local_install_only_mode:
             return


### PR DESCRIPTION
Don't call `cylc refresh` on reload mode, as it may nuke the passphrase
by calling un-register and register on the suite.

See also cylc/cylc#1774. Close #1846,