### PR TITLE
rose.app_run: increase pylint score

### DIFF
--- a/doc/rose-configuration.html
+++ b/doc/rose-configuration.html
@@ -595,8 +595,8 @@ root-dir=hpc*=$WORKDIR
         <p>Files in this directory are copied to the working directory in run
         time.</p>
 
-        <p>Note: If there is a clash between a <var>[file:*]</var> section and a
-        file under <var>file/</var>, the setting in the <var>[file:*]</var>
+        <p>Note: If there is a clash between a <var>[file:*]</var> section and
+        a file under <var>file/</var>, the setting in the <var>[file:*]</var>
         section takes precedence. E.g. Suppose we have a file
         <samp>file/hello.txt</samp>. In the absence of
         <samp>[file:hello.txt]</samp>, it will copy <samp>file/hello.txt</samp>
@@ -774,22 +774,24 @@ file-test=test -e {} &amp;&amp; grep -q 'hello' {}
         be performed a number of times with delays between them. If the
         prerequisites are still not met after the number of delays, the
         application runner will fail with a time out. The list is a
-        comma-separated list. The syntax looks like <var>[R*]T[U]</var>, where
-        <var>U</var> is a unit (<kbd>s</kbd> for seconds (default),
-        <kbd>m</kbd> for minutes and <kbd>h</kbd> for hours), <var>T</var> is
-        the number of units. E.g.:</p>
+        comma-separated list. The syntax looks like <var>[n*][DURATION]</var>,
+        where <var>DURATION</var> is an <a href=
+        "https://en.wikipedia.org/wiki/ISO_8601#Durations">ISO 8601
+        duration</a> such as <kbd>PT5S</kbd> (5 seconds) or <kbd>PT10M</kbd>
+        (10 minutes), and <var>n</var> is an optional number of times to repeat
+        it. E.g.:</p>
         <pre class="prettyprint lang-rose_conf">
 # Default
 delays=0
 
 # Poll 1 minute after the runner begins, repeat every minute 10 times
-delays=10*1m
+delays=10*PT1M
 
 # Poll when runner begins,
 # repeat every 10 seconds 6 times,
 # repeat every minute 60 times,
 # repeat once after 1 hour
-delays=0,6*10s,60*1m,1h
+delays=0,6*PT10S,60*PT1M,PT1H
 </pre>
       </dd>
     </dl>

--- a/lib/python/rose/app_run.py
+++ b/lib/python/rose/app_run.py
@@ -27,7 +27,7 @@ from time import localtime, sleep, strftime, time
 import traceback
 
 from isodatetime.data import get_timepoint_for_now
-from isodatetime.parsers import DurationParser, ISO8601SyntaxError
+from isodatetime.parsers import ISO8601SyntaxError
 from rose.config import ConfigDumper
 from rose.date import RoseDateTimeOperator
 from rose.env import env_var_process, UnboundEnvironmentVariableError
@@ -115,6 +115,178 @@ class PollEvent(Event):
             ok_str, strftime("%Y-%m-%dT%H:%M:%S", localtime(sec)), test)
 
 
+class Poller(object):
+
+    """Handle the [poll] functionality for AppRunner."""
+
+    OLD_DURATION_UNITS = {"h": 3600, "m": 60, "s": 1}
+
+    def __init__(self, popen, handle_event_func):
+        self.popen = popen
+        self.handle_event = handle_event_func
+        self.date_time_oper = RoseDateTimeOperator()
+
+    @staticmethod
+    def _get_tests(conf_tree):
+        """Return the poll tests configuration."""
+        poll_test = conf_tree.node.get_value(["poll", "test"])
+        poll_all_files_value = conf_tree.node.get_value(["poll", "all-files"])
+        poll_all_files = []
+        if poll_all_files_value:
+            try:
+                poll_all_files = shlex.split(
+                    env_var_process(poll_all_files_value))
+            except UnboundEnvironmentVariableError as exc:
+                raise ConfigValueError(["poll", "all-files"],
+                                       poll_all_files_value, exc)
+        poll_any_files_value = conf_tree.node.get_value(["poll", "any-files"])
+        poll_any_files = []
+        if poll_any_files_value:
+            try:
+                poll_any_files = shlex.split(
+                    env_var_process(poll_any_files_value))
+            except UnboundEnvironmentVariableError as exc:
+                raise ConfigValueError(["poll", "any-files"],
+                                       poll_any_files_value, exc)
+        poll_file_test = None
+        if poll_all_files or poll_any_files:
+            poll_file_test = conf_tree.node.get_value(["poll", "file-test"])
+            if poll_file_test and "{}" not in poll_file_test:
+                raise ConfigValueError(["poll", "file-test"], poll_file_test,
+                                       ConfigValueError.SYNTAX)
+
+        return poll_test, poll_file_test, poll_all_files, poll_any_files
+
+    def _get_delays(self, conf_tree):
+        """Return the poll delays from the configuration."""
+        # Parse something like this: delays=10,4*PT30S,PT2M30S,2*PT1H
+        # R*DURATION: repeat the value R times
+        conf_keys = ["poll", "delays"]
+        poll_delays_value = conf_tree.node.get_value(
+            conf_keys, default="").strip()
+        if not poll_delays_value:
+            return [0]  # poll once without a delay
+
+        poll_delays = []
+        is_legacy0 = None
+        for item in poll_delays_value.split(","):
+            value = item.strip()
+            repeat = 1
+            if "*" in value:
+                repeat, value = value.split("*", 1)
+                try:
+                    repeat = int(repeat)
+                except ValueError:
+                    raise ConfigValueError(conf_keys,
+                                           poll_delays_value,
+                                           ConfigValueError.SYNTAX)
+            try:
+                value = self.date_time_oper.duration_parser.parse(
+                    value).get_seconds()
+                is_legacy = False
+            except ISO8601SyntaxError:
+                # Legacy mode: nnnU
+                # nnn is a float, U is the unit
+                # No unit or s: seconds
+                # m: minutes
+                # h: hours
+                unit = None
+                if value[-1].lower() in self.OLD_DURATION_UNITS:
+                    unit = self.OLD_DURATION_UNITS[value[-1].lower()]
+                    value = value[:-1]
+                try:
+                    value = float(value)
+                except ValueError:
+                    raise ConfigValueError(conf_keys,
+                                           poll_delays_value,
+                                           ConfigValueError.SYNTAX)
+                if unit:
+                    value *= unit
+                is_legacy = True
+            if is_legacy0 is None:
+                is_legacy0 = is_legacy
+            elif is_legacy0 != is_legacy:
+                raise ConfigValueError(
+                    conf_keys,
+                    poll_delays_value,
+                    ConfigValueError.DURATION_LEGACY_MIX)
+            poll_delays += [value] * repeat
+        return poll_delays
+
+    def poll(self, conf_tree):
+        """Poll for prerequisites of applications."""
+        # Get the poll configuration.
+        poll_test, poll_file_test, poll_all_files, poll_any_files = (
+            self._get_tests(conf_tree))
+        poll_delays = []
+        if poll_test or poll_all_files or poll_any_files:
+            poll_delays = self._get_delays(conf_tree)
+
+        # Launch the polling.
+        t_init = get_timepoint_for_now()
+        poll_test, poll_any_files, poll_all_files = (
+            self._run_poll(poll_test, poll_all_files,
+                           poll_any_files, poll_delays,
+                           poll_file_test=poll_file_test)
+        )
+        t_finish = get_timepoint_for_now()
+
+        # Handle any failures.
+        failed_items = []
+        if poll_test:
+            failed_items.append("test")
+        if poll_any_files:
+            failed_items.append("any-files")
+        if poll_all_files:
+            failed_items.append("all-files:" +
+                                self.popen.list_to_shell_str(poll_all_files))
+        if failed_items:
+            now = get_timepoint_for_now()
+            raise PollTimeoutError(now, t_finish - t_init, failed_items)
+
+    def _run_poll(self, poll_test, poll_all_files, poll_any_files, poll_delays,
+                  poll_file_test=None):
+        """Poll, including waiting for delays."""
+        while poll_delays and (poll_test or poll_any_files or poll_all_files):
+            poll_delay = poll_delays.pop(0)
+            if poll_delay:
+                sleep(poll_delay)
+            if poll_test:
+                ret_code = self.popen.run(
+                    poll_test, shell=True,
+                    stdout=sys.stdout, stderr=sys.stderr)[0]
+                self.handle_event(PollEvent(time(), poll_test, ret_code == 0))
+                if ret_code == 0:
+                    poll_test = None
+            any_files = list(poll_any_files)
+            for file_ in any_files:
+                if self._poll_file(file_, poll_file_test):
+                    self.handle_event(PollEvent(time(), "any-files", True))
+                    poll_any_files = []
+                    break
+            all_files = list(poll_all_files)
+            for file_ in all_files:
+                if self._poll_file(file_, poll_file_test):
+                    poll_all_files.remove(file_)
+            if all_files and not poll_all_files:
+                self.handle_event(PollEvent(time(), "all-files", True))
+        # Return any remaining test-failing files.
+        return poll_test, poll_any_files, poll_all_files
+
+    def _poll_file(self, file_, poll_file_test):
+        """Poll for existence of a file."""
+        is_done = False
+        if poll_file_test:
+            test = poll_file_test.replace(
+                "{}", self.popen.list_to_shell_str([file_]))
+            is_done = self.popen.run(
+                test, shell=True, stdout=sys.stdout, stderr=sys.stderr)[0] == 0
+        else:
+            is_done = bool(glob(file_))
+        self.handle_event(PollEvent(time(), "file:" + file_, is_done))
+        return is_done
+
+
 class BuiltinApp(object):
 
     """An abstract base class for a builtin application.
@@ -153,7 +325,6 @@ class AppRunner(Runner):
 
     """Invoke a Rose application."""
 
-    OLD_DURATION_UNITS = {"h": 3600, "m": 60, "s": 1}
     NAME = "app"
     OPTIONS = ["app_mode", "command_key", "conf_dir", "defines",
                "install_only_mode", "new_mode", "no_overwrite_mode",
@@ -187,162 +358,17 @@ class AppRunner(Runner):
             return builtin_app.run(self, conf_tree, opts, args, uuid,
                                    work_files)
 
-    def _poll(self, conf_tree):
-        """Poll for prerequisites of applications."""
-        # Poll configuration
-        poll_test = conf_tree.node.get_value(["poll", "test"])
-        poll_all_files_value = conf_tree.node.get_value(["poll", "all-files"])
-        poll_all_files = []
-        if poll_all_files_value:
-            try:
-                poll_all_files = shlex.split(
-                    env_var_process(poll_all_files_value))
-            except UnboundEnvironmentVariableError as exc:
-                raise ConfigValueError(["poll", "all-files"],
-                                       poll_all_files_value, exc)
-        poll_any_files_value = conf_tree.node.get_value(["poll", "any-files"])
-        poll_any_files = []
-        if poll_any_files_value:
-            try:
-                poll_any_files = shlex.split(
-                    env_var_process(poll_any_files_value))
-            except UnboundEnvironmentVariableError as exc:
-                raise ConfigValueError(["poll", "any-files"],
-                                       poll_any_files_value, exc)
-        poll_file_test = None
-        if poll_all_files or poll_any_files:
-            poll_file_test = conf_tree.node.get_value(["poll", "file-test"])
-            if poll_file_test and "{}" not in poll_file_test:
-                raise ConfigValueError(["poll", "file-test"], poll_file_test,
-                                       ConfigValueError.SYNTAX)
-        poll_delays = []
-        if poll_test or poll_all_files or poll_any_files:
-            # Parse something like this: delays=10,4*PT30S,PT2M30S,2*PT1H
-            # R*DURATION: repeat the value R times
-            conf_keys = ["poll", "delays"]
-            poll_delays_value = conf_tree.node.get_value(
-                conf_keys, default="").strip()
-            if poll_delays_value:
-                is_legacy0 = None
-                for item in poll_delays_value.split(","):
-                    value = item.strip()
-                    repeat = 1
-                    if "*" in value:
-                        repeat, value = value.split("*", 1)
-                        try:
-                            repeat = int(repeat)
-                        except ValueError as exc:
-                            raise ConfigValueError(conf_keys,
-                                                   poll_delays_value,
-                                                   ConfigValueError.SYNTAX)
-                    try:
-                        value = self.date_time_oper.duration_parser.parse(
-                            value).get_seconds()
-                        is_legacy = False
-                    except ISO8601SyntaxError:
-                        # Legacy mode: nnnU
-                        # nnn is a float, U is the unit
-                        # No unit or s: seconds
-                        # m: minutes
-                        # h: hours
-                        unit = None
-                        if value[-1].lower() in self.OLD_DURATION_UNITS:
-                            unit = self.OLD_DURATION_UNITS[value[-1].lower()]
-                            value = value[:-1]
-                        try:
-                            value = float(value)
-                        except ValueError as exc:
-                            raise ConfigValueError(conf_keys,
-                                                   poll_delays_value,
-                                                   ConfigValueError.SYNTAX)
-                        if unit:
-                            value *= unit
-                        is_legacy = True
-                    if is_legacy0 is None:
-                        is_legacy0 = is_legacy
-                    elif is_legacy0 != is_legacy:
-                        raise ConfigValueError(
-                            conf_keys,
-                            poll_delays_value,
-                            ConfigValueError.DURATION_LEGACY_MIX)
-                    poll_delays += [value] * repeat
-            else:
-                poll_delays = [0]  # poll once without a delay
-
-        # Poll
-        t_init = get_timepoint_for_now()
-        while poll_delays and (poll_test or poll_any_files or poll_all_files):
-            poll_delay = poll_delays.pop(0)
-            if poll_delay:
-                sleep(poll_delay)
-            if poll_test:
-                ret_code = self.popen.run(
-                    poll_test, shell=True,
-                    stdout=sys.stdout, stderr=sys.stderr)[0]
-                self.handle_event(PollEvent(time(), poll_test, ret_code == 0))
-                if ret_code == 0:
-                    poll_test = None
-            any_files = list(poll_any_files)
-            for file_ in any_files:
-                if self._poll_file(file_, poll_file_test):
-                    self.handle_event(PollEvent(time(), "any-files", True))
-                    poll_any_files = []
-                    break
-            all_files = list(poll_all_files)
-            for file_ in all_files:
-                if self._poll_file(file_, poll_file_test):
-                    poll_all_files.remove(file_)
-            if all_files and not poll_all_files:
-                self.handle_event(PollEvent(time(), "all-files", True))
-        failed_items = []
-        if poll_test:
-            failed_items.append("test")
-        if poll_any_files:
-            failed_items.append("any-files")
-        if poll_all_files:
-            failed_items.append("all-files:" +
-                                self.popen.list_to_shell_str(poll_all_files))
-        if failed_items:
-            now = get_timepoint_for_now()
-            raise PollTimeoutError(now, now - t_init, failed_items)
-
-    def _poll_file(self, file_, poll_file_test):
-        """Poll for existence of a file."""
-        is_done = False
-        if poll_file_test:
-            test = poll_file_test.replace(
-                "{}", self.popen.list_to_shell_str([file_]))
-            is_done = self.popen.run(
-                test, shell=True, stdout=sys.stdout, stderr=sys.stderr)[0] == 0
-        else:
-            is_done = bool(glob(file_))
-        self.handle_event(PollEvent(time(), "file:" + file_, is_done))
-        return is_done
-
     def _prep(self, conf_tree, opts):
         """Prepare to run the application."""
 
         if opts.new_mode:
-            conf_dir = opts.conf_dir
-            if not conf_dir or os.path.abspath(conf_dir) == os.getcwd():
-                raise NewModeError(os.getcwd())
-            for path in os.listdir("."):
-                self.fs_util.delete(path)
+            self._prep_new(opts)
 
         # Dump the actual configuration as rose-app-run.conf
         ConfigDumper()(conf_tree.node, "rose-app-run.conf")
 
         # Environment variables: PATH
-        paths = []
-        for conf_dir in conf_tree.conf_dirs:
-            conf_bin_dir = os.path.join(conf_dir, "bin")
-            if os.path.isdir(conf_bin_dir):
-                paths.append(conf_bin_dir)
-        if paths:
-            value = os.pathsep.join(paths + [os.getenv("PATH")])
-            conf_tree.node.set(["env", "PATH"], value)
-        else:
-            conf_tree.node.set(["env", "PATH"], os.getenv("PATH"))
+        self._prep_path(conf_tree)
 
         # Free format files not defined in the configuration file
         file_section_prefix = self.config_pm.get_handler("file").PREFIX
@@ -373,6 +399,33 @@ class AppRunner(Runner):
         # Process Files
         self.config_pm(conf_tree, "file",
                        no_overwrite_mode=opts.no_overwrite_mode)
+
+    def _prep_new(self, opts):
+        """Clear out run directory on a --new option if possible."""
+        conf_dir = opts.conf_dir
+        if not conf_dir or os.path.abspath(conf_dir) == os.getcwd():
+            raise NewModeError(os.getcwd())
+        for path in os.listdir("."):
+            self.fs_util.delete(path)
+
+    @staticmethod
+    def _prep_path(conf_tree):
+        """Add bin directories to the PATH seen by the app command."""
+        paths = []
+        for conf_dir in conf_tree.conf_dirs:
+            conf_bin_dir = os.path.join(conf_dir, "bin")
+            if os.path.isdir(conf_bin_dir):
+                paths.append(conf_bin_dir)
+        if paths:
+            value = os.pathsep.join(paths + [os.getenv("PATH")])
+            conf_tree.node.set(["env", "PATH"], value)
+        else:
+            conf_tree.node.set(["env", "PATH"], os.getenv("PATH"))
+
+    def _poll(self, conf_tree):
+        """Run any configured file polling."""
+        poller = Poller(self.popen, self.handle_event)
+        poller.poll(conf_tree)
 
     def _command(self, conf_tree, opts, args):
         """Run the command."""


### PR DESCRIPTION
Addresses a small part of #129.

(I'm starting at the beginning - app-run isn't actually particularly bad).

pylint (correctly, I think) identified that the old `_poll` method was a bit too big, so I've split it up.
After the split up, I thought that it would be better in its own class. Very little code blocks are
actually changed.

I've also trimmed `_prep`.

Pylint score now at 9.61/10 (`cd lib/python; pylint rose/app_run.py`) from 9.46. I'm OK with the remaining warnings. To be honest, in the future, code over 9.25 (say) should probably just be ignored.

@matthewrmshin, please review.
@oliver-sanders, please review 2.