### PR TITLE
Rose stem mirror variable incorrect when run within subdirectory

### DIFF
--- a/lib/python/rose/stem.py
+++ b/lib/python/rose/stem.py
@@ -247,6 +247,10 @@ class StemRunner(object):
         # Generate mirror location
         mirror = re.sub(proj_root, mirror_repo, source_dict['url'])
 
+        # Remove any sub-tree
+        mirror = re.sub(source_dict['sub_tree'], r'', mirror)
+        mirror = re.sub(r'/@', r'@', mirror)
+
         # Add forwards slash after .xm if missing
         if '.xm/' not in mirror:
             mirror = re.sub(r'\.xm', r'.xm/', mirror)

--- a/t/rose-stem/00-run-basic.t
+++ b/t/rose-stem/00-run-basic.t
@@ -50,7 +50,7 @@ cp $TEST_SOURCE_DIR/00-run-basic/rose-suite.conf $WORKINGCOPY/rose-stem
 touch $WORKINGCOPY/rose-stem/rose-suite.conf
 #We should now have a valid rose-stem suite.
 #-------------------------------------------------------------------------------
-N_TESTS=41
+N_TESTS=42
 tests $N_TESTS
 #-------------------------------------------------------------------------------
 #Test for successful execution
@@ -130,6 +130,9 @@ TEST_KEY=$TEST_KEY_BASE-subdirectory-source-base
 file_grep $TEST_KEY "SOURCE_FOO_BASE=$WORKINGCOPY\$" $OUTPUT
 TEST_KEY=$TEST_KEY_BASE-subdirectory-source-rev
 file_grep $TEST_KEY "SOURCE_FOO_REV=\$" $OUTPUT
+TEST_KEY=$TEST_KEY_BASE-subdirectory-source-mirror
+file_grep $TEST_KEY "SOURCE_FOO_MIRROR=fcm:foo.xm/trunk@1\$" $OUTPUT
+cp $OUTPUT ~
 #-------------------------------------------------------------------------------
 # Fourth test, checking relative path with -C is working
 TEST_KEY=$TEST_KEY_BASE-relative-path

--- a/t/rose-stem/00-run-basic.t
+++ b/t/rose-stem/00-run-basic.t
@@ -132,7 +132,6 @@ TEST_KEY=$TEST_KEY_BASE-subdirectory-source-rev
 file_grep $TEST_KEY "SOURCE_FOO_REV=\$" $OUTPUT
 TEST_KEY=$TEST_KEY_BASE-subdirectory-source-mirror
 file_grep $TEST_KEY "SOURCE_FOO_MIRROR=fcm:foo.xm/trunk@1\$" $OUTPUT
-cp $OUTPUT ~
 #-------------------------------------------------------------------------------
 # Fourth test, checking relative path with -C is working
 TEST_KEY=$TEST_KEY_BASE-relative-path


### PR DESCRIPTION
The `_MIRROR` variable in rose-stem isn't being set correctly when the command is invoked from within a subdirectory, it should have the base path of the URL, but it currently includes the path to the location where the command was run. This aims to fix it, and also to add a test which would have showed up the issue.