### PR TITLE
Project not found error tested too late in rose-stem

### DIFF
--- a/lib/python/rose/stem.py
+++ b/lib/python/rose/stem.py
@@ -286,7 +286,6 @@ class StemRunner(object):
 
         mirror = self._deduce_mirror(source_dict, project)
 
-
         if 'peg_rev' in source_dict and '@' in item:
             revision = '@' + source_dict['peg_rev']
             base = re.sub(r'@.*', r'', item)

--- a/lib/python/rose/stem.py
+++ b/lib/python/rose/stem.py
@@ -281,10 +281,11 @@ class StemRunner(object):
 
         source_dict = self._get_base_dir(item)
         project = self._get_project_from_url(source_dict)
-        mirror = self._deduce_mirror(source_dict, project)
-
         if not project:
             raise ProjectNotFoundException(item)
+
+        mirror = self._deduce_mirror(source_dict, project)
+
 
         if 'peg_rev' in source_dict and '@' in item:
             revision = '@' + source_dict['peg_rev']

--- a/t/rose-stem/00-run-basic.t
+++ b/t/rose-stem/00-run-basic.t
@@ -50,7 +50,7 @@ cp $TEST_SOURCE_DIR/00-run-basic/rose-suite.conf $WORKINGCOPY/rose-stem
 touch $WORKINGCOPY/rose-stem/rose-suite.conf
 #We should now have a valid rose-stem suite.
 #-------------------------------------------------------------------------------
-N_TESTS=42
+N_TESTS=44
 tests $N_TESTS
 #-------------------------------------------------------------------------------
 #Test for successful execution
@@ -206,6 +206,19 @@ run_fail "$TEST_KEY" \
 OUTPUT=$TEST_DIR/${TEST_KEY}.err
 TEST_KEY=$TEST_KEY_BASE-incompatible-versions-correct_error
 file_grep $TEST_KEY "Running rose-stem version 1 but suite is at version 0" $OUTPUT
+#-------------------------------------------------------------------------------
+# Eighth test - test error message when project not in keywords
+# Remove the keywords file and re-copy the original rose-suite.conf file
+unset FCM_CONF_PATH
+cp $TEST_SOURCE_DIR/00-run-basic/rose-suite.conf $WORKINGCOPY/rose-stem
+TEST_KEY=$TEST_KEY_BASE-project-not-in-keywords
+run_fail "$TEST_KEY" \
+   rose stem --group=earl_grey --task=milk,sugar --group=spoon,cup,milk \
+             --source=$WORKINGCOPY --source=fcm:foo.x_tr@head --no-gcontrol \
+             --name $SUITENAME -- --debug 
+OUTPUT=$TEST_DIR/${TEST_KEY}.err
+TEST_KEY=$TEST_KEY_BASE-project-not-in-keywords-correct_error
+file_grep $TEST_KEY "Cannot ascertain project for source tree" $OUTPUT
 #-------------------------------------------------------------------------------
 #Clean suite
 rose suite-clean -q -y $SUITENAME


### PR DESCRIPTION
The test on whether the project of the rose-stem source tree was determined correctly is a few lines too late - it comes after the project variable is actually used to determine a possible mirror, and if the project is not found the code aborts in mirror determination as it tries to do a regular expression on `None`, before the test would generate a nice error.

The fix is to move the test a couple of lines up, so it's checked immediately after it tries to work out the project.

