### PR TITLE
rose bush: job entry: link 0-size file any way

### DIFF
--- a/lib/html/template/rose-bush/job-entry.html
+++ b/lib/html/template/rose-bush/job-entry.html
@@ -67,7 +67,7 @@
             {% elif key == "02-err" -%}
               {% set key = "err" -%}
             {% endif -%}
-            {% if log.exists and log.size -%}
+            {% if log.exists -%}
               {% if log.path_in_tar -%}
                 {% if path_in_tar is defined and path_in_tar == log.path_in_tar -%}
                   {{key}}
@@ -87,8 +87,6 @@
                   title="{{log.size}} bytes">{{key}}{% if log.size == "?" -%}?{% endif -%}</a>
                 {% endif -%}
               {% endif -%}
-            {% elif log.exists -%}
-              <span class="muted" title="{{log.size}} bytes">{{key}}</span>
             {% else -%}
               <span class="muted" title="{{log.size}} bytes, gone">{{key}}</span>
             {% endif -%}


### PR DESCRIPTION
There may be a delay before the batch system completes writing data to `job.err` and `job.out`. On job completion, they may appear to be zero-size, and get registered to the database as such. The files are then populated with data. This change ensures that these files get linked.