### PR TITLE
rose app-upgrade: fix change_setting_value with forced=True

### DIFF
--- a/lib/python/rose/upgrade.py
+++ b/lib/python/rose/upgrade.py
@@ -203,8 +203,8 @@ class MacroUpgrade(rose.macro.MacroBase):
         node = config.get([section, option])
         if node is None:
             if forced:
-                return self.add_setting(config, keys, value, node.state,
-                                        comments, info)
+                return self.add_setting(config, keys, value=value,
+                                        comments=comments, info=info)
             return False
         if node.value == value:
             return False

--- a/t/rose-app-upgrade/03-complex.t
+++ b/t/rose-app-upgrade/03-complex.t
@@ -232,6 +232,9 @@ class UpgradeAppletoFig(rose.upgrade.MacroUpgrade):
         self.change_setting_value(config, ["namelist:change_opt",
                                            "trig_ignore_opt_has_changed"],
                                   ".true.")
+        self.change_setting_value(config, ["namelist:change_opt",
+                                           "opt_force_added_change"],
+                                  ".true.", forced=True)
 
         # Remove settings.
         self.remove_setting(config, ["namelist:missing_sect"])
@@ -303,7 +306,7 @@ TEST_KEY=$TEST_KEY_BASE-upgrade
 run_pass "$TEST_KEY" rose app-upgrade --non-interactive \
  --meta-path=../rose-meta/ -C ../config fig
 file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<'__OUTPUT__'
-[U] Upgrade_apple-fig: changes: 50
+[U] Upgrade_apple-fig: changes: 51
     namelist:add_sect=new_opt=.true.
         Added with value '.true.'
     namelist:add_sect_only=None=None
@@ -340,6 +343,8 @@ file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<'__OUTPUT__'
         Value: '.false.' -> '.true.'
     namelist:change_opt=trig_ignore_opt_has_changed=.true.
         Value: '.false.' -> '.true.'
+    namelist:change_opt=opt_force_added_change=.true.
+        Added with value '.true.'
     namelist:remove_sect_empty=None=None
         Removed
     namelist:remove_sect_full=opt_with_content=None
@@ -443,6 +448,7 @@ new_opt=.true.
 
 [namelist:change_opt]
 !ignore_opt_has_changed=.true.
+opt_force_added_change=.true.
 opt_has_changed=.true.
 trig_ignore_opt_has_changed=.true.
 
@@ -736,6 +742,9 @@ class UpgradeAppletoFig(rose.upgrade.MacroUpgrade):
         self.change_setting_value(config, ["namelist:change_opt",
                                            "trig_ignore_opt_has_changed"],
                                   ".true.", info="good")
+        self.change_setting_value(config, ["namelist:change_opt",
+                                           "opt_force_added_change"],
+                                  ".true.", forced=True, info="good")
         self.remove_setting(config, ["namelist:missing_sect"], info="bad")
         self.remove_setting(config, ["namelist:missing_sect", "missing_opt"],
                             info="bad")
@@ -798,7 +807,7 @@ TEST_KEY=$TEST_KEY_BASE-upgrade-info
 run_pass "$TEST_KEY" rose app-upgrade --non-interactive \
  --meta-path=../rose-meta/ -C ../config fig
 file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<'__OUTPUT__'
-[U] Upgrade_apple-fig: changes: 33
+[U] Upgrade_apple-fig: changes: 34
     namelist:add_sect=new_opt=.true.
         good
     namelist:add_sect_only=None=None
@@ -834,6 +843,8 @@ file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<'__OUTPUT__'
     namelist:change_opt=ignore_opt_has_changed=.true.
         good
     namelist:change_opt=trig_ignore_opt_has_changed=.true.
+        good
+    namelist:change_opt=opt_force_added_change=.true.
         good
     namelist:remove_sect_empty=None=None
         good
@@ -904,6 +915,7 @@ new_opt=.true.
 
 [namelist:change_opt]
 !ignore_opt_has_changed=.true.
+opt_force_added_change=.true.
 opt_has_changed=.true.
 trig_ignore_opt_has_changed=.true.
 


### PR DESCRIPTION
Currently, calling the `change_setting_value` MacroUpgrade method with `forced=True` (add if missing) will cause the following traceback:

```
Traceback (most recent call last):
  File "/opt/python/runpy.py", line 122, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/opt/python/runpy.py", line 34, in _run_code
    exec code in run_globals
  File "/opt/rose/lib/python/rose/upgrade.py", line 671, in <module>
    main()
  File "/opt/rose/lib/python/rose/upgrade.py", line 638, in main
    combined_config_map, meta_config, macro_function, macro_name=macro_id)
  File "/opt/rose/lib/python/rose/macro.py", line 1110, in apply_macro_to_config_map
    return_value = macro_function(macro_config, meta_config)
  File "/opt/rose/lib/python/rose/upgrade.py", line 630, in <lambda>
    conf, meta, opts.non_interactive)
  File "/opt/rose/lib/python/rose/upgrade.py", line 449, in transform
    upgrade_macro_result = func(config, meta_config, **res)
  File "/etc/rose-meta/test-app-upgrade/versions.py", line 112, in upgrade
    ".true.", forced=True, info="good")
  File "/opt/rose/lib/python/rose/upgrade.py", line 206, in change_setting_value
    return self.add_setting(config, keys, value, node.state,
AttributeError: 'NoneType' object has no attribute 'state'
```

This fixes the error.

@oliver-sanders, please review.
@arjclark, please review 2 (quick sanity check).