### PR TITLE
t: rose-config-edit-00: fix py.test argument

### DIFF
--- a/t/rose-config-edit/00-pytest.t
+++ b/t/rose-config-edit/00-pytest.t
@@ -20,8 +20,8 @@
 . "$(dirname "$0")/test_header"
 set -eu
 
-if ! python -c 'import pytest, tap' 2>'/dev/null'; then
-    skip_all '"pytest-tap" not installed'
+if ! python -c 'import mock, pytest, tap' 2>'/dev/null'; then
+    skip_all 'Python modules "mock", "pytest" or "tap" not installed'
 fi
-py.test --tap-stream
+py.test --tap-stream "${TEST_SOURCE_DIR}"
 exit


### PR DESCRIPTION
Detect missing "mock" Python module in skip logic.
Supply `${TEST_SOURCE_DIR}` as argument to `py.test`.

Follow up of #1929 and #1941.