### PR TITLE
rose macro: removed un-necessary prompting with opt configs

### DIFF
--- a/lib/python/rose/macro.py
+++ b/lib/python/rose/macro.py
@@ -691,8 +691,11 @@ def check_config_integrity(app_config):
 
 
 def validate_config(app_config, meta_config, run_macro_list, modules,
-                    macro_info_tuples, opt_non_interactive=False):
+                    macro_info_tuples, opt_non_interactive=False,
+                    optional_config_name=None, optional_values=None):
     """Run validator custom macros on the config and return problems."""
+    if optional_values is None:
+        optional_values = {}
     macro_problem_map = {}
     for module_name, class_name, method, help in macro_info_tuples:
         macro_name = ".".join([module_name, class_name])
@@ -715,7 +718,18 @@ def validate_config(app_config, meta_config, run_macro_list, modules,
                     else:
                         break
                 if optionals:
-                    res = get_user_values(optionals)
+                    res = {}
+                    if "optional_config_name" in optionals:
+                        res["optional_config_name"] = optional_config_name
+                    for key in set(optionals) & set(optional_values):
+                        res[key] = optional_values[key]
+                    res.update(
+                        get_user_values(
+                            dict(((key, value) for key, value in
+                                  optionals.iteritems() if key not in res))))
+                    optional_values.update(res)
+                    if "optional_config_name" in optional_values:
+                        del optional_values["optional_config_name"]
             problem_list = macro_meth(app_config, meta_config, **res)
             if not isinstance(problem_list, list):
                 raise ValueError(ERROR_RETURN_VALUE.format(macro_name))
@@ -725,9 +739,11 @@ def validate_config(app_config, meta_config, run_macro_list, modules,
 
 
 def transform_config(config, meta_config, transformer_macro, modules,
-                     macro_info_tuples, opt_non_interactive=False):
+                     macro_info_tuples, opt_non_interactive=False,
+                     optional_config_name=None, optional_values=None):
     """Run transformer custom macros on the config and return problems."""
-    macro_change_dict = {}
+    if optional_values is None:
+        optional_values = {}
     for module_name, class_name, method, help in macro_info_tuples:
         if method != TRANSFORM_METHOD:
             continue
@@ -752,7 +768,19 @@ def transform_config(config, meta_config, transformer_macro, modules,
                 else:
                     break
             if optionals:
-                res = get_user_values(optionals)
+                res = {}
+                if "optional_config_name" in optionals:
+                    res["optional_config_name"] = optional_config_name
+                for key in [key for key in optionals if key in
+                            optional_values]:
+                    res[key] = optional_values[key]
+                res.update(
+                    get_user_values(
+                        dict(((key, value) for key, value in
+                              optionals.iteritems() if key not in res))))
+                optional_values.update(res)
+                if "optional_config_name" in optional_values:
+                    del optional_values["optional_config_name"]
         return macro_method(config, meta_config, **res)
     return config, []
 
@@ -921,10 +949,12 @@ def run_macros(config_map, meta_config, config_name, macro_names,
     if VALIDATE_METHOD in macros_by_type:
         new_combined_config_map = combine_opt_config_map(config_map)
         macro_config_problems_map = {}
+        optional_values = {}
         for conf_key, config in new_combined_config_map.items():
             config_problems_map = validate_config(
                 config, meta_config, macros_by_type[VALIDATE_METHOD], modules,
-                macro_tuples, opt_non_interactive
+                macro_tuples, opt_non_interactive,
+                optional_config_name=conf_key, optional_values=optional_values
             )
             if config_problems_map:
                 rc = 1
@@ -1088,11 +1118,14 @@ def _run_transform_macros(macros, config_name, config_map, meta_config,
                           reporter=None):
     no_changes = True
     combined_config_map = combine_opt_config_map(config_map)
+    optional_values = {}
     for transformer_macro in macros:
         macro_function = (
-            lambda conf, meta: transform_config(conf, meta, transformer_macro,
-                                                modules, macro_tuples,
-                                                opt_non_interactive))
+            lambda conf, meta, opt: transform_config(
+                conf, meta, transformer_macro, modules, macro_tuples,
+                opt_non_interactive, optional_config_name=opt,
+                optional_values=optional_values)
+        )
         new_config_map, changes_map = apply_macro_to_config_map(
             combined_config_map, meta_config, macro_function,
             macro_name=transformer_macro
@@ -1117,7 +1150,7 @@ def apply_macro_to_config_map(config_map, meta_config, macro_function,
     for conf_key in conf_keys:
         config = config_map[conf_key]
         macro_config = copy.deepcopy(config)
-        return_value = macro_function(macro_config, meta_config)
+        return_value = macro_function(macro_config, meta_config, conf_key)
         err_bad_return_value = ERROR_RETURN_VALUE.format(macro_name)
         if (not isinstance(return_value, tuple) or
                 len(return_value) != 2):

--- a/lib/python/rose/upgrade.py
+++ b/lib/python/rose/upgrade.py
@@ -626,7 +626,7 @@ def main():
     macro_config = copy.deepcopy(app_config)
     combined_config_map = rose.macro.combine_opt_config_map(config_map)
     macro_function = (
-        lambda conf, meta: upgrade_manager.transform(
+        lambda conf, meta, conf_key: upgrade_manager.transform(
             conf, meta, opts.non_interactive)
     )
     method_id = UPGRADE_METHOD.upper()[0]
@@ -650,7 +650,7 @@ def main():
     config_map = new_config_map
     combined_config_map = rose.macro.combine_opt_config_map(config_map)
     macro_function = (
-        lambda conf, meta:
+        lambda conf, meta, conf_key:
         rose.macros.trigger.TriggerMacro().transform(conf, meta)
     )
     new_config_map, changes_map = rose.macro.apply_macro_to_config_map(

--- a/t/rose-macro/24-prompt.t
+++ b/t/rose-macro/24-prompt.t
@@ -1,0 +1,52 @@
+#!/bin/bash
+#-------------------------------------------------------------------------------
+# (C) British Crown Copyright 2012-6 Met Office.
+#
+# This file is part of Rose, a framework for meteorological suites.
+#
+# Rose is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Rose is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Rose. If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test "rose macro" in the absence of a rose configuration.
+#-------------------------------------------------------------------------------
+. $(dirname $0)/test_header
+#-------------------------------------------------------------------------------
+tests 2
+#-------------------------------------------------------------------------------
+# Test that only relevant prompts are provided
+init <<'__CONFIG__'
+[env]
+ANSWER=42
+__CONFIG__
+
+setup
+init_meta <<'__META_CONFIG__'
+[env=ANSWER]
+macro=prompt.Test
+__META_CONFIG__
+
+init_opt baseeight <<'__OPT_CONFIG__'
+[env]
+ANSWER=52
+__OPT_CONFIG__
+
+init_macro prompt.py < $TEST_SOURCE_DIR/lib/custom_macro_prompt.py
+TEST_KEY="$TEST_KEY_BASE"
+rose macro --config='../config' -V <<<'' >>'temp'
+grep_count_ok "$TEST_KEY"-1 'Value for answer (default 42)' 'temp' 1
+grep_count_ok "$TEST_KEY"-2 'Value for optional_config_name' 'temp' 0
+
+rm temp
+teardown
+#-------------------------------------------------------------------------------
+exit

--- a/t/rose-macro/lib/custom_macro_prompt.py
+++ b/t/rose-macro/lib/custom_macro_prompt.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import rose.macro
+
+
+class Test(rose.macro.MacroBase):
+
+    def validate(self, config, meta_config=None, answer=42,
+                 optional_config_name=None):
+        return self.reports

--- a/t/rose-macro/test_header
+++ b/t/rose-macro/test_header
@@ -77,3 +77,15 @@ function teardown() {
     rm -rf $TEST_DIR/run
     rm -rf $TEST_DIR/config/meta
 }
+
+function grep_count_ok() {
+    local TEST_KEY=$1
+    local PATTERN=$2
+    local FILE=$3
+    local COUNT=$4
+    if (( $(grep "$PATTERN" "$FILE" -c) == $COUNT )); then
+        pass "$TEST_KEY"
+        return
+    fi
+    fail "$TEST_KEY"
+}


### PR DESCRIPTION
Closes #1650, #1688.
- no longer prompts for `optional_config_name`
- now only prompts once for unknown values when using optional configs

@benfitzpatrick Please review
@matthewrmshin Please review