### PR TITLE
rose configuration: allow more characters in setting indices

### DIFF
--- a/lib/python/rose/macro.py
+++ b/lib/python/rose/macro.py
@@ -70,9 +70,9 @@ MACRO_OUTPUT_VALIDATE_ISSUES = "{0}: issues: {1}\n"
 MACRO_OUTPUT_WARNING_ISSUES = "{0}: warnings: {1}\n"
 OPT_CONFIG_REPORT = "(opts={0})"
 REC_MODIFIER = re.compile(r"\{.+\}")
-REC_ID_STRIP_DUPL = re.compile(r"\([:, \w]+\)")
-REC_ID_STRIP = re.compile('(?:\{.+\})?(?:\([:, \w]+\))?$')
-REC_ID_ELEMENT = re.compile(r"\(([:, \w]+)\)$")
+REC_ID_STRIP_DUPL = re.compile(r"\([^()]+\)")
+REC_ID_STRIP = re.compile('(?:\{.+\})?(?:\([^()]+\))?$')
+REC_ID_ELEMENT = re.compile(r"\(([^()]+)\)$")
 REC_ID_SINGLE_ELEMENT = re.compile(r"\((\d+)\)$")
 ID_ELEMENT_FORMAT = "{0}({1})"
 PROBLEM_ENTRY = "    {0}{1}={2}={3}\n        {4}\n"

--- a/t/rose-macro/14-duplicate-check.t
+++ b/t/rose-macro/14-duplicate-check.t
@@ -35,7 +35,9 @@ my_var5(1) = .true.
 my_var6(2) = .true.
 my_var7 = .true.
 
-
+[namelist:nl5(`!"%^&sd_-3)]
+my_var6(3) = .true.
+my_var7 = .true.
 __CONFIG__
 #-------------------------------------------------------------------------------
 tests 6
@@ -59,6 +61,9 @@ duplicate = true
 
 [namelist:nl4{modifier}]
 duplicate = true
+
+[namelist:nl5]
+duplicate = true
 __META_CONFIG__
 run_pass "$TEST_KEY" rose macro --config=../config rose.macros.DefaultValidators
 file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
@@ -75,17 +80,21 @@ duplicate = true
 [namelist:nl2]
 
 [namelist:nl3=foo]
+
+[namelist:nl5]
 __META_CONFIG__
 run_fail "$TEST_KEY" rose macro --config=../config rose.macros.DefaultValidators
 file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" <<'__CONTENT__'
-[V] rose.macros.DefaultValidators: issues: 3
+[V] rose.macros.DefaultValidators: issues: 4
     namelist:nl1=None=None
         incorrect "duplicate=true" metadata
     namelist:nl2(1)=None=None
         namelist:nl2 requires "duplicate=true" metadata
     namelist:nl3{modifier}=None=None
         namelist:nl3 requires "duplicate=true" metadata
+    namelist:nl5(`!"%^&sd_-3)=None=None
+        namelist:nl5 requires "duplicate=true" metadata
 __CONTENT__
 teardown
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
This allows a greater range of characters in the indices for duplicate settings.

This is prompted by the move towards including profile names in the indices for UM STASH namelists - many of these have characters like `+`, etc.

@scwhitehouse - this is kind of necessary for the above UM change, since past and current Rose will not recognise a namelist like `[namelist:foo(t+5_abcdef01)]` as a member of `[namelist:foo]`, so the metadata including triggering information will be lost.