### PR TITLE
rose app-run: fix file installation clash

### DIFF
--- a/doc/rose-configuration.html
+++ b/doc/rose-configuration.html
@@ -591,6 +591,20 @@ root-dir=hpc*=$WORKDIR
           <li>other configuration files that require more than
           section=key=value.</li>
         </ul>
+
+        <p>Files in this directory are copied to the working directory in run
+        time.</p>
+
+        <p>Note: If there is a clash between a <var>[file:*]</var> section and a
+        file under <var>file/</var>, the setting in the <var>[file:*]</var>
+        section takes precedence. E.g. Suppose we have a file
+        <samp>file/hello.txt</samp>. In the absence of
+        <samp>[file:hello.txt]</samp>, it will copy <samp>file/hello.txt</samp>
+        to <samp>$PWD/hello.txt</samp> in run time. However, if we have a
+        <samp>[file:hello.txt]</samp> section and a <var>source=SOURCE</var>
+        setting, then it will install the file from <var>SOURCE</var> instead.
+        If we have <samp>[!file:hello.txt]</samp>, then the file will not be
+        installed at all.</p>
       </li>
 
       <li><samp>bin/</samp> directory for e.g. scripts and executables used by

--- a/doc/rose-rug-task-run.html
+++ b/doc/rose-rug-task-run.html
@@ -208,7 +208,19 @@ WORLDS=Mars Jupiter Saturn
       detail.</li>
 
       <li>Copy any regular files under the <var>file/</var> sub-directory of
-      the application configuration to the working directory.</li>
+      the application configuration to the working directory.
+
+        <p>Note: If there is a clash between a <var>[file:*]</var> section and a
+        file under <var>file/</var>, the setting in the <var>[file:*]</var>
+        section takes precedence. E.g. Suppose we have a file
+        <samp>file/hello.txt</samp>. In the absence of
+        <samp>[file:hello.txt]</samp>, it will copy <samp>file/hello.txt</samp>
+        to <samp>$PWD/hello.txt</samp> in run time. However, if we have a
+        <samp>[file:hello.txt]</samp> section and a <var>source=SOURCE</var>
+        setting, then it will install the file from <var>SOURCE</var> instead.
+        If we have <samp>[!file:hello.txt]</samp>, then the file will not be
+        installed at all.</p>
+      </li>
     </ul>
 
     <p>If the command for the application requires some pre-defined standard

--- a/lib/python/rose/app_run.py
+++ b/lib/python/rose/app_run.py
@@ -360,7 +360,7 @@ class AppRunner(Runner):
                 target_node = conf_tree.node.get([target_key])
             elif target_node.is_ignored():
                 continue
-            source_node = target_node.get("source")
+            source_node = target_node.get(["source"])
             if source_node is None:
                 target_node.set(["source"],
                                 os.path.join(conf_dir, "file", name))

--- a/t/rose-app-run/23-file-both.t
+++ b/t/rose-app-run/23-file-both.t
@@ -1,0 +1,52 @@
+#!/bin/bash
+#-------------------------------------------------------------------------------
+# (C) British Crown Copyright 2012-6 Met Office.
+#
+# This file is part of Rose, a framework for meteorological suites.
+#
+# Rose is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Rose is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Rose. If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test "rose app-run" file install, with both [file:NAME] and "file/NAME".
+# The [file:NAME]source=SOURCE should override.
+. $(dirname $0)/test_header
+
+test_init <<__CONFIG__
+[command]
+default=true
+
+[file:whatever.txt]
+source=${TEST_DIR}/etc/whatever.txt
+__CONFIG__
+
+mkdir "${TEST_DIR}/config/file" "${TEST_DIR}/etc"
+echo "I don't care!" >"${TEST_DIR}/config/file/whatever.txt"
+echo 'Whatever!' >"${TEST_DIR}/etc/whatever.txt"
+
+#-------------------------------------------------------------------------------
+tests 4
+#-------------------------------------------------------------------------------
+TEST_KEY="${TEST_KEY_BASE}"
+test_setup
+run_pass "${TEST_KEY}" rose app-run --config='../config'
+sed -n '/\[INFO\] \(install\|    source\)/p;' "${TEST_KEY}.out" \
+    >"${TEST_KEY}.out.edited"
+file_cmp "${TEST_KEY}.out" "${TEST_KEY}.out.edited" <<__OUT__
+[INFO] install: whatever.txt
+[INFO]     source: ${TEST_DIR}/etc/whatever.txt
+__OUT__
+file_cmp "${TEST_KEY}.err" "${TEST_KEY}.err" <'/dev/null'
+file_cmp "${TEST_KEY}-whatever.txt" 'whatever.txt' <<<'Whatever!'
+test_teardown
+#-------------------------------------------------------------------------------
+exit


### PR DESCRIPTION
Suppose we have both `file/whatever.txt` and `[file:whatever.txt]source=somewhere/whatever.txt`, the setting in the `rose-app.conf` should take precedence. A bug in the logic meant that this was not the case. This has now been fixed.

@benfitzpatrick @arjclark please review. This bug was reported via email by @hjoliver and @jonnyhtw.