### PR TITLE
t: fix string test broken by cylc/cylc#1774

### DIFF
--- a/t/rose-suite-restart/00-no-run.t
+++ b/t/rose-suite-restart/00-no-run.t
@@ -45,7 +45,7 @@ file_cmp "${TEST_KEY}.err.head" "${TEST_KEY}.err.head" <<__ERR__
 [FAIL] cylc restart ${NAME}  # return-code=1, stderr=
 __ERR__
 file_grep "${TEST_KEY}.err.grep" \
-    "'ERROR: Suite not found ${NAME}'" "${TEST_KEY}.err"
+    "ERROR: Suite not found ${NAME}" "${TEST_KEY}.err"
 rmdir "${HOME}/cylc-run/${NAME}"
 #-------------------------------------------------------------------------------
 exit


### PR DESCRIPTION
cylc/cylc#1774 introduces a small change to how `RegistrationError` is reported. (It no longer quotes the error string.)

@benfitzpatrick please review. (I believe 1 review is enough.) The test will only pass on latest cylc master.