### PR TITLE
rose macro: fix trigger transform order-sensitivity bug

### DIFF
--- a/lib/python/rose/macros/trigger.py
+++ b/lib/python/rose/macros/trigger.py
@@ -80,7 +80,6 @@ class TriggerMacro(rose.macro.MacroBaseRoseEdit):
         state_map = {enabled: 'enabled     ',
                      trig_ignored: 'trig-ignored',
                      user_ignored: 'user-ignored'}
-        change_list = []
         id_list = []
         prev_ignoreds = {trig_ignored: [], user_ignored: []}
         for keylist, node in config.walk():
@@ -91,8 +90,14 @@ class TriggerMacro(rose.macro.MacroBaseRoseEdit):
             id_list.append(n_id)
             if node.state in prev_ignoreds:
                 prev_ignoreds[node.state].append(n_id)
-        for var_id in self.trigger_family_lookup:
+
+        # Update in breadth-first order to get the ignored parent statuses
+        # correct and trickled down.
+        ranked_ids = self._get_ranked_trigger_ids()
+        for rank, var_id in sorted(ranked_ids):
             self.update(var_id, config, meta_config)
+
+        # Report any discrepancies in ignored status.
         for var_id in id_list:
             section, option = self._get_section_option_from_id(var_id)
             node = config.get([section, option])
@@ -261,6 +266,24 @@ class TriggerMacro(rose.macro.MacroBaseRoseEdit):
                         id_stack.insert(1, (child_id, False))
             id_stack.pop(0)
         return update_id_list
+
+    def _get_ranked_trigger_ids(self):
+        """Return trigger ids with their maximum trigger chain depth."""
+        stack = [(id_, 0) for id_ in self.trigger_family_lookup]
+        id_ranks = dict(stack)
+        while stack:
+            parent_id, depth = stack.pop(0)
+            child_ids = self.trigger_family_lookup.get(parent_id, [])
+            for child_id in child_ids:
+                id_ranks.setdefault(child_id, depth + 1)
+                if depth + 1 > id_ranks[child_id]:
+                    id_ranks[child_id] = depth + 1
+                stack.append((child_id, depth + 1))
+        ranked_ids = []
+        for id_, rank in id_ranks.items():
+            ranked_ids.append((rank, id_))
+        ranked_ids.sort()
+        return ranked_ids
 
     def validate(self, config, meta_config=None):
         self.reports = []

--- a/t/rose-macro/10-trigger-check.t
+++ b/t/rose-macro/10-trigger-check.t
@@ -38,7 +38,7 @@ atrig = 2
 btrig = 3
 __CONFIG__
 #-------------------------------------------------------------------------------
-tests 24
+tests 27
 #-------------------------------------------------------------------------------
 # Check trigger checking - this is nearly cyclic but should be fine.
 TEST_KEY=$TEST_KEY_BASE-ok
@@ -1004,6 +1004,64 @@ trigger=namelist:baz=b: 1;
 trigger=namelist:baz=c: 2;
 
 [namelist:baz=c]
+__META_CONFIG__
+run_pass "$TEST_KEY" rose macro --config=../config rose.macros.DefaultValidators
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+#-------------------------------------------------------------------------------
+# Check ignored mid-level trigger status handling.
+# Old bug behaviour was strongly dependent on exact ordering and naming.
+TEST_KEY=$TEST_KEY_BASE-dupl-namelist-within
+setup
+init <<'__CONFIG__'
+[namelist:rrr0]
+l_alternate=.true.
+
+[namelist:rrr]
+l_culmination_level=.false.
+!!l_mid_level=.true.
+!!lowest_level_opt=0
+
+[namelist:zzz0]
+l_alternate=.true.
+
+[namelist:zzz]
+l_culmination_level=.false.
+!!l_mid_level=.true.
+!!lowest_level_opt=0
+__CONFIG__
+init_meta <<__META_CONFIG__
+[namelist:rrr0=l_alternate]
+trigger=namelist:rrr=l_mid_level: .true.
+
+[namelist:rrr=l_culmination_level]
+trigger=namelist:rrr=l_mid_level: .true.
+
+[namelist:rrr=l_mid_level]
+trigger=namelist:rrr=lowest_level_opt: .true.
+
+[namelist:rrr=lowest_level_opt]
+
+[namelist:foo=bar]
+
+[namelist:foo=baz]
+trigger=namelist:foo=bar: .true.
+
+[namelist:xyz=bar]
+
+[namelist:xyz=baz]
+trigger=namelist:xyz=bar: this
+
+[namelist:zzz0=l_alternate]
+trigger=namelist:zzz=l_mid_level: .true.
+
+[namelist:zzz=l_culmination_level]
+trigger=namelist:zzz=l_mid_level: .true.
+
+[namelist:zzz=l_mid_level]
+trigger=namelist:zzz=lowest_level_opt: .true.
+
+[namelist:zzz=lowest_level_opt]
 __META_CONFIG__
 run_pass "$TEST_KEY" rose macro --config=../config rose.macros.DefaultValidators
 file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null


### PR DESCRIPTION
The `trigger` mechanism in transform macro mode (`rose macro`, and `rose edit` for trigger error checking) can sometimes (rarely?) be incorrect.

The code currently does:
```python
        for var_id in self.trigger_family_lookup:
            self.update(var_id, config, meta_config)
```
where `self.update` launches a cascading check down the trigger chain from `var_id`.

These cascading chains will overlap, and every setting will be checked at least once, but the unordered nature of the `for` loop means that in some particular cases the ignored status of a parent will not get properly transmitted to an ignored status for a child.

The new code loops over ids based on their maximum rank in the trigger hierarchy, from lowest to highest. This means that any parent should propagate their status properly (reliably!) to their children.

I've added a test that fails on current master and succeeds on this branch. The test is very sensitive to the exact contents of the metadata configuration, which is why it has settings that look like unnecessary junk - once removed or renamed, the test will no longer fail!

@matthewrmshin, @arjclark please review.

I've checked the change is null with respect to the latest UM trunk, and will check vs our suites to get a handle on the effects.