### PR TITLE
rose macro, app-upgrade: fix section comment removal of options bug

### DIFF
--- a/lib/python/rose/config.py
+++ b/lib/python/rose/config.py
@@ -368,11 +368,11 @@ class ConfigNodeDiff(object):
 
         """
         node = ConfigNode()
-        for keys, info in self.get_added():
-            value, state, comments = info
-            node.set(keys, value=value, state=state, comments=comments)
         for keys, old_and_new_info in self.get_modified():
             old_info, info = old_and_new_info
+            value, state, comments = info
+            node.set(keys, value=value, state=state, comments=comments)
+        for keys, info in self.get_added():
             value, state, comments = info
             node.set(keys, value=value, state=state, comments=comments)
         for keys, info in self.get_removed():

--- a/t/rose-macro/20-opt-conf-change-modify.t
+++ b/t/rose-macro/20-opt-conf-change-modify.t
@@ -21,7 +21,7 @@
 #-------------------------------------------------------------------------------
 . $(dirname $0)/test_header
 #-------------------------------------------------------------------------------
-tests 20
+tests 25
 #-------------------------------------------------------------------------------
 setup
 #-------------------------------------------------------------------------------
@@ -252,6 +252,44 @@ paint_job=sparkly
 [!garage]
 door_paint_job=boring
 __CONFIG__
-teardown
 #-------------------------------------------------------------------------------
+TEST_KEY=$TEST_KEY_BASE-comment-in-section-bug
+init <<'__CONFIG__'
+[car]
+budget=1000
+paint_job=standard
+wheels=4
+
+[garage]
+__CONFIG__
+init_opt colour <<'__OPT_CONFIG__'
+[car]
+paint_job=sparkly
+
+# Garages are for boats, not cars.
+[garage]
+door_paint_job=boring
+__OPT_CONFIG__
+run_pass "$TEST_KEY" rose macro -y --config=../config modify.InvisibleCarPaint
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<'__OUT__'
+[T] modify.InvisibleCarPaint: changes: 1
+    car=paint_job=invisible
+        Where did I park?
+__OUT__
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+file_cmp "$TEST_KEY.config" ../config/rose-app.conf <<'__CONFIG__'
+[car]
+budget=1000
+paint_job=invisible
+wheels=4
+
+[garage]
+__CONFIG__
+file_cmp "$TEST_KEY.opt-config" ../config/opt/rose-app-colour.conf <<'__CONFIG__'
+# Garages are for boats, not cars.
+[garage]
+door_paint_job=boring
+__CONFIG__
+#-------------------------------------------------------------------------------
+teardown
 exit


### PR DESCRIPTION
This fixes a bad bad bug in `rose macro` and `rose app-upgrade` when handling optional 
configurations with sections that have different comments or different state from their parent. The bug would completely remove the additional options within that section from the optional configuration.

For example, an app config that looks like this:
```ini
[env]
FOO=baz

[namelist:foo]
```
with an optional configuration that looks like this:
```ini
[env]
FOO=bar

# Some comment.
[namelist:foo]
baz=5
```
and metadata that looks like this:
```ini
[env=QUX]
compulsory=true
```
when ran through `rose macro --fix -y` will end up with a rose-app.conf like this:
```ini
[env]
FOO=baz
QUX=

[namelist:foo]
```
and an optional configuration missing the additional option in `namelist:foo`:
```ini
[env]
FOO=bar

# Some comment.
[namelist:foo]
```

The bug is caused by the handling of modified settings after added settings. This meant that
the additional options in an optional configuration would be added first. If their parent section was modified (different ignored state or different comments) then that modification would happen after that.
Unfortunately, by design, the value for a section in this code is set to `None`. This meant that when the section was modified, ostensibly to add the comment or change the ignored state, the section node value became empty and the added children were lost. The fix applies modifications to settings first, then adds any new settings.

I believe this is related to #1853, which I didn't reproduce at the time. The change in state is probably the cause of the disappearance of settings from the ignored sections. Ignoring a section in an optional configuration will actually not cause runtime problems with this bug. I'll keep the issue open and look into it.

The new test will fail on current master (`door_paint_job` will be missing from the final optional configuration).

Reported by @steoxley.

@arjclark, please review.
@matthewrmshin, please review.