### PR TITLE
rose date: enable --as-total option when printing durations

### DIFF
--- a/bin/rose-date
+++ b/bin/rose-date
@@ -52,7 +52,8 @@
 #
 #     # 3.  Convert ISO8601 duration
 #     # 3.1 Into the total number of hours (H), minutes (M) or seconds (S)
-#     #     it represents
+#     #     it represents, preceed negative durations with a double backslash
+#     #     (e.g. \\-PT1H)
 #     rose date --as-total=s PT1H
 #
 # DESCRIPTION

--- a/doc/rose-command.html
+++ b/doc/rose-command.html
@@ -982,7 +982,8 @@ rose date 19700101T000000Z 20380119T031407Z
 
 # 3.  Convert ISO8601 duration
 # 3.1 Into the total number of hours (H), minutes(M) or seconds (S)
-#     it represents
+#     it represents, preceed negative durations with a double backslash
+#     (e.g. \\-PT1H)
 rose date --as-total=s PT1H
 </pre>
 

--- a/lib/python/rose/date.py
+++ b/lib/python/rose/date.py
@@ -395,7 +395,8 @@ def _print_duration(date_time_oper, opts, args):
 
 def _convert_duration(date_time_oper, opts, args):
     """Implement usage 3 of "rose date", convert ISO8601 duration."""
-    time_in_8601 = date_time_oper.duration_parser.parse(args[0])
+    time_in_8601 = date_time_oper.duration_parser.parse(
+        args[0].replace('\\', ''))  # allows parsing of negative durations
     time = time_in_8601.get_seconds()
     options = {'S': time, 'M': time / 60, 'H': time / 3600}
     if opts.duration_print_format.upper() in options:

--- a/lib/python/rose/date.py
+++ b/lib/python/rose/date.py
@@ -386,7 +386,11 @@ def _print_duration(date_time_oper, opts, args):
         for offset in opts.offsets2:
             time_point_2 = date_time_oper.date_shift(time_point_2, offset)
     duration, sign = date_time_oper.date_diff(time_point_1, time_point_2)
-    print date_time_oper.date_diff_format(opts.print_format, duration, sign)
+    out = date_time_oper.date_diff_format(opts.print_format, duration, sign)
+    if opts.duration_print_format:
+        _convert_duration(date_time_oper, opts, [out])
+        sys.exit(0)
+    print out
 
 
 def _convert_duration(date_time_oper, opts, args):
@@ -395,8 +399,7 @@ def _convert_duration(date_time_oper, opts, args):
     time = time_in_8601.get_seconds()
     options = {'S': time, 'M': time / 60, 'H': time / 3600}
     if opts.duration_print_format.upper() in options:
-        # supplied duration format is valid (upper removes
-        # case-sensitivity)
+        # supplied duration format is valid (upper removes case-sensitivity)
         print options[opts.duration_print_format.upper()]
     else:
         # supplied duration format not valid

--- a/t/rose-date/00-basic.t
+++ b/t/rose-date/00-basic.t
@@ -21,7 +21,7 @@
 #-------------------------------------------------------------------------------
 . $(dirname $0)/test_header
 #-------------------------------------------------------------------------------
-tests 107
+tests 111
 #-------------------------------------------------------------------------------
 # Produce the correct format for the current date/time.
 TEST_KEY=$TEST_KEY_BASE-current-format
@@ -329,5 +329,19 @@ __OUT__
 # Test rose date --as-total=FORMAT fails for invalid format
 TEST_KEY=$TEST_KEY_BASE-as-total-invalid-format
 run_fail "$TEST_KEY" rose date --as-total=y PT1M
+#-------------------------------------------------------------------------------
+# Test rose date --as-total=FORMAT for use case 2
+TEST_KEY=$TEST_KEY_BASE-as-total-between-dates
+run_pass "$TEST_KEY" rose date 2000-01-01T00:00:00 2000-01-01T01:00:00 --as-total=s
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<'__OUT__'
+3600.0
+__OUT__
+#-------------------------------------------------------------------------------
+# Test rose date --as-total=FORMAT for use case 2 with an offset
+TEST_KEY=$TEST_KEY_BASE-as-total-between-dates-with-offset
+run_pass "$TEST_KEY" rose date 2000-01-01T00:00:00 --offset=PT1H 2000-01-01T01:00:00 --as-total=s
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<'__OUT__'
+0.0
+__OUT__
 #-------------------------------------------------------------------------------
 exit 0

--- a/t/rose-date/00-basic.t
+++ b/t/rose-date/00-basic.t
@@ -21,7 +21,7 @@
 #-------------------------------------------------------------------------------
 . $(dirname $0)/test_header
 #-------------------------------------------------------------------------------
-tests 111
+tests 113
 #-------------------------------------------------------------------------------
 # Produce the correct format for the current date/time.
 TEST_KEY=$TEST_KEY_BASE-current-format
@@ -329,6 +329,13 @@ __OUT__
 # Test rose date --as-total=FORMAT fails for invalid format
 TEST_KEY=$TEST_KEY_BASE-as-total-invalid-format
 run_fail "$TEST_KEY" rose date --as-total=y PT1M
+#-------------------------------------------------------------------------------
+# Test rose date --as-total=FORMAT for negative durations
+TEST_KEY=$TEST_KEY_BASE-as-total-negative
+run_pass "$TEST_KEY" rose date --as-total=S \\-PT1M1S
+file_cmp "TEST_KEY.out" "$TEST_KEY.out" <<'__OUT__'
+-61.0
+__OUT__
 #-------------------------------------------------------------------------------
 # Test rose date --as-total=FORMAT for use case 2
 TEST_KEY=$TEST_KEY_BASE-as-total-between-dates


### PR DESCRIPTION
Improvement on #1806 

At pressent the `--as-total=FORMAT` option only works when provided with a duration as in use case 3
- e.g: `rose date --as-total=S PT1H`

This change enables the option to be used when printing a duration as in use case 2
- e.g.: `rose date date1 date2 --as-total=M`

@matthewrmshin Please Review
@benfitzpatrick Please Review