### PR TITLE
rose web service now requires cherrypy 3.2.2

### DIFF
--- a/doc/rose-install.html
+++ b/doc/rose-install.html
@@ -141,7 +141,7 @@
                   <p><dfn>used by:</dfn> Rose Bush and Rosie web
                   service.</p>
 
-                  <p><dfn>tested with version:</dfn> 3.1.2.</p>
+                  <p><dfn>tested with version:</dfn> 3.2.2.</p>
                 </dd>
 
                 <dt>Python: <a href=


### PR DESCRIPTION
Close #1922. I now think it is best to up cherrypy version than hacking a fix in. Supersede #1924.

@benfitzpatrick please review.