### PR TITLE
rose bush: fixed depreciated bootstrap 2 class

### DIFF
--- a/lib/html/template/rose-bush/job-entry.html
+++ b/lib/html/template/rose-bush/job-entry.html
@@ -40,7 +40,7 @@
       {% if entry.task_status == "success" -%}
         {% set badge_class = "label-success" %}
       {% elif entry.task_status == "fail" -%}
-        {% set badge_class = "label-important" %}
+        {% set badge_class = "label-danger" %}
       {% else -%}
         {% set badge_class = "label-default" %}
       {% endif -%}


### PR DESCRIPTION
A `.label-important` managed to slip the net in #1891.

@benfitzpatrick Please review.