### PR TITLE
rose edit: fix trigger latent section traceback

### DIFF
--- a/lib/python/rose/config_editor/updater.py
+++ b/lib/python/rose/config_editor/updater.py
@@ -467,7 +467,7 @@ class Updater(object):
                         if ns not in triggered_ns_list:
                             triggered_ns_list.append(ns)
                         var.ignored_reason.pop(
-                            rose.variable.IGNORED_BY_SECTION)
+                            rose.variable.IGNORED_BY_SECTION, None)
             elif section in trigger.ignored_dict:
                 # Trigger-ignored sections
                 parents = trigger.ignored_dict.get(section, {})


### PR DESCRIPTION
This fixes a traceback when a variable triggers a section which is missing from the configuration (a latent section):

```
Traceback (most recent call last):
  File "/opt/rose/lib/python/rose/config_editor/valuewidget/radiobuttons.py", line 86, in setter
    self.set_value(self.value)
  File "/opt/rose/lib/python/rose/config_editor/variable.py", line 141, in _valuewidget_set_value
    self.var_ops.set_var_value(self.variable, value)
  File "/opt/rose/lib/python/rose/config_editor/ops/variable.py", line 274, in set_var_value
    self.trigger_update(variable.metadata['full_ns'])
  File "/opt/rose/lib/python/rose/config_editor/updater.py", line 216, in update_namespace
    skip_sub_data_update=skip_sub_data_update)
  File "/opt/rose/lib/python/rose/config_editor/updater.py", line 238, in update_status
    self.update_ignored_statuses(page.namespace)
  File "/opt/rose/lib/python/rose/config_editor/updater.py", line 345, in update_ignored_statuses
    var_id)
  File "/opt/rose/lib/python/rose/config_editor/updater.py", line 470, in update_ignoreds
    rose.variable.IGNORED_BY_SECTION)
```

@matthewrmshin @oliver-sanders please review.

