### PR TITLE
t: rose task-env: ROSE_DATAC__????

### DIFF
--- a/t/rose-task-run/01-run-basic-iso.t
+++ b/t/rose-task-run/01-run-basic-iso.t
@@ -33,7 +33,7 @@ if (($? != 0)); then
     exit 0
 fi
 #-------------------------------------------------------------------------------
-tests 44
+tests 46
 #-------------------------------------------------------------------------------
 rose suite-run -q -C $TEST_SOURCE_DIR/$TEST_KEY_BASE --name=$NAME \
     --no-gcontrol --host=localhost -- --debug
@@ -82,6 +82,18 @@ for CYCLE in 20130101T0000Z 20130101T1200Z 20130102T0000Z; do
     file_grep "$TEST_KEY-ROSE_TASK_SUFFIX" "ROSE_TASK_SUFFIX=1" $FILE
     file_grep "$TEST_KEY-MY_PATH" "MY_PATH=$MY_PATH" $FILE
     PREV_CYCLE=$CYCLE
+done
+# Test ROSE_DATAC__???? (offset to a future cycle)
+NEXT_CYCLE=
+for CYCLE in 20130102T0000Z 20130101T1200Z 20130101T0000Z; do
+    if [[ -n "${NEXT_CYCLE}" ]]; then
+        TEST_KEY="${TEST_KEY_BASE}-file-${CYCLE}"
+        FILE="${HOME}/cylc-run/${NAME}/log/job/${CYCLE}/my_task_1/01/job.txt"
+        file_grep "${TEST_KEY}-ROSE_DATAC__PT12H" \
+            "ROSE_DATAC__PT12H=${SUITE_RUN_DIR}/share/cycle/${NEXT_CYCLE}" \
+            "${FILE}"
+    fi
+    NEXT_CYCLE="${CYCLE}"
 done
 #-------------------------------------------------------------------------------
 rose suite-clean -q -y $NAME

--- a/t/rose-task-run/01-run-basic-iso/suite.rc
+++ b/t/rose-task-run/01-run-basic-iso/suite.rc
@@ -1,8 +1,9 @@
 #!jinja2
 [cylc]
     UTC mode = True
+    abort if any task fails = True
     [[event hooks]]
-        timeout handler = rose suite-hook --shutdown
+        abort on timeout = True
         timeout = PT2M
 [scheduling]
     initial cycle point = 20130101T0000Z
@@ -12,16 +13,7 @@
             graph = my_task_1
 
 [runtime]
-    [[root]]
-        script = """
-rose task-run --debug --cycle-offset=PT12H --path=MY_PATH='etc/my-path/*'
-"""
-        [[[event hooks]]]
-           succeeded handler = rose suite-hook
-           failed handler = rose suite-hook --shutdown
-           submission failed handler = rose suite-hook --shutdown
-           submission timeout handler = rose suite-hook
-           execution timeout handler = rose suite-hook
-           submission timeout = PT1M
-           execution timeout  = PT1M
     [[my_task_1]]
+        script = """
+rose task-run --debug --cycle-offset=PT12H --cycle-offset=-PT12H --path=MY_PATH='etc/my-path/*'
+"""

--- a/t/rose-task-run/03-env-basic-iso/suite.rc
+++ b/t/rose-task-run/03-env-basic-iso/suite.rc
@@ -1,8 +1,9 @@
 #!jinja2
 [cylc]
     UTC mode = True
+    abort if any task fails = True
     [[event hooks]]
-        timeout handler = rose suite-hook --shutdown
+        abort on timeout = True
         timeout = PT2M
 [scheduling]
     initial cycle point = 20130101T0000Z
@@ -12,17 +13,8 @@
             graph = my_task_1
 
 [runtime]
-    [[root]]
+    [[my_task_1]]
         env-script = """
-eval $(rose task-env --cycle-offset=PT12H --path=MY_PATH='etc/my-path/*')
+eval $(rose task-env --cycle-offset=PT12H --cycle-offset=-PT12H --path=MY_PATH='etc/my-path/*')
 """
         script = rose task-run --path=MY_PATH='etc/your-path'
-        [[[event hooks]]]
-           succeeded handler = rose suite-hook
-           failed handler = rose suite-hook --shutdown
-           submission failed handler = rose suite-hook --shutdown
-           submission timeout handler = rose suite-hook
-           execution timeout handler = rose suite-hook
-           submission timeout = PT1M
-           execution timeout = PT1M
-    [[my_task_1]]


### PR DESCRIPTION
Ensure a future cycle offset generates a `ROSE_DATAC__????` environment variable.

@arjclark please review and/or reassign. Looks like we don't have a test for this documented functionality.