### PR TITLE
change command/environment scripting to script/env-script  

### DIFF
--- a/bin/rose-task-env
+++ b/bin/rose-task-env
@@ -121,9 +121,9 @@
 #
 # USAGE IN SUITES
 #     rose task-env can be used to make environment variables available to a
-#     suite by defining its suite.rc environment scripting option as:
+#     suite by defining its suite.rc env-script option as:
 #
-#     environment scripting = "eval $(rose task-env)"
+#     env-script = "eval $(rose task-env)"
 #
 #-------------------------------------------------------------------------------
 exec python -m rose.task_env "$@"

--- a/doc/etc/rose-rug-advanced-tutorials-rose-stem/src/suite.rc.html
+++ b/doc/etc/rose-rug-advanced-tutorials-rose-stem/src/suite.rc.html
@@ -94,12 +94,12 @@
 [runtime]
 # Root, inherited by everything
     [[root]]
-        initial scripting = """
+        init-script = """
 export CYLC_VERSION={{CYLC_VERSION}}
 export ROSE_VERSION={{ROSE_VERSION}}
 """
         script = rose task-run --verbose
-        environment scripting = eval $(rose task-env)
+        env-script = eval $(rose task-env)
         [[[events]]]
             mail events = submission retry, submission failed, submission timeout, \
                           retry, failed, execution timeout

--- a/doc/etc/rose-rug-advanced-tutorials-suite-date-time/suite.rc.html
+++ b/doc/etc/rose-rug-advanced-tutorials-suite-date-time/suite.rc.html
@@ -64,7 +64,7 @@
         script = sleep 5
     [[arrival]]
     [[assign_gate]]
-        environment scripting = eval $(rose task-env)
+        env-script = eval $(rose task-env)
         script = """
              GATE="A"$((RANDOM%3))
              echo "GATE=$GATE" &gt; $ROSE_DATAC/flight_gate

--- a/doc/rose-command.html
+++ b/doc/rose-command.html
@@ -2648,10 +2648,10 @@ launcher-preopts.mpiexec=-n $NPROC
     <h3>USAGE IN SUITES</h3>
 
     <p><kbd>rose task-env</kbd> can be used to make environment variables
-    available to a suite by defining its suite.rc <var>environment
-    scripting</var> option as:</p>
+    available to a suite by defining its suite.rc <var>env-script</var>
+    option as:</p>
     <pre>
-environment scripting = "eval $(rose task-env)"
+env-script = "eval $(rose task-env)"
 </pre>
 
     <h2 id="rose-task-run">rose task-run</h2>

--- a/doc/rose-rug-advanced-tutorials-arch.html
+++ b/doc/rose-rug-advanced-tutorials-arch.html
@@ -133,7 +133,7 @@
         graph = create_files =&gt; archive_files_rsync =&gt; archive_files_scp
 [runtime]
     [[root]]
-        environment scripting = eval $(rose task-env)
+        env-script = eval $(rose task-env)
         script = rose task-run
 </pre>
     </div>

--- a/doc/rose-rug-advanced-tutorials-clock-triggered.html
+++ b/doc/rose-rug-advanced-tutorials-clock-triggered.html
@@ -134,7 +134,7 @@
         [[[events]]]
             mail events = failed
     [[bell]]
-        environment scripting = eval $(rose task-env)
+        env-script = eval $(rose task-env)
         script = yes 'bong' | head -n $(rose date -c --format=%H)
 </pre>
     </div>

--- a/doc/rose-rug-advanced-tutorials-polling.html
+++ b/doc/rose-rug-advanced-tutorials-polling.html
@@ -143,7 +143,7 @@
     [[compose_letter]]
         script = sleep 5; echo 'writing a letter to Bob...'
     [[send_letter]]
-        environment scripting = eval `rose task-env`
+        env-script = eval `rose task-env`
         script = """
 sleep 5
 echo 'Hello Bob' &gt; $ROSE_DATA/letter.txt
@@ -159,7 +159,7 @@ sleep 10
     [[bob]]
         script = rose task-run
     [[read_letter]]
-        environment scripting = eval `rose task-env`
+        env-script = eval `rose task-env`
         script = sleep 5; cat $ROSE_DATA/letter.txt
         post-script = rm $ROSE_DATA/letter.txt
 </pre>

--- a/doc/rose-rug-advanced-tutorials-suite-date-time.html
+++ b/doc/rose-rug-advanced-tutorials-suite-date-time.html
@@ -120,7 +120,7 @@
       <p><samp>assign_gate</samp> gets a random gate number and writes it to a
       file (<samp>flight_gates</samp>). It uses the Rose environment variable
       <samp>ROSE_DATAC</samp> provided by <code>rose task-env</code> in the
-      <samp>environment scripting</samp> runtime section. This points to a data
+      <samp>env-script</samp> runtime section. This points to a data
       directory for this particular cycle time, where the file will be
       written.</p>
     </div>
@@ -133,7 +133,7 @@
       runtime section of the <samp>suite.rc</samp> file:</p>
       <pre class="prettyprint lang-cylc">
     [[startup]]
-        environment scripting = eval $(rose task-env --cycle-offset=PT12H)
+        env-script = eval $(rose task-env --cycle-offset=PT12H)
         script = """
             GATE="A"$((RANDOM%3))
             echo "GATE=$GATE" &gt; $ROSE_DATACPT12H/flight_gate
@@ -168,12 +168,12 @@
       <p>Rose will give us the environment variable for the last cycle's data
       directory, if we ask for it.</p>
 
-      <p>We need to use the same <samp>environment scripting</samp> option, but
+      <p>We need to use the same <samp>env-script</samp> option, but
       with a <samp>--cycle-offset=PT12H</samp> option - add this to your
       <samp>[[boarding]]</samp> runtime section:</p>
       <pre class="prettyprint lang-cylc">
     [[boarding]]
-        environment scripting = eval $(rose task-env --cycle-offset=PT12H)
+        env-script = eval $(rose task-env --cycle-offset=PT12H)
 </pre>
     </div>
 

--- a/doc/rose-rug-suite-writing-tutorial.html
+++ b/doc/rose-rug-suite-writing-tutorial.html
@@ -832,7 +832,7 @@ rose suite-log
     <div class="slide">
       <h3 id="scripts">Adding a Script</h3>
 
-      <p>It isn't necessary to put all scripting in an app or in the
+      <p>It isn't necessary to put all commands in an app or in the
       <samp>script</samp> in the <samp>suite.rc</samp> - you can put
       scripts in the <samp>bin/</samp> directory of a suite, and they will be
       added to cylc's path.</p>

--- a/doc/rose-rug-suites-I.html
+++ b/doc/rose-rug-suites-I.html
@@ -208,7 +208,7 @@
 
         <li>Task environment</li>
 
-        <li>Task scripting</li>
+        <li>Task scripts</li>
       </ul>
     </div>
 

--- a/doc/rose-rug-suites-II.html
+++ b/doc/rose-rug-suites-II.html
@@ -347,7 +347,7 @@
       "http://cylc.github.io/cylc/html/single/cug-html.html">cylc User
       Guide</a>. Note: to reference Rose environment variables in your
       <samp>suite.rc</samp> file, you'll need to use <code>rose task-env</code>
-      in the <samp>environment scripting</samp> runtime setting (tutorial
+      in the <samp>env-script</samp> runtime setting (tutorial
       <a href="rose-rug-advanced-tutorials-suite-date-time.html">here</a>).</p>
     </div>
 

--- a/etc/rose-rug-simple/suite.rc
+++ b/etc/rose-rug-simple/suite.rc
@@ -1,8 +1,9 @@
 #!jinja2
 [cylc]
     UTC mode=True
+    abort if any task fails = True
     [[event hooks]]
-        timeout handler=rose suite-hook --shutdown
+        abort on timeout = True
         timeout=PT2M
 
 [scheduling]
@@ -14,9 +15,5 @@
 
 [runtime]
     [[root]]
-        command scripting=rose task-run
-        [[[event hooks]]]
-            succeeded handler=rose suite-hook
-            failed handler=rose suite-hook --shutdown
-            submission failed handler=rose suite-hook --shutdown
+        script=rose task-run
     [[hello]]

--- a/t/rose-ana/00-run-basic/suite.rc
+++ b/t/rose-ana/00-run-basic/suite.rc
@@ -17,23 +17,23 @@ UTC mode=True
 
 [runtime]
     [[rose_ana_t1]]
-        command scripting = rose task-run -v -v --debug
+        script = rose task-run -v -v --debug
 
     [[rose_ana_t2_activated]]
-        command scripting = rose task-run -v -v --debug --app-key=rose_ana_t2
+        script = rose task-run -v -v --debug --app-key=rose_ana_t2
 
     [[rose_ana_t2_deactivated]]
-        command scripting = rose task-run -v -v --debug --app-key=rose_ana_t2 --opt-conf-key=deactivate
+        script = rose task-run -v -v --debug --app-key=rose_ana_t2 --opt-conf-key=deactivate
 
     [[rose_ana_t3_within_tolerance]]
-        command scripting = rose task-run -v -v --debug --app-key=rose_ana_t3
+        script = rose task-run -v -v --debug --app-key=rose_ana_t3
         [[[environment]]]
             TOLERANCE=10%
 
     [[rose_ana_t3_outside_tolerance]]
-        command scripting = rose task-run -v -v --debug --app-key=rose_ana_t3
+        script = rose task-run -v -v --debug --app-key=rose_ana_t3
         [[[environment]]]
             TOLERANCE=2%
 
     [[db_check]]
-        command scripting = rose task-run -v -v --debug
+        script = rose task-run -v -v --debug

--- a/t/rose-cli-bash-completion/01-suite-running/suite.rc
+++ b/t/rose-cli-bash-completion/01-suite-running/suite.rc
@@ -13,7 +13,7 @@ my_task_1
 [runtime]
     [[root]]
     [[my_task_1]]
-        command scripting = """
+        script = """
 while [[ ! -e $CYLC_SUITE_RUN_DIR/flag ]]; do
     sleep 1
 done

--- a/t/rose-macro/10-trigger-check.t
+++ b/t/rose-macro/10-trigger-check.t
@@ -1008,6 +1008,7 @@ __META_CONFIG__
 run_pass "$TEST_KEY" rose macro --config=../config rose.macros.DefaultValidators
 file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+teardown
 #-------------------------------------------------------------------------------
 # Check ignored mid-level trigger status handling.
 # Old bug behaviour was strongly dependent on exact ordering and naming.

--- a/t/rose-stem/00-run-basic/suite.rc
+++ b/t/rose-stem/00-run-basic/suite.rc
@@ -12,7 +12,7 @@
 
 [runtime]
     [[root]]
-        command scripting = """
+        script = """
 echo RUN_NAMES={{RUN_NAMES}}
 echo SOURCE_FOO={{SOURCE_FOO}}
 echo SOURCE_FOO_BASE={{SOURCE_FOO_BASE}}

--- a/t/rose-suite-clean/02-only-1/suite.rc
+++ b/t/rose-suite-clean/02-only-1/suite.rc
@@ -12,7 +12,7 @@ my_task_2
 
 [runtime]
     [[root]]
-        command scripting = true
+        script = true
     [[my_task_1]]
 {% if HOST is defined %}
     [[my_task_2]]

--- a/t/rose-suite-clean/03-only-2/suite.rc
+++ b/t/rose-suite-clean/03-only-2/suite.rc
@@ -15,8 +15,8 @@ my_task_2
 
 [runtime]
     [[root]]
-        environment scripting = eval $(rose task-env)
-        command scripting = """
+        env-script = eval $(rose task-env)
+        script = """
 mkdir -p "$ROSE_SUITE_DIR/etc" || true
 mkdir -p "$ROSE_SUITE_DIR/etc/$ROSE_TASK_CYCLE_TIME" || true
 for ITEM in 'hello-world.out:Hello World' 'greet-earth.out:Greet Earth'; do

--- a/t/rose-suite-hook/00-shutdown/suite.rc
+++ b/t/rose-suite-hook/00-shutdown/suite.rc
@@ -22,6 +22,6 @@ my_task_2
            submission timeout=1
            execution timeout=1
     [[my_task_1]]
-        command scripting=false
+        script=false
     [[my_task_2]]
-        command scripting=true
+        script=true

--- a/t/rose-suite-hook/01-job-host/suite.rc
+++ b/t/rose-suite-hook/01-job-host/suite.rc
@@ -21,6 +21,6 @@ my_task_1
            submission timeout = 1
            execution timeout  = 1
     [[my_task_1]]
-        command scripting = "echo 'Hello World' >$CYLC_TASK_LOG_ROOT.txt"
+        script = "echo 'Hello World' >$CYLC_TASK_LOG_ROOT.txt"
         [[[remote]]]
             host = "`rose host-select {{HOST}}`"

--- a/t/rose-suite-hook/03-mail/suite.rc
+++ b/t/rose-suite-hook/03-mail/suite.rc
@@ -6,4 +6,4 @@
         graph=t1
 [runtime]
     [[t1]]
-        command scripting=true
+        script=true

--- a/t/rose-suite-hook/04-mail-bad/suite.rc
+++ b/t/rose-suite-hook/04-mail-bad/suite.rc
@@ -4,4 +4,4 @@
         graph = foo
 [runtime]
     [[foo]]
-        command scripting = "sleep 100"
+        script = "sleep 100"

--- a/t/rose-suite-log/00-update-task/suite.rc
+++ b/t/rose-suite-log/00-update-task/suite.rc
@@ -13,7 +13,7 @@ my_task_2
 
 [runtime]
     [[root]]
-        command scripting = echo Hello
+        script = echo Hello
         [[[event hooks]]]
             failed handler = rose suite-hook --shutdown --retrieve-job-logs
             submission failed handler = rose suite-hook --shutdown

--- a/t/rose-suite-log/01-update-cycle/suite.rc
+++ b/t/rose-suite-log/01-update-cycle/suite.rc
@@ -16,7 +16,7 @@ my_task_2
 
 [runtime]
     [[root]]
-        command scripting = echo Hello
+        script = echo Hello
         [[[event hooks]]]
             failed handler = rose suite-hook --shutdown --retrieve-job-logs
             submission failed handler = rose suite-hook --shutdown

--- a/t/rose-suite-log/02-update-force/suite.rc
+++ b/t/rose-suite-log/02-update-force/suite.rc
@@ -16,7 +16,7 @@ my_task_2
 
 [runtime]
     [[root]]
-        command scripting = "echo Hello"
+        script = "echo Hello"
         [[[event hooks]]]
             failed handler = "rose suite-hook --shutdown --retrieve-job-logs"
             submission failed handler = "rose suite-hook --shutdown"

--- a/t/rose-suite-restart/01-running/suite.rc
+++ b/t/rose-suite-restart/01-running/suite.rc
@@ -3,7 +3,7 @@
         graph = foo
 [runtime]
     [[foo]]
-        command scripting = """
+        script = """
 touch 'file'
 timeout 60 bash -c 'while test -e "file"; do sleep 1; done'
 """

--- a/t/rose-suite-restart/02-basic/suite.rc
+++ b/t/rose-suite-restart/02-basic/suite.rc
@@ -3,6 +3,6 @@
         graph = "t1 => t2"
 [runtime]
     [[t1]]
-        command scripting = cylc stop "${CYLC_SUITE_NAME}"
+        script = cylc stop "${CYLC_SUITE_NAME}"
     [[t2]]
-        command scripting = true
+        script = true

--- a/t/rose-suite-run/00-run-basic/suite.rc
+++ b/t/rose-suite-run/00-run-basic/suite.rc
@@ -13,7 +13,7 @@
 
 [runtime]
     [[root]]
-        command scripting = """
+        script = """
 I=0
 OLD_I=
 while [[ ! -e $CYLC_SUITE_RUN_DIR/flag ]]; do

--- a/t/rose-suite-run/02-install/suite.rc
+++ b/t/rose-suite-run/02-install/suite.rc
@@ -15,7 +15,7 @@ my_task_1
 
 [runtime]
     [[root]]
-        command scripting = """rose task-run"""
+        script = """rose task-run"""
         [[[event hooks]]]
            succeeded handler = "rose suite-hook"
            failed handler = "rose suite-hook --shutdown"

--- a/t/rose-suite-run/05-log/suite.rc
+++ b/t/rose-suite-run/05-log/suite.rc
@@ -13,4 +13,4 @@
 
 [runtime]
     [[my_task_1]]
-        command scripting = true
+        script = true

--- a/t/rose-suite-run/06-opt-conf/suite.rc
+++ b/t/rose-suite-run/06-opt-conf/suite.rc
@@ -12,5 +12,5 @@ my_task_1
 
 [runtime]
     [[root]]
-        command scripting = """echo Hello \"{{WORLD}}\" 1>$CYLC_TASK_LOG_ROOT.txt"""
+        script = """echo Hello \"{{WORLD}}\" 1>$CYLC_TASK_LOG_ROOT.txt"""
     [[my_task_1]]

--- a/t/rose-suite-run/08-pgrep/suite.rc
+++ b/t/rose-suite-run/08-pgrep/suite.rc
@@ -10,5 +10,5 @@
 
 [runtime]
     [[root]]
-        command scripting=false
+        script=false
     [[my_task_1]]

--- a/t/rose-suite-run/10-import-1/hello/suite.rc
+++ b/t/rose-suite-run/10-import-1/hello/suite.rc
@@ -17,7 +17,7 @@ hello_{{world}}
 
 [runtime]
     [[root]]
-        command scripting=rose task-run --debug --app-key=hello
+        script=rose task-run --debug --app-key=hello
         [[[environment]]]
             HELLO={{hello|default("hello")}}
         [[[event hooks]]]

--- a/t/rose-suite-run/12-run-dir-root/suite.rc
+++ b/t/rose-suite-run/12-run-dir-root/suite.rc
@@ -16,7 +16,7 @@ my_task_2
 
 [runtime]
 [[root]]
-command scripting=true
+script=true
 [[my_task_1]]
 {% if JOB_HOST is defined %}
 [[my_task_2]]

--- a/t/rose-suite-run/13-ignore-cylc-version/suite.rc
+++ b/t/rose-suite-run/13-ignore-cylc-version/suite.rc
@@ -9,4 +9,4 @@ timeout=2
 graph=t1
 [runtime]
 [[t1]]
-command scripting=false
+script=false

--- a/t/rose-suite-run/14-reload-null/suite.rc
+++ b/t/rose-suite-run/14-reload-null/suite.rc
@@ -12,4 +12,4 @@ final cycle point=2013010112
 graph="""t1[T-12]=>t1"""
 [runtime]
 [[t1]]
-command scripting=rose task-run {{ROSE_TASK_RUN_ARGS}}
+script=rose task-run {{ROSE_TASK_RUN_ARGS}}

--- a/t/rose-suite-run/16-suite-rc-not-writable/suite.rc
+++ b/t/rose-suite-run/16-suite-rc-not-writable/suite.rc
@@ -9,4 +9,4 @@
         graph=t1
 [runtime]
     [[t1]]
-        command scripting=true
+        script=true

--- a/t/rose-suite-run/17-install-overlap/suite.rc
+++ b/t/rose-suite-run/17-install-overlap/suite.rc
@@ -9,4 +9,4 @@
         graph=t1
 [runtime]
     [[t1]]
-        command scripting=true
+        script=true

--- a/t/rose-suite-run/18-restart-init-dir/suite.rc
+++ b/t/rose-suite-run/18-restart-init-dir/suite.rc
@@ -9,4 +9,4 @@
         graph=t1
 [runtime]
     [[t1]]
-        command scripting=true
+        script=true

--- a/t/rose-suite-run/19-restart-init-dir-remote/suite.rc
+++ b/t/rose-suite-run/19-restart-init-dir-remote/suite.rc
@@ -9,6 +9,6 @@
         graph=t1
 [runtime]
     [[t1]]
-        command scripting=true
+        script=true
         [[[remote]]]
             host={{T_HOST}}

--- a/t/rose-suite-run/20-pgrep-conflict/suite.rc
+++ b/t/rose-suite-run/20-pgrep-conflict/suite.rc
@@ -3,4 +3,4 @@
         graph = "foo"
 [runtime]
     [[foo]]
-        command scripting = true
+        script = true

--- a/t/rose-suite-run/21-sharecycle-back-compat/suite.rc
+++ b/t/rose-suite-run/21-sharecycle-back-compat/suite.rc
@@ -12,4 +12,4 @@
             graph = t1
 [runtime]
     [[t1]]
-        command scripting = rose task-run
+        script = rose task-run

--- a/t/rose-suite-run/22-sharecycle/suite.rc
+++ b/t/rose-suite-run/22-sharecycle/suite.rc
@@ -12,4 +12,4 @@
             graph = t1
 [runtime]
     [[t1]]
-        command scripting = rose task-run
+        script = rose task-run

--- a/t/rose-suite-scan/00-localhost/suite.rc
+++ b/t/rose-suite-scan/00-localhost/suite.rc
@@ -13,7 +13,7 @@ my_task_1
 [runtime]
     [[root]]
     [[my_task_1]]
-        command scripting = """
+        script = """
 while [[ ! -e $CYLC_SUITE_RUN_DIR/flag ]]; do
     sleep 1
 done

--- a/t/rose-suite-shutdown/00-run-basic/suite.rc
+++ b/t/rose-suite-shutdown/00-run-basic/suite.rc
@@ -10,5 +10,5 @@
 
 [runtime]
     [[root]]
-        command scripting=false
+        script=false
     [[my_task_1]]

--- a/t/rose-task-env/00-non-cycle/suite.rc
+++ b/t/rose-task-env/00-non-cycle/suite.rc
@@ -9,8 +9,8 @@
         graph = t1
 [runtime]
     [[t1]]
-        environment scripting = eval $(rose task-env)
-        command scripting = rose task-run -v
+        env-script = eval $(rose task-env)
+        script = rose task-run -v
         [[[event hooks]]]
            succeeded handler = rose suite-hook
            failed handler = rose suite-hook --shutdown

--- a/t/rose-task-env/01-integer-cycling/suite.rc
+++ b/t/rose-task-env/01-integer-cycling/suite.rc
@@ -22,6 +22,6 @@
            submission timeout = PT10S
            execution timeout = PT30S
     [[foo]]
-        environment scripting = eval $(rose task-env -T P1 -T __P5)
-        command scripting = rose task-run -v
+        env-script = eval $(rose task-env -T P1 -T __P5)
+        script = rose task-run -v
 

--- a/t/rose-task-run/00-run-basic/suite.rc
+++ b/t/rose-task-run/00-run-basic/suite.rc
@@ -15,7 +15,7 @@ my_task_1
 
 [runtime]
     [[root]]
-        command scripting = """
+        script = """
 rose task-run --debug --cycle-offset=T12H --path=MY_PATH='etc/my-path/*'
 """
         [[[event hooks]]]

--- a/t/rose-task-run/01-run-basic-iso/suite.rc
+++ b/t/rose-task-run/01-run-basic-iso/suite.rc
@@ -13,7 +13,7 @@
 
 [runtime]
     [[root]]
-        command scripting = """
+        script = """
 rose task-run --debug --cycle-offset=PT12H --path=MY_PATH='etc/my-path/*'
 """
         [[[event hooks]]]

--- a/t/rose-task-run/02-env-basic/suite.rc
+++ b/t/rose-task-run/02-env-basic/suite.rc
@@ -15,10 +15,10 @@ my_task_1
 
 [runtime]
     [[root]]
-        environment scripting = """
+        env-script = """
 eval $(rose task-env --cycle-offset=T12H --path=MY_PATH='etc/my-path/*')
 """
-        command scripting = """rose task-run --path=MY_PATH='etc/your-path'"""
+        script = """rose task-run --path=MY_PATH='etc/your-path'"""
         [[[event hooks]]]
            succeeded handler = "rose suite-hook"
            failed handler = "rose suite-hook --shutdown"

--- a/t/rose-task-run/03-env-basic-iso/suite.rc
+++ b/t/rose-task-run/03-env-basic-iso/suite.rc
@@ -13,10 +13,10 @@
 
 [runtime]
     [[root]]
-        environment scripting = """
+        env-script = """
 eval $(rose task-env --cycle-offset=PT12H --path=MY_PATH='etc/my-path/*')
 """
-        command scripting = rose task-run --path=MY_PATH='etc/your-path'
+        script = rose task-run --path=MY_PATH='etc/your-path'
         [[[event hooks]]]
            succeeded handler = rose suite-hook
            failed handler = rose suite-hook --shutdown

--- a/t/rose-task-run/04-run-path-empty/suite.rc
+++ b/t/rose-task-run/04-run-path-empty/suite.rc
@@ -24,8 +24,8 @@ install => my_task_1
            submission timeout = PT1M
            execution timeout  = PT1M
     [[install]]
-        command scripting = """rose task-run"""
+        script = """rose task-run"""
     [[my_task_1]]
-        command scripting = """
+        script = """
 rose task-run --path= --path=etc/your-path
 """

--- a/t/rose-task-run/05-app-prune-compat/suite.rc
+++ b/t/rose-task-run/05-app-prune-compat/suite.rc
@@ -21,7 +21,7 @@ cold | WARM[T-12]:finish-all => rose_prune
 
 [runtime]
     [[root]]
-        command scripting = "rose task-run"
+        script = "rose task-run"
         [[[event hooks]]]
             succeeded handler = "rose suite-hook"
             failed handler = "rose suite-hook"
@@ -31,7 +31,7 @@ cold | WARM[T-12]:finish-all => rose_prune
             submission timeout = 1
             execution timeout  = 1
     [[cold]]
-        command scripting = "true"
+        script = "true"
     [[WARM]]
     [[my_task_1]]
         inherit = WARM
@@ -43,6 +43,6 @@ cold | WARM[T-12]:finish-all => rose_prune
 {% endif %}
     [[rose_prune]]
         inherit = WARM
-        command scripting = """
+        script = """
 rose task-run --debug | tee -a $CYLC_SUITE_RUN_DIR/prune.log
 """

--- a/t/rose-task-run/06-app-prune-iso/suite.rc
+++ b/t/rose-task-run/06-app-prune-iso/suite.rc
@@ -19,7 +19,7 @@ WARM[-PT12H]:finish-all => rose_prune
 
 [runtime]
     [[root]]
-        command scripting = rose task-run
+        script = rose task-run
         [[[event hooks]]]
             succeeded handler = rose suite-hook
             failed handler = rose suite-hook
@@ -29,7 +29,7 @@ WARM[-PT12H]:finish-all => rose_prune
             submission timeout = PT1M
             execution timeout  = PT1M
     [[cold]]
-        command scripting = true
+        script = true
     [[WARM]]
     [[my_task_1]]
         inherit = WARM
@@ -41,6 +41,6 @@ WARM[-PT12H]:finish-all => rose_prune
 {% endif %}
     [[rose_prune]]
         inherit = WARM
-        command scripting = """
+        script = """
 rose task-run --debug | tee -a $CYLC_SUITE_RUN_DIR/prune.log
 """

--- a/t/rose-task-run/07-app-arch/suite.rc
+++ b/t/rose-task-run/07-app-arch/suite.rc
@@ -23,7 +23,7 @@ archive[T-12] => archive
 
 [runtime]
     [[root]]
-        command scripting="""
+        script="""
 RC=0
 rose task-run --debug || RC=$?
 """
@@ -37,7 +37,7 @@ rose task-run --debug || RC=$?
             submission timeout=1
             execution timeout=1
     [[archive]]
-        post-command scripting="""
+        post-script="""
 {
 sqlite3 .rose-arch.db 'SELECT * FROM targets;' | sort
 sqlite3 .rose-arch.db 'SELECT * FROM sources;' | sort
@@ -45,7 +45,7 @@ sqlite3 .rose-arch.db 'SELECT * FROM sources;' | sort
 ((RC==0))
 """
     [[ARCHIVE_BAD]]
-        command scripting = """rose task-run || true; RC=$?"""
+        script = """rose task-run || true; RC=$?"""
         retry delays=0
 {% for bad_num in bad_nums %}
     [[archive_bad_{{bad_num}}]]

--- a/t/rose-task-run/08-app-fcm-make/suite.rc
+++ b/t/rose-task-run/08-app-fcm-make/suite.rc
@@ -17,7 +17,7 @@ fcm_make_t5 => fcm_make2_t5 # mirror
 """
 [runtime]
 [[root]]
-command scripting=rose task-run -v -v --debug
+script=rose task-run -v -v --debug
 [[[event hooks]]]
 succeeded handler=rose suite-hook
 failed handler=rose suite-hook --shutdown

--- a/t/rose-task-run/09-app-prune-work/suite.rc
+++ b/t/rose-task-run/09-app-prune-work/suite.rc
@@ -24,8 +24,8 @@ root[T-12]:finish-all => rose_prune
             submission timeout=1
             execution timeout=1
     [[t1,t2,t3]]
-        command scripting=rose task-run --app-key=hello
+        script=rose task-run --app-key=hello
     [[rose_prune]]
-        command scripting="""
+        script="""
 rose task-run -v -v --debug | tee -a $CYLC_SUITE_RUN_DIR/prune.log
 """

--- a/t/rose-task-run/10-specify-cycle/suite.rc
+++ b/t/rose-task-run/10-specify-cycle/suite.rc
@@ -13,7 +13,7 @@
 
 [runtime]
     [[t1]]
-        command scripting=rose task-run --cycle=T12H
+        script=rose task-run --cycle=T12H
         [[[event hooks]]]
            succeeded handler=rose suite-hook
            failed handler=rose suite-hook --shutdown

--- a/t/rose-task-run/11-specify-cycle-iso/suite.rc
+++ b/t/rose-task-run/11-specify-cycle-iso/suite.rc
@@ -13,7 +13,7 @@
 
 [runtime]
     [[t1]]
-        command scripting=rose task-run --cycle=PT12H
+        script=rose task-run --cycle=PT12H
         [[[event hooks]]]
            succeeded handler=rose suite-hook
            failed handler=rose suite-hook --shutdown

--- a/t/rose-task-run/12-app-prune-integer/suite.rc
+++ b/t/rose-task-run/12-app-prune-integer/suite.rc
@@ -14,7 +14,7 @@
 
 [runtime]
     [[root]]
-        command scripting = rose task-run -v -v --debug
+        script = rose task-run -v -v --debug
         [[[event hooks]]]
            succeeded handler            = rose suite-hook
            failed handler               = rose suite-hook

--- a/t/rose-task-run/13-app-arch-cmd-out/suite.rc
+++ b/t/rose-task-run/13-app-arch-cmd-out/suite.rc
@@ -10,7 +10,7 @@
 
 [runtime]
     [[archive]]
-        command scripting=rose task-run --debug
+        script=rose task-run --debug
         [[[event hooks]]]
             succeeded handler=rose suite-hook
             failed handler=rose suite-hook --shutdown

--- a/t/rose-task-run/14-app-prune-remove/suite.rc
+++ b/t/rose-task-run/14-app-prune-remove/suite.rc
@@ -13,7 +13,7 @@
 
 [runtime]
     [[root]]
-        command scripting = rose task-run -v -v --debug
+        script = rose task-run -v -v --debug
         [[[event hooks]]]
            succeeded handler            = rose suite-hook
            failed handler               = rose suite-hook

--- a/t/rose-task-run/15-app-prune-extglob/suite.rc
+++ b/t/rose-task-run/15-app-prune-extglob/suite.rc
@@ -24,12 +24,12 @@ creator[-P1D] => pruner => creator
             submission timeout=PT1M
             execution timeout=PT1M
     [[creator]]
-        command scripting=rose task-run
+        script=rose task-run
 {% if JOB_HOST is defined %}
         [[[remote]]]
             host = {{JOB_HOST}}
 {% endif %}
     [[pruner]]
-        command scripting="""
+        script="""
 rose task-run -v -v --debug | tee -a "${CYLC_SUITE_RUN_DIR}/prune.log"
 """

--- a/t/rose-task-run/16-app-prune-point/suite.rc
+++ b/t/rose-task-run/16-app-prune-point/suite.rc
@@ -28,12 +28,12 @@ t1[1970] & t1[1980] => pruner
             submission timeout=PT1M
             execution timeout=PT1M
     [[t1]]
-        command scripting="""
+        script="""
 mkdir -p "${CYLC_SUITE_RUN_DIR}/var/${CYLC_TASK_CYCLE_POINT}"
 cd "${CYLC_SUITE_RUN_DIR}/var/${CYLC_TASK_CYCLE_POINT}"
 echo 'garbage' | tee 'a.file' 'b.file' 'c.file' >'/dev/null'
 """
     [[pruner]]
-        command scripting="""
+        script="""
 rose task-run -v -v --debug | tee -a "${CYLC_SUITE_RUN_DIR}/prune.log"
 """

--- a/t/rose-task-run/17-app-prune-glob-as-cycle-fmt/suite.rc
+++ b/t/rose-task-run/17-app-prune-glob-as-cycle-fmt/suite.rc
@@ -28,13 +28,13 @@ t1[1970] => pruner
             submission timeout=PT1M
             execution timeout=PT1M
     [[t1]]
-        command scripting="""
+        script="""
 cd "${CYLC_SUITE_RUN_DIR}/share"
 for NAME in 'earth' 'mars' 'venus'; do
     echo 'garbage' >"hello-${NAME}-at-${CYLC_TASK_CYCLE_POINT}.txt"
 done
 """
     [[pruner]]
-        command scripting="""
+        script="""
 rose task-run -v -v --debug | tee -a "${CYLC_SUITE_RUN_DIR}/prune.log"
 """

--- a/t/rose-task-run/31-app-bunch/suite.rc
+++ b/t/rose-task-run/31-app-bunch/suite.rc
@@ -14,7 +14,7 @@
 
 [runtime]
     [[root]]
-        command scripting=rose task-run -v -v --debug
+        script=rose task-run -v -v --debug
         [[[event hooks]]]
             succeeded handler          = rose suite-hook
             failed handler             = rose suite-hook
@@ -46,4 +46,4 @@
             POOL_SIZE=1
             
     [[dummy]]
-        command scripting = true
+        script = true

--- a/t/rose-task-run/37-app-bunch-rm-old/suite.rc
+++ b/t/rose-task-run/37-app-bunch-rm-old/suite.rc
@@ -13,7 +13,7 @@
 
 [runtime]
     [[root]]
-        command scripting=rose task-run -v -v --debug
+        script=rose task-run -v -v --debug
         [[[event hooks]]]
             succeeded handler          = rose suite-hook
             failed handler             = rose suite-hook


### PR DESCRIPTION
Plus:
* 1 instance of `post-script` from `post-command scripting`.
* Improve rose-rug-simple `suite.rc`.
* Run `teardown` before the final set of tests under `t/rose-macro/10-trigger-check.t`.

@arjclark @oliver-sanders please review.