### PR TITLE
t: rose-config-edit-00: fix traceback display

### DIFF
--- a/t/rose-config-edit/00-pytest.t
+++ b/t/rose-config-edit/00-pytest.t
@@ -1,17 +1,27 @@
 #!/bin/bash
+#-------------------------------------------------------------------------------
+# (C) British Crown Copyright 2012-6 Met Office.
+#
+# This file is part of Rose, a framework for meteorological suites.
+#
+# Rose is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Rose is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Rose. If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+. "$(dirname "$0")/test_header"
 set -eu
 
-# These unit tests are run with py.test, which requires the 'pytest-tap' plugin
-# to output in TAP format
-
-skip_all() {
-    echo "1..0 # SKIP $@"
-    exit
-}
-
-if ! python -c 'import pytest, tap'; then
-    skip_all 'Python package "pytest-tap" not installed'
-else
-    # Ask py.test to output in TAP format
-    py.test --tap-stream
+if ! python -c 'import pytest, tap' 2>'/dev/null'; then
+    skip_all '"pytest-tap" not installed'
 fi
+py.test --tap-stream
+exit

--- a/t/rose-config-edit/test_header
+++ b/t/rose-config-edit/test_header
@@ -1,0 +1,1 @@
+../lib/bash/test_header


### PR DESCRIPTION
Don't display traceback on failure to import pytest module, and bring test file in line with our normal style.

@benfitzpatrick please review.