### PR TITLE
rose bush: use os.stat to get last_activity_time in all rose bush pages.

### DIFF
--- a/lib/python/rose/bush.py
+++ b/lib/python/rose/bush.py
@@ -116,7 +116,7 @@ class RoseBushService(object):
             "script": cherrypy.request.script_name,
             "method": "broadcast_states",
             "states": {},
-            "time": strftime("%Y-%m-%dT%H:%M:%S+0000", gmtime()),
+            "time": strftime("%Y-%m-%dT%H:%M:%SZ", gmtime()),
         }
         data["states"].update(
             self.suite_engine_proc.get_suite_state_summary(user, suite))
@@ -150,7 +150,7 @@ class RoseBushService(object):
             "script": cherrypy.request.script_name,
             "method": "broadcast_events",
             "states": {},
-            "time": strftime("%Y-%m-%dT%H:%M:%S+0000", gmtime())
+            "time": strftime("%Y-%m-%dT%H:%M:%SZ", gmtime())
         }
         data["states"].update(
             self.suite_engine_proc.get_suite_state_summary(user, suite))
@@ -220,7 +220,7 @@ class RoseBushService(object):
             user_suite_dir, self.suite_engine_proc.SUITE_DB)
         data["states"]["last_activity_time"] = \
             self.get_last_activity_time(suite_db)
-        data["time"] = strftime("%Y-%m-%dT%H:%M:%S+0000", gmtime())
+        data["time"] = strftime("%Y-%m-%dT%H:%M:%SZ", gmtime())
         if form == "json":
             return simplejson.dumps(data)
         try:
@@ -336,7 +336,7 @@ class RoseBushService(object):
                 data["n_pages"] += 1
         else:
             data["n_pages"] = 1
-        data["time"] = strftime("%Y-%m-%dT%H:%M:%S+0000", gmtime())
+        data["time"] = strftime("%Y-%m-%dT%H:%M:%SZ", gmtime())
         if form == "json":
             return simplejson.dumps(data)
         try:
@@ -455,7 +455,7 @@ class RoseBushService(object):
                     entry["info"][key] = node.value
             except (IOError, rose.config.ConfigSyntaxError):
                 pass
-        data["time"] = strftime("%Y-%m-%dT%H:%M:%S+0000", gmtime())
+        data["time"] = strftime("%Y-%m-%dT%H:%M:%SZ", gmtime())
         if form == "json":
             return simplejson.dumps(data)
         template = self.template_env.get_template("suites.html")
@@ -635,7 +635,7 @@ class RoseBushService(object):
             rose_version=self.rose_version,
             script=cherrypy.request.script_name,
             method="view",
-            time=strftime("%Y-%m-%dT%H:%M:%S+0000", gmtime()),
+            time=strftime("%Y-%m-%dT%H:%M:%SZ", gmtime()),
             logo=self.logo,
             title=self.title,
             host=self.host_name,

--- a/lib/python/rose/bush.py
+++ b/lib/python/rose/bush.py
@@ -120,6 +120,10 @@ class RoseBushService(object):
         }
         data["states"].update(
             self.suite_engine_proc.get_suite_state_summary(user, suite))
+        suite_db = os.path.join(
+            user_suite_dir, self.suite_engine_proc.SUITE_DB)
+        data["states"]["last_activity_time"] = \
+            self.get_last_activity_time(suite_db)
         data.update(self._get_suite_logs_info(user, suite))
         data["broadcast_states"] = (
             self.suite_engine_proc.get_suite_broadcast_states(user, suite))
@@ -212,6 +216,10 @@ class RoseBushService(object):
         data.update(self._get_suite_logs_info(user, suite))
         data["states"].update(
             self.suite_engine_proc.get_suite_state_summary(user, suite))
+        suite_db = os.path.join(
+            user_suite_dir, self.suite_engine_proc.SUITE_DB)
+        data["states"]["last_activity_time"] = \
+            self.get_last_activity_time(suite_db)
         data["time"] = strftime("%Y-%m-%dT%H:%M:%S+0000", gmtime())
         if form == "json":
             return simplejson.dumps(data)
@@ -313,6 +321,10 @@ class RoseBushService(object):
         data.update(self._get_suite_logs_info(user, suite))
         data["states"].update(
             self.suite_engine_proc.get_suite_state_summary(user, suite))
+        suite_db = os.path.join(
+            user_suite_dir, self.suite_engine_proc.SUITE_DB)
+        data["states"]["last_activity_time"] = \
+            self.get_last_activity_time(suite_db)
         entries, of_n_entries = self.suite_engine_proc.get_suite_job_events(
             user, suite, cycles, tasks, no_statuses, order, per_page,
             (page - 1) * per_page)
@@ -405,9 +417,7 @@ class RoseBushService(object):
             suite_db = os.path.join(
                 user_suite_dir, self.suite_engine_proc.SUITE_DB)
             try:
-                last_activity_time = strftime(
-                    "%Y-%m-%dT%H:%M:%S+0000",
-                    gmtime(os.stat(suite_db).st_mtime))
+                last_activity_time = self.get_last_activity_time(suite_db)
             except OSError:
                 last_activity_time = None
             data["entries"].append({
@@ -542,6 +552,12 @@ class RoseBushService(object):
             file_content = self.suite_engine_proc.is_conf(path)
 
         return lines, job_entry, entry, file_content, f_name
+
+    def get_last_activity_time(self, suite_db):
+        """Returns last activity time for a suite based on database stat"""
+        last_activity_time = strftime("%Y-%m-%dT%H:%M:%SZ",
+                                      gmtime(os.stat(suite_db).st_mtime))
+        return last_activity_time
 
     @cherrypy.expose
     def viewsearch(self, user, suite, path=None, path_in_tar=None, mode=None,

--- a/lib/python/rose/suite_engine_procs/cylc.py
+++ b/lib/python/rose/suite_engine_procs/cylc.py
@@ -1004,27 +1004,20 @@ class CylcProcessor(SuiteEngineProcessor):
     def get_suite_state_summary(self, user_name, suite_name):
         """Return a the state summary of a user's suite.
 
-        Return {"last_activity_time": s, "is_running": b, "is_failed": b}
+        Return {"is_running": b, "is_failed": b, "server": s}
         where:
-        * last_activity_time is a string in %Y-%m-%dT%H:%M:%S format,
-          the time of the latest activity in the suite
         * is_running is a boolean to indicate if the suite is running
         * is_failed: a boolean to indicate if any tasks (submit) failed
         * server: host:port of server, if available
 
         """
         ret = {
-            "last_activity_time": None,
             "is_running": False,
             "is_failed": False,
             "server": None}
         dao = self._db_init(self.SUITE_DB, user_name, suite_name)
         if not os.access(dao.db_f_name, os.F_OK | os.R_OK):
             return ret
-
-        ret["last_activity_time"] = strftime("%Y-%m-%dT%H:%M:%S+0000",
-                                             gmtime(os.stat(
-                                                    dao.db_f_name).st_mtime))
 
         port_file_path = os.path.expanduser(
             os.path.join("~" + user_name, ".cylc", "ports", suite_name))

--- a/lib/python/rose/suite_engine_procs/cylc.py
+++ b/lib/python/rose/suite_engine_procs/cylc.py
@@ -40,7 +40,7 @@ import socket
 import sqlite3
 import tarfile
 from tempfile import mkstemp
-from time import sleep, time
+from time import sleep, time, gmtime, strftime
 from uuid import uuid4
 
 
@@ -1021,10 +1021,10 @@ class CylcProcessor(SuiteEngineProcessor):
         dao = self._db_init(self.SUITE_DB, user_name, suite_name)
         if not os.access(dao.db_f_name, os.F_OK | os.R_OK):
             return ret
-        stmt = "SELECT time FROM task_events ORDER BY time DESC LIMIT 1"
-        for row in self._db_exec(self.SUITE_DB, user_name, suite_name, stmt):
-            ret["last_activity_time"] = row[0]
-            break
+
+        ret["last_activity_time"] = strftime("%Y-%m-%dT%H:%M:%S+0000",
+                                             gmtime(os.stat(
+                                                    dao.db_f_name).st_mtime))
 
         port_file_path = os.path.expanduser(
             os.path.join("~" + user_name, ".cylc", "ports", suite_name))


### PR DESCRIPTION
Instead of performing an expensive query to get last activity time for rose bush pages (jobs/cycles) we can use the os.stat function instead as we do on the suites summary page.

@benfitzpatrick - please review 1
@oliver-sanders - please review 2 