### PR TITLE
rose doc erratum

### DIFF
--- a/doc/etc/rose-rug-advanced-tutorials-fail-if/meta/rose-meta.conf.html
+++ b/doc/etc/rose-rug-advanced-tutorials-fail-if/meta/rose-meta.conf.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-
+<html>
 <head>
 
   <title>Rose User Guide - Advanced Tutorials: fail-if, warn-if

--- a/doc/etc/rose-rug-advanced-tutorials-jinja2/rose-app.conf.html
+++ b/doc/etc/rose-rug-advanced-tutorials-jinja2/rose-app.conf.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-
+<html>
 <head>
 
   <title>Rose User Guide - Advanced Tutorials: Jinja2

--- a/doc/etc/rose-rug-advanced-tutorials-jinja2/suite.rc.standalone.html
+++ b/doc/etc/rose-rug-advanced-tutorials-jinja2/suite.rc.standalone.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-
+<html>
 <head>
 
   <title>Rose User Guide - Advanced Tutorials: Jinja2

--- a/doc/etc/rose-rug-advanced-tutorials-jinja2/suite.rc.start.html
+++ b/doc/etc/rose-rug-advanced-tutorials-jinja2/suite.rc.start.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-
+<html>
 <head>
 
   <title>Rose User Guide - Advanced Tutorials: Jinja2

--- a/doc/etc/rose-rug-advanced-tutorials-macro/planet.py.start.html
+++ b/doc/etc/rose-rug-advanced-tutorials-macro/planet.py.start.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-
+<html>
 <head>
 
   <title>Rose User Guide - Advanced Tutorials: Custom Macro

--- a/doc/etc/rose-rug-advanced-tutorials-macro/planet.py.transform-kwargs.html
+++ b/doc/etc/rose-rug-advanced-tutorials-macro/planet.py.transform-kwargs.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-
+<html>
 <head>
 
   <title>Rose User Guide - Advanced Tutorials: Custom Macro

--- a/doc/etc/rose-rug-advanced-tutorials-macro/planet.py.transform-start.html
+++ b/doc/etc/rose-rug-advanced-tutorials-macro/planet.py.transform-start.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-
+<html>
 <head>
 
   <title>Rose User Guide - Advanced Tutorials: Custom Macro

--- a/doc/etc/rose-rug-advanced-tutorials-macro/planet.py.transform.html
+++ b/doc/etc/rose-rug-advanced-tutorials-macro/planet.py.transform.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-
+<html>
 <head>
 
   <title>Rose User Guide - Advanced Tutorials: Custom Macro

--- a/doc/etc/rose-rug-advanced-tutorials-macro/planet.py.validate.html
+++ b/doc/etc/rose-rug-advanced-tutorials-macro/planet.py.validate.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-
+<html>
 <head>
 
   <title>Rose User Guide - Advanced Tutorials: Custom Macro

--- a/doc/etc/rose-rug-advanced-tutorials-multi-inherit/output.html
+++ b/doc/etc/rose-rug-advanced-tutorials-multi-inherit/output.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-
+<html>
 <head>
 
   <title>Rose User Guide - Advanced Tutorials: Multiple Inheritance

--- a/doc/etc/rose-rug-advanced-tutorials-multi-inherit/suite.rc.html
+++ b/doc/etc/rose-rug-advanced-tutorials-multi-inherit/suite.rc.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-
+<html>
 <head>
 
   <title>Rose User Guide - Advanced Tutorials: Suite Date/Time

--- a/doc/etc/rose-rug-advanced-tutorials-rose-bunch/src/land.html
+++ b/doc/etc/rose-rug-advanced-tutorials-rose-bunch/src/land.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-
+<html>
 <head>
 
   <title>Rose User Guide - Rose Bunch Advanced Tutorial land

--- a/doc/etc/rose-rug-advanced-tutorials-rose-stem/src/kgo.txt.html
+++ b/doc/etc/rose-rug-advanced-tutorials-rose-stem/src/kgo.txt.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-
+<html>
 <head>
 
   <title>Rose User Guide - Rose-stem Tutorial kgo.txt</title>

--- a/doc/etc/rose-rug-advanced-tutorials-rose-stem/src/spaceship_command.f90.html
+++ b/doc/etc/rose-rug-advanced-tutorials-rose-stem/src/spaceship_command.f90.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-
+<html>
 <head>
 
   <title>Rose User Guide - Rose-stem Tutorial

--- a/doc/etc/rose-rug-advanced-tutorials-rose-stem/src/suite.rc.html
+++ b/doc/etc/rose-rug-advanced-tutorials-rose-stem/src/suite.rc.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-
+<html>
 <head>
 
   <title>Rose User Guide - Rose-stem Tutorial suite.rc</title>

--- a/doc/etc/rose-rug-advanced-tutorials-suite-date-time/suite.rc.html
+++ b/doc/etc/rose-rug-advanced-tutorials-suite-date-time/suite.rc.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-
+<html>
 <head>
 
   <title>Rose User Guide - Advanced Tutorials: Suite Date/Time

--- a/doc/etc/rose-rug-advanced-tutorials-trigger/meta/rose-meta.conf.html
+++ b/doc/etc/rose-rug-advanced-tutorials-trigger/meta/rose-meta.conf.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-
+<html>
 <head>
 
   <title>Rose User Guide - Advanced Tutorials: Trigger

--- a/doc/etc/rose-rug-advanced-tutorials-widget/username.py.html
+++ b/doc/etc/rose-rug-advanced-tutorials-widget/username.py.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-
+<html>
 <head>
 
   <title>Rose User Guide - Advanced Tutorials: Widget

--- a/doc/etc/rose-rug-advanced-tutorials-widget/username.py.start.html
+++ b/doc/etc/rose-rug-advanced-tutorials-widget/username.py.start.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-
+<html>
 <head>
 
   <title>Rose User Guide - Advanced Tutorials: Widget

--- a/doc/etc/rose-rug-suite-writing-tutorial/src/dead_reckoning.f90.html
+++ b/doc/etc/rose-rug-suite-writing-tutorial/src/dead_reckoning.f90.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-
+<html>
 <head>
 
   <title>Rose User Guide - Suite Writing Tutorial

--- a/doc/etc/rose-rug-suite-writing-tutorial/suite.rc.html
+++ b/doc/etc/rose-rug-suite-writing-tutorial/suite.rc.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-
+<html>
 <head>
 
   <title>Rose User Guide - Suite Writing Tutorial suite.rc</title>

--- a/doc/js/rose-doc.js
+++ b/doc/js/rose-doc.js
@@ -368,26 +368,37 @@ $(function () {
                 // namespace all section ids and add h2 elements to the nav
                 pathStr = $(this).attr("id");
                 var headings = $(this).find("h2, h3, h4, h5, h6");
-                var k;
+                var hed;
+                var anc;
                 var headingID;
-                for (k = 0; k < headings.length; k += 1) {
-                    if (!$(headings[k]).attr("id")) {
+                var origID;
+                for (hed = 0; hed < headings.length; hed += 1) {
+                    if (!$(headings[hed]).attr("id")) {
                         continue;
                     }
-                    headingID = safeID($(headings[k]).attr("id"));
+                    origID = $(headings[hed]).attr('id');
+                    headingID = safeID(origID);
                     if (headingID !== null) {
                         // namespace the heading
-                        $(headings[k]).attr({"id": pathStr + "_" + headingID});
-                        if (headings[k].tagName === "H2") {
+                        $(headings[hed]).attr({"id": pathStr + "_" + headingID});
+                        if (headings[hed].tagName === "H2") {
                             // if heading is an h2 element add to the sidebar
                             // nav
                             ul.append(
                                 $("<li />").append(
                                     $("<a />", {
                                         "href": "#" + pathStr + "_" + headingID
-                                    }).append($(headings[k]).html())
+                                    }).append($(headings[hed]).html())
                                 )
                             );
+
+                            // update anything that was referencing this header
+                            var anchors = $(this)
+                                .find('a[href="#' + origID + '"]');
+                            for (anc = 0; anc < anchors.length; anc += 1) {
+                                $(anchors[anc]).attr(
+                                    'href', '#' + pathStr + "_" + headingID);
+                            }
                         }
                     }
                 }

--- a/doc/rose-api.html
+++ b/doc/rose-api.html
@@ -1,5 +1,5 @@
-<!DOCTYPE html">
-
+<!DOCTYPE html>
+<html>
 <head>
 
   <title>Rose Reference Guide: API</title>

--- a/doc/rose-command.html
+++ b/doc/rose-command.html
@@ -1,5 +1,5 @@
-<!DOCTYPE html">
-
+<!DOCTYPE html>
+<html>
 <head>
 
   <title>Rose Reference Guide: CLI</title>

--- a/doc/rose-configuration-metadata.html
+++ b/doc/rose-configuration-metadata.html
@@ -1,5 +1,5 @@
-<!DOCTYPE html">
-
+<!DOCTYPE html>
+<html>
 <head>
 
   <title>Rose Reference Guide: Configuration Metadata</title>

--- a/doc/rose-configuration.html
+++ b/doc/rose-configuration.html
@@ -1,5 +1,5 @@
-<!DOCTYPE html">
-
+<!DOCTYPE html>
+<html>
 <head>
 
   <title>Rose Reference Guide: Configuration</title>

--- a/doc/rose-install.html
+++ b/doc/rose-install.html
@@ -1,5 +1,5 @@
-<!DOCTYPE html">
-
+<!DOCTYPE html>
+<html>
 <head>
 
   <title>Rose: Installation</title>

--- a/doc/rose-introduction.html
+++ b/doc/rose-introduction.html
@@ -1,5 +1,5 @@
-<!DOCTYPE html">
-
+<!DOCTYPE html>
+<html>
 <head>
 
   <title>Rose Documentation: What is Rose?</title>

--- a/doc/rose-quick-ref.html
+++ b/doc/rose-quick-ref.html
@@ -1,5 +1,5 @@
-<!DOCTYPE html">
-
+<!DOCTYPE html>
+<html>
 <head>
 
   <title>Rose Reference Guide: CLI</title>

--- a/doc/rose-rosie-advice.html
+++ b/doc/rose-rosie-advice.html
@@ -1,5 +1,5 @@
-<!DOCTYPE html">
-
+<!DOCTYPE html>
+<html>
 <head>
 
   <title>Rose Micellaneous: rosie create v copy v checkout</title>

--- a/doc/rose-rug-advanced-tutorials-arch.html
+++ b/doc/rose-rug-advanced-tutorials-arch.html
@@ -1,5 +1,5 @@
-<!DOCTYPE html">
-
+<!DOCTYPE html>
+<html>
 <head>
 
   <title>Rose Advanced Tutorial: rose_arch</title>

--- a/doc/rose-rug-advanced-tutorials-broadcast.html
+++ b/doc/rose-rug-advanced-tutorials-broadcast.html
@@ -1,5 +1,5 @@
-<!DOCTYPE html">
-
+<!DOCTYPE html>
+<html>
 <head>
 
   <title>Rose Advanced Tutorial: cylc broadcast</title>

--- a/doc/rose-rug-advanced-tutorials-bunch.html
+++ b/doc/rose-rug-advanced-tutorials-bunch.html
@@ -1,5 +1,5 @@
-<!DOCTYPE html">
-
+<!DOCTYPE html>
+<html>
 <head>
 
   <title>Rose Advanced Tutorial: Rose Bunch</title>

--- a/doc/rose-rug-advanced-tutorials-clock-triggered.html
+++ b/doc/rose-rug-advanced-tutorials-clock-triggered.html
@@ -1,5 +1,5 @@
-<!DOCTYPE html">
-
+<!DOCTYPE html>
+<html>
 <head>
 
   <title>Rose Advanced Tutorial: Clock triggered tasks</title>

--- a/doc/rose-rug-advanced-tutorials-command-key.html
+++ b/doc/rose-rug-advanced-tutorials-command-key.html
@@ -1,5 +1,5 @@
-<!DOCTYPE html">
-
+<!DOCTYPE html>
+<html>
 <head>
 
   <title>Rose Advanced Tutorial: alternate commands</title>

--- a/doc/rose-rug-advanced-tutorials-fail-if.html
+++ b/doc/rose-rug-advanced-tutorials-fail-if.html
@@ -1,5 +1,5 @@
-<!DOCTYPE html">
-
+<!DOCTYPE html>
+<html>
 <head>
 
   <title>Rose Advanced Tutorial: fail-if, warn-if</title>

--- a/doc/rose-rug-advanced-tutorials-family-trigs.html
+++ b/doc/rose-rug-advanced-tutorials-family-trigs.html
@@ -1,5 +1,5 @@
-<!DOCTYPE html">
-
+<!DOCTYPE html>
+<html>
 <head>
 
   <title>Rose Advanced Tutorial: family triggers</title>

--- a/doc/rose-rug-advanced-tutorials-jinja2.html
+++ b/doc/rose-rug-advanced-tutorials-jinja2.html
@@ -1,5 +1,5 @@
-<!DOCTYPE html">
-
+<!DOCTYPE html>
+<html>
 <head>
 
   <title>Rose Advanced Tutorial: suite.rc Templating</title>

--- a/doc/rose-rug-advanced-tutorials-macro.html
+++ b/doc/rose-rug-advanced-tutorials-macro.html
@@ -1,5 +1,5 @@
-<!DOCTYPE html">
-
+<!DOCTYPE html>
+<html>
 <head>
 
   <title>Rose Advanced Tutorial: Custom Macros</title>

--- a/doc/rose-rug-advanced-tutorials-multi-inherit.html
+++ b/doc/rose-rug-advanced-tutorials-multi-inherit.html
@@ -1,5 +1,5 @@
-<!DOCTYPE html">
-
+<!DOCTYPE html>
+<html>
 <head>
 
   <title>Rose Advanced Tutorial: Suite Multiple Inheritance</title>

--- a/doc/rose-rug-advanced-tutorials-opt-conf.html
+++ b/doc/rose-rug-advanced-tutorials-opt-conf.html
@@ -1,5 +1,5 @@
-<!DOCTYPE html">
-
+<!DOCTYPE html>
+<html>
 <head>
 
   <title>Rose Advanced Tutorial: Optional Configurations</title>

--- a/doc/rose-rug-advanced-tutorials-polling.html
+++ b/doc/rose-rug-advanced-tutorials-polling.html
@@ -1,5 +1,5 @@
-<!DOCTYPE html">
-
+<!DOCTYPE html>
+<html>
 <head>
 
   <title>Rose Advanced Tutorial: polling</title>

--- a/doc/rose-rug-advanced-tutorials-queues.html
+++ b/doc/rose-rug-advanced-tutorials-queues.html
@@ -1,5 +1,5 @@
-<!DOCTYPE html">
-
+<!DOCTYPE html>
+<html>
 <head>
 
   <title>Rose Advanced Tutorial: Queues</title>

--- a/doc/rose-rug-advanced-tutorials-remotes.html
+++ b/doc/rose-rug-advanced-tutorials-remotes.html
@@ -1,5 +1,5 @@
-<!DOCTYPE html">
-
+<!DOCTYPE html>
+<html>
 <head>
 
   <title>Rose Advanced Tutorial: remote hosts</title>

--- a/doc/rose-rug-advanced-tutorials-retries.html
+++ b/doc/rose-rug-advanced-tutorials-retries.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-
+<html>
 <head>
 
   <title>Rose Advanced Tutorial: Retries</title>

--- a/doc/rose-rug-advanced-tutorials-rose-stem.html
+++ b/doc/rose-rug-advanced-tutorials-rose-stem.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-
+<html>
 <head>
 
   <title>Rose Advanced Tutorial: Testing with rose stem</title>

--- a/doc/rose-rug-advanced-tutorials-suicide.html
+++ b/doc/rose-rug-advanced-tutorials-suicide.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-
+<html>
 <head>
 
   <title>Rose Advanced Tutorial: suicide triggers</title>

--- a/doc/rose-rug-advanced-tutorials-suite-date-time.html
+++ b/doc/rose-rug-advanced-tutorials-suite-date-time.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-
+<html>
 <head>
 
   <title>Rose Advanced Tutorial: Suite Date/Time

--- a/doc/rose-rug-advanced-tutorials-trigger.html
+++ b/doc/rose-rug-advanced-tutorials-trigger.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-
+<html>
 <head>
 
   <title>Rose Advanced Tutorial: trigger</title>

--- a/doc/rose-rug-advanced-tutorials-upgrade-dev.html
+++ b/doc/rose-rug-advanced-tutorials-upgrade-dev.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-
+<html>
 <head>
 
   <title>Rose Advanced Tutorial: Upgrade Macro Development</title>

--- a/doc/rose-rug-advanced-tutorials-upgrade-usage.html
+++ b/doc/rose-rug-advanced-tutorials-upgrade-usage.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-
+<html>
 <head>
 
   <title>Rose Advanced Tutorial: Upgrade Usage</title>

--- a/doc/rose-rug-advanced-tutorials-widget.html
+++ b/doc/rose-rug-advanced-tutorials-widget.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-
+<html>
 <head>
 
   <title>Rose Advanced Tutorial: Custom Widgets</title>

--- a/doc/rose-rug-appendix-training.html
+++ b/doc/rose-rug-appendix-training.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-
+<html>
 <head>
 
   <title>Rose User Guide: Appendix - Giving a Training

--- a/doc/rose-rug-brief-tour.html
+++ b/doc/rose-rug-brief-tour.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-
+<html>
 <head>
 
   <title>Rose User Guide: A Brief Tour</title>

--- a/doc/rose-rug-config-edit.html
+++ b/doc/rose-rug-config-edit.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-
+<html>
 <head>
 
   <title>Rose User Guide: Rose Config Edit</title>

--- a/doc/rose-rug-files.html
+++ b/doc/rose-rug-files.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-
+<html>
 <head>
 
   <title>Rose User Guide: Suite Files and Rosie</title>

--- a/doc/rose-rug-getting-started.html
+++ b/doc/rose-rug-getting-started.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-
+<html>
 <head>
 
   <title>Rose User Guide: Getting Started</title>

--- a/doc/rose-rug-introduction.html
+++ b/doc/rose-rug-introduction.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-
+<html>
 <head>
 
   <title>Rose User Guide: Introduction</title>

--- a/doc/rose-rug-metadata-tutorial.html
+++ b/doc/rose-rug-metadata-tutorial.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-
+<html>
 <head>
 
   <title>Rose User Guide: Configuration Metadata Tutorial</title>

--- a/doc/rose-rug-metadata.html
+++ b/doc/rose-rug-metadata.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-
+<html>
 <head>
 
   <title>Rose User Guide: Configuration Metadata</title>

--- a/doc/rose-rug-quiz.html
+++ b/doc/rose-rug-quiz.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-
+<html>
 <head>
 
   <title>Rose User Guide: Quiz</title>

--- a/doc/rose-rug-rosie-go.html
+++ b/doc/rose-rug-rosie-go.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-
+<html>
 <head>
 
   <title>Rose User Guide: Rosie Go</title>

--- a/doc/rose-rug-stem.html
+++ b/doc/rose-rug-stem.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-
+<html>
 <head>
 
   <title>Rose User Guide: rose stem</title>

--- a/doc/rose-rug-suite-control.html
+++ b/doc/rose-rug-suite-control.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-
+<html>
 <head>
 
   <title>Rose User Guide: Suite Control</title>

--- a/doc/rose-rug-suite-writing-tutorial.html
+++ b/doc/rose-rug-suite-writing-tutorial.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-
+<html>
 <head>
 
   <title>Rose User Guide: Suite Writing Tutorial</title>

--- a/doc/rose-rug-suites-I.html
+++ b/doc/rose-rug-suites-I.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-
+<html>
 <head>
 
   <title>Rose User Guide: Suites I</title>

--- a/doc/rose-rug-suites-II.html
+++ b/doc/rose-rug-suites-II.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-
+<html>
 <head>
 
   <title>Rose User Guide: Suites II</title>

--- a/doc/rose-rug-task-run.html
+++ b/doc/rose-rug-task-run.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-
+<html>
 <head>
 
   <title>Rose User Guide: Running Tasks</title>

--- a/doc/rose-single-page.html
+++ b/doc/rose-single-page.html
@@ -39,7 +39,7 @@
           <li>
             <span class="navbar-text">
               <span class="compliance">
-                &copy; British Crown Copyright 2012-6
+                &#169; British Crown Copyright 2012-6
                 <a href="http://www.metoffice.gov.uk">Met Office</a>.
                 See <a href="rose-terms-of-use.html">Terms of Use</a>.<br />
                 This document is released under the

--- a/doc/rose-terms-of-use.html
+++ b/doc/rose-terms-of-use.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-
+<html>
 <head>
 
   <title>Rose: Terms of Use</title>

--- a/doc/rose-variables.html
+++ b/doc/rose-variables.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-
+<html>
 <head>
 
   <title>Rose Reference Guide: Variables</title>

--- a/doc/rose.html
+++ b/doc/rose.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
-
+<html>
 <head>
-
   <title>Rose Documentation</title>
   <meta name="author" content="Rose Team, Met Office, UK" />
   <meta http-equiv="Content-Type" content=
@@ -39,7 +38,7 @@
         </div>
 
         <div class="col-md-3 col-sm-12">
-          <small>&copy; British Crown Copyright 2012-6 <a href=
+          <small>&#169; British Crown Copyright 2012-6 <a href=
           "http://www.metoffice.gov.uk">Met Office</a>. See
           <a href="rose-terms-of-use.html">Terms of Use</a>.<br />
           This document is released under the <a href=

--- a/doc/template/etc.html
+++ b/doc/template/etc.html
@@ -35,7 +35,7 @@
           <li>
             <span class="navbar-text">
               <span class="compliance">
-                &copy; British Crown Copyright 2012-6
+                &#169; British Crown Copyright 2012-6
                 <a href="http://www.metoffice.gov.uk">Met Office</a>.
                 See <a href="rose-terms-of-use.html">Terms of Use</a>.<br />
                 This document is released under the

--- a/doc/template/regular.html
+++ b/doc/template/regular.html
@@ -42,7 +42,7 @@
           <li>
             <span class="navbar-text">
               <span class="compliance">
-                &copy; British Crown Copyright 2012-6
+                &#169; British Crown Copyright 2012-6
                 <a href="http://www.metoffice.gov.uk">Met Office</a>.
                 See <a href="rose-terms-of-use.html">Terms of Use</a>.<br />
                 This document is released under the

--- a/doc/template/slides.html
+++ b/doc/template/slides.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
-
-
+<html>
 <head>
   <title><!-- TODO: Title --></title>
   <meta name="author" content="Rose Team, Met Office, UK" />
@@ -49,7 +48,7 @@
           <li>
             <span class="navbar-text">
               <span class="compliance">
-                &copy; British Crown Copyright 2012-6
+                &#169; British Crown Copyright 2012-6
                 <a href="http://www.metoffice.gov.uk">Met Office</a>.
                 See <a href="rose-terms-of-use.html">Terms of Use</a>.<br />
                 This document is released under the


### PR DESCRIPTION
Fixes a bug whereby anchors linked to fragment urls (e.g. #section) were broken in single page view due to namespacing (e.g. the links under Rose Reference Guide => Command Line Interface => Overview => Rose Commands).
Also adds some (embarrassingly) missing `<html>` tags and changes any `&copy;` to `&#169;` (Firefox seems to prefer it).

@matthewrmshin Please review and add second if required.