### PR TITLE
rose edit: fix right click menu segfault in summary panel

### DIFF
--- a/lib/python/rose/config_editor/panelwidget/summary_data.py
+++ b/lib/python/rose/config_editor/panelwidget/summary_data.py
@@ -495,6 +495,7 @@ class BaseSummaryDataPanel(gtk.VBox):
 
             # list shortcut keys
             accel = gtk.AccelGroup()
+            menu.set_accel_group(accel)
             for key_press, menuitem in shortcuts:
                 key, mod = gtk.accelerator_parse(key_press)
                 menuitem.add_accelerator(


### PR DESCRIPTION
This fixes a problem where selecting certain right click menu items in the summary panel (e.g. the UM STASH panel) causes a GTK segfault.

@matthewrmshin, @oliver-sanders please review 1 and 2.