### PR TITLE
rose edit: Don't show "old_value" in info dialog.

### DIFF
--- a/lib/python/rose/config_editor/util.py
+++ b/lib/python/rose/config_editor/util.py
@@ -129,7 +129,7 @@ def launch_node_info_dialog(node, changes, search_function):
     maxlen = rose.config_editor.DIALOG_NODE_INFO_MAX_LEN
     for i, (att_name, att_val) in enumerate(att_list):
         if (att_name == 'metadata' or att_name.startswith("_") or
-                callable(att_val)):
+                callable(att_val) or att_name == 'old_value'):
             continue
         if i == metadata_start_index:
             text += "\n" + rose.config_editor.DIALOG_NODE_INFO_METADATA


### PR DESCRIPTION
Closes #1680 by not displaying "old_value" in info box. Previous value can already be seen via the hover over for the variable.

@benfitzpatrick - please review 1
@oliver-sanders - please review 2