### PR TITLE
rose bunch tutorial: Correct [bunch]name= to [bunch]names=

### DIFF
--- a/doc/rose-rug-advanced-tutorials-bunch.html
+++ b/doc/rose-rug-advanced-tutorials-bunch.html
@@ -290,7 +290,7 @@ chmod +x land
               can sometimes be difficult to quickly identify which
               file to look in for output. To aid this, <code>rose
               bunch</code> supports naming command instances via
-              the <code>[bunch]name=</code> option.</p>
+              the <code>[bunch]names=</code> option.</p>
             </div>
 
             <div class="slide">


### PR DESCRIPTION
Typo corrected.

@benfitzpatrick - corrected. Only needs the one review.