### PR TITLE
t: allow tests to pass on Ubuntu 16.04LTS

### DIFF
--- a/t/rose-suite-scan/00-localhost.t
+++ b/t/rose-suite-scan/00-localhost.t
@@ -40,9 +40,9 @@ NAME=$(basename $SUITE_RUN_DIR)
 rose suite-run -q -C $TEST_SOURCE_DIR/$TEST_KEY_BASE --name=$NAME \
     --no-gcontrol --host=$HOST
 if [[ $HOST == 'localhost' ]]; then
-    PORT=$(cat ~/.cylc/ports/$NAME)
+    PORT=$(head -1 ~/.cylc/ports/$NAME)
 else
-    PORT=$(ssh -oBatchMode=yes $HOST cat ~/.cylc/ports/$NAME)
+    PORT=$(ssh -oBatchMode=yes $HOST head -1 ~/.cylc/ports/$NAME)
 fi
 #-------------------------------------------------------------------------------
 # No argument

--- a/t/rose-task-run/38-app-bunch-counts/app/cutoff/rose-app.conf
+++ b/t/rose-task-run/38-app-bunch-counts/app/cutoff/rose-app.conf
@@ -1,7 +1,7 @@
 mode=rose_bunch
 
 [bunch]
-command-format=(( $CYLC_TASK_SUBMIT_NUMBER > %(cutoff)s ))
+command-format=test $CYLC_TASK_SUBMIT_NUMBER -gt %(cutoff)s
 fail-mode=abort
 pool-size=1
 

--- a/t/rose-task-run/38-app-bunch-counts/suite.rc
+++ b/t/rose-task-run/38-app-bunch-counts/suite.rc
@@ -1,16 +1,13 @@
 [cylc]
     UTC mode = True
+    abort if any task fails = True
     [[event hooks]]
-        timeout handler = rose suite-hook --shutdown
-        timeout         = PT1M
+        abort on timeout = True
+        timeout = PT1M
 [scheduling]
-[[dependencies]]
-    graph = cutoff
+    [[dependencies]]
+        graph = cutoff
 [runtime]
-[[root]]
-    command scripting = rose task-run
-    retry delays = 2*PT1S
-        [[[event hooks]]]
-            failed handler             = rose suite-hook --shutdown
-            submission failed handler  = rose suite-hook --shutdown
-[[cutoff]]
+    [[cutoff]]
+        script = rose task-run
+        retry delays = 2*PT1S


### PR DESCRIPTION
The rose-suite-scan/00 test is passing dubiously any way. After the port file
change in cylc, it is running `grep` on the wrong thing. The problem was picked
up under Ubuntu 16.04 due to it being more unstable.

Ubuntu runs dash instead of bash by default, so the double bracket syntax for
numeric comparison in the new rose_bunch test does not work. Modifying it to use
the old `test` command allows the test to work as intended.