### PR TITLE
clock trigger tutorial: Add a final cycle point offset

### DIFF
--- a/doc/rose-rug-advanced-tutorials-clock-triggered.html
+++ b/doc/rose-rug-advanced-tutorials-clock-triggered.html
@@ -125,6 +125,7 @@
     UTC mode = True # Ignore DST
 [scheduling]
     initial cycle point = <span id="cylc-time"></span>
+    final cycle point = +P1D # Run for one day
     [[dependencies]]
         [[[PT1H]]]
             graph = bell


### PR DESCRIPTION
Adds a final cycle point offset of +P1D to the clock triggered tutorial.

Reasoning: we've seen people leave this suite running and forget about it on several occasions now, this just means it'll shutdown after a day's worth of cycling rather than running forever.

@matthewrmshin - please review. As original tutorial author I don't think this needs a second review but feel free to assign one if you see fit. 