### PR TITLE
Handle SuiteNotRunning error in rosie go.

### DIFF
--- a/lib/python/rosie/browser/__init__.py
+++ b/lib/python/rosie/browser/__init__.py
@@ -160,6 +160,8 @@ DIALOG_MESSAGE_DELETE_CONFIRMATION = (
     "\"{0}\". This will permanently delete all branches, " +
     "trunk and any local copy." +
     "\n\nAre you sure you wish to proceed?")
+DIALOG_MESSAGE_SUITE_NOT_RUNNING = ("Cannot launch gcontrol: " +
+                                     "suite {0} is not running.")
 DIALOG_MESSAGE_UNCOMPLETED_FILTER = "Uncompleted filter"
 DIALOG_MESSAGE_UNREGISTERED_SUITE = ("Cannot launch gcontrol: " +
                                      "suite {0} is not registered.")
@@ -168,6 +170,7 @@ DIALOG_TITLE_CREATE_PREFIX = "Create"
 DIALOG_TITLE_DELETE = "Confirm Delete"
 DIALOG_TITLE_HISTORY_ERROR = "History Error"
 DIALOG_TITLE_INFO = "Suite Info"
+DIALOG_TITLE_SUITE_NOT_RUNNING = "Suite not running"
 DIALOG_TITLE_UNCOMPLETED_FILTER = "Filter error"
 DIALOG_TITLE_UNREGISTERED_SUITE = "Suite not registered"
 DIALOG_MESSAGE_SOURCE_CHANGED = "Data source changed to {0}."

--- a/lib/python/rosie/browser/__init__.py
+++ b/lib/python/rosie/browser/__init__.py
@@ -161,7 +161,7 @@ DIALOG_MESSAGE_DELETE_CONFIRMATION = (
     "trunk and any local copy." +
     "\n\nAre you sure you wish to proceed?")
 DIALOG_MESSAGE_SUITE_NOT_RUNNING = ("Cannot launch gcontrol: " +
-                                     "suite {0} is not running.")
+                                    "suite {0} does not appear to be running.")
 DIALOG_MESSAGE_UNCOMPLETED_FILTER = "Uncompleted filter"
 DIALOG_MESSAGE_UNREGISTERED_SUITE = ("Cannot launch gcontrol: " +
                                      "suite {0} is not registered.")

--- a/lib/python/rosie/browser/__init__.py
+++ b/lib/python/rosie/browser/__init__.py
@@ -160,8 +160,7 @@ DIALOG_MESSAGE_DELETE_CONFIRMATION = (
     "\"{0}\". This will permanently delete all branches, " +
     "trunk and any local copy." +
     "\n\nAre you sure you wish to proceed?")
-DIALOG_MESSAGE_SUITE_NOT_RUNNING = ("Cannot launch gcontrol: " +
-                                    "suite {0} does not appear to be running.")
+DIALOG_MESSAGE_SUITE_NOT_RUNNING = ("Cannot launch gcontrol: {0}")
 DIALOG_MESSAGE_UNCOMPLETED_FILTER = "Uncompleted filter"
 DIALOG_MESSAGE_UNREGISTERED_SUITE = ("Cannot launch gcontrol: " +
                                      "suite {0} is not registered.")

--- a/lib/python/rosie/browser/main.py
+++ b/lib/python/rosie/browser/main.py
@@ -49,7 +49,7 @@ from rose.opt_parse import RoseOptionParser
 from rose.popen import RosePopenError
 import rose.reporter
 from rose.resource import ResourceLocator, ResourceError
-from rose.suite_control import SuiteControl
+from rose.suite_control import SuiteControl, SuiteNotRunningError
 from rose.suite_engine_proc import (
     NoSuiteLogError, SuiteEngineProcessor, WebBrowserEvent)
 import rosie.browser.history
@@ -907,7 +907,15 @@ class MainWindow(gtk.Window):
         this_id = str(SuiteId(id_text=self.get_selected_suite_id()))
 
         if SuiteControl().suite_engine_proc.is_suite_registered(this_id):
-            return SuiteControl().gcontrol(this_id)
+            try:
+                return SuiteControl().gcontrol(this_id)
+            except SuiteNotRunningError:
+                msg = rosie.browser.DIALOG_MESSAGE_SUITE_NOT_RUNNING.format(
+                    this_id)
+                return rose.gtk.dialog.run_dialog(
+                    rose.gtk.dialog.DIALOG_TYPE_ERROR,
+                    msg,
+                    rosie.browser.DIALOG_TITLE_SUITE_NOT_RUNNING)
         else:
             msg = rosie.browser.DIALOG_MESSAGE_UNREGISTERED_SUITE.format(
                 this_id)

--- a/lib/python/rosie/browser/main.py
+++ b/lib/python/rosie/browser/main.py
@@ -909,9 +909,9 @@ class MainWindow(gtk.Window):
         if SuiteControl().suite_engine_proc.is_suite_registered(this_id):
             try:
                 return SuiteControl().gcontrol(this_id)
-            except SuiteNotRunningError:
+            except SuiteNotRunningError as err:
                 msg = rosie.browser.DIALOG_MESSAGE_SUITE_NOT_RUNNING.format(
-                    this_id)
+                    str(err))
                 return rose.gtk.dialog.run_dialog(
                     rose.gtk.dialog.DIALOG_TYPE_ERROR,
                     msg,


### PR DESCRIPTION
Closes #1874 

Adds a dialog to capture the SuiteNotRunning exception being thrown on trying to launch gcylc from withing rosie go for a non running suite.

@matthewrmshin - please review 1
@kaday - please review 2