### PR TITLE
rose edit, rosie go: handle site/user incorrect value types

### DIFF
--- a/doc/rose-rug-config-edit.html
+++ b/doc/rose-rug-config-edit.html
@@ -562,99 +562,99 @@ should_show_custom_help=True
             title.</p>
 
             <h4 id="options-should_show_all_comments">
-            should_show_all_comments=false</h4>
+            should_show_all_comments=False</h4>
 
             <p>Control showing all comment text.</p>
 
             <h4 id="options-should_show_custom_description">
-            should_show_custom_description=false</h4>
+            should_show_custom_description=False</h4>
 
             <p>Control showing a custom variable description
             format.</p>
 
             <h4 id="options-should_show_custom_help">
-            should_show_custom_help=false</h4>
+            should_show_custom_help=False</h4>
 
             <p>Control showing a custom variable help format.</p>
 
             <h4 id="options-should_show_custom_title">
-            should_show_custom_title=false</h4>
+            should_show_custom_title=False</h4>
 
             <p>control showing a custom variable title format.</p>
 
             <h4 id="options-should_show_fixed_vars">
-            should_show_fixed_vars=false</h4>
+            should_show_fixed_vars=False</h4>
 
             <p>Control showing fixed variables on a page.</p>
 
             <h4 id="options-should_show_flag_no_meta_vars">
-            should_show_flag_no_meta_vars=false</h4>
+            should_show_flag_no_meta_vars=False</h4>
 
             <p>Control flagging no-metadata variables.</p>
 
             <h4 id="options-should_show_flag_opt_conf_vars">
-            should_show_flag_opt_conf_vars=true</h4>
+            should_show_flag_opt_conf_vars=True</h4>
 
             <p>Control flagging optional configuration
             variables.</p>
 
             <h4 id="options-should_show_flag_optional_vars">
-            should_show_flag_optional_vars=false</h4>
+            should_show_flag_optional_vars=False</h4>
 
             <p>Control flagging non-compulsory variables.</p>
 
             <h4 id="options-should_show_ignored_pages">
-            should_show_ignored_pages=false</h4>
+            should_show_ignored_pages=False</h4>
 
             <p>Control showing ! or !! ignored pages.</p>
 
             <h4 id="options-should_show_ignored_vars">
-            should_show_ignored_vars=false</h4>
+            should_show_ignored_vars=False</h4>
 
             <p>Control showing ! or !! ignored variables on a
             page.</p>
 
             <h4 id="options-should_show_latent_pages">
-            should_show_latent_pages=false</h4>
+            should_show_latent_pages=False</h4>
 
             <p>Control showing latent (potential) pages.</p>
 
             <h4 id="options-should_show_latent_vars">
-            should_show_latent_vars=false</h4>
+            should_show_latent_vars=False</h4>
 
             <p>Control showing latent (potential) variables on a
             page.</p>
 
             <h4 id="options-should_show_no_description">
-            should_show_no_description=false</h4>
+            should_show_no_description=False</h4>
 
             <p>control hiding the description text for variables on
             a page.</p>
 
             <h4 id="options-should_show_no_help">
-            should_show_no_help=true</h4>
+            should_show_no_help=True</h4>
 
             <p>Control hiding the help text for variables on a
             page.</p>
 
             <h4 id="options-should_show_no_title">
-            should_show_no_title=false</h4>
+            should_show_no_title=False</h4>
 
             <p>Control hiding the title text for variables on a
             page.</p>
 
             <h4 id="options-should_show_status_bar">
-            should_show_status_bar=true</h4>
+            should_show_status_bar=True</h4>
 
             <p>Control showing the status bar.</p>
 
             <h4 id="options-should_show_user_ignored_pages">
-            should_show_user_ignored_pages=true</h4>
+            should_show_user_ignored_pages=True</h4>
 
             <p>Control showing ! ignored pages.</p>
 
             <h4 id="options-should_show_user_ignored_vars">
-            should_show_user_ignored_vars=true</h4>
+            should_show_user_ignored_vars=True</h4>
 
             <p>Control showing ! ignored variables on a page.</p>
 

--- a/lib/python/rose/config_editor/__init__.py
+++ b/lib/python/rose/config_editor/__init__.py
@@ -720,23 +720,42 @@ UNTITLED_NAME = "Untitled"
 VAR_ID_IN_CONFIG = "Variable id {0} from the configuration {1}"
 
 
+class OverrideValueError(Exception):
+
+    """An error raised on failure to override a particular constant above."""
+
+    OVERRIDE_WARNING = "{0}={1}={2}: site/user conf: was {3}, supplied {4}"
+
+    def __str__(self):
+        return self.OVERRIDE_WARNING.format(*self.args)
+
+
 def false_function(*args, **kwargs):
     """Return False, no matter what the arguments are."""
     return False
 
 
-def load_override_config():
-    conf = ResourceLocator.default().get_conf().get(["rose-config-edit"])
-    if conf is None:
-        return
-    for key, node in conf.value.items():
-        if node.is_ignored():
+def load_override_config(sections, my_globals=None):
+    if my_globals is None:
+        my_globals = globals()
+    for section in sections:
+        conf = ResourceLocator.default().get_conf().get([section])
+        if conf is None:
             continue
-        try:
-            cast_value = ast.literal_eval(node.value)
-        except Exception:
-            cast_value = node.value
-        globals()[key.replace("-", "_").upper()] = cast_value
+        for key, node in conf.value.items():
+            if node.is_ignored():
+                continue
+            try:
+                cast_value = ast.literal_eval(node.value)
+            except Exception:
+                cast_value = node.value
+            name = key.replace("-", "_").upper()
+            orig_value = my_globals[name]
+            if (type(orig_value) is not type(cast_value) and
+                    orig_value is not None):
+                raise OverrideValueError(section, key, cast_value,
+                                         type(orig_value), type(cast_value))
+            my_globals[name] = cast_value
 
 
-load_override_config()
+load_override_config(["rose-config-edit"])

--- a/lib/python/rose/config_editor/__init__.py
+++ b/lib/python/rose/config_editor/__init__.py
@@ -727,7 +727,6 @@ _OVERRIDE_WARNING_TYPE = (
     "Cannot override: {0}={1}={2}: site/user conf: was {3}, supplied {4}\n")
 
 
-
 def false_function(*args, **kwargs):
     """Return False, no matter what the arguments are."""
     return False

--- a/lib/python/rosie/browser/__init__.py
+++ b/lib/python/rosie/browser/__init__.py
@@ -53,6 +53,7 @@ text, remembering to add the [rosie-go] section.
 import ast
 import os
 
+from rose.config_editor import load_override_config
 from rose.resource import ResourceLocator
 
 # Accelerators
@@ -272,21 +273,4 @@ SPLASH_SEARCH_MANAGER = "search manager"
 SPLASH_SETUP_WINDOW = "main window"
 
 
-def load_override_config():
-    """Load any overrides of the above settings."""
-    conf = ResourceLocator.default().get_conf()
-    for s in ["rosie-browse", "rosie-go"]:
-        node = conf.get([s], no_ignore=True)
-        if node is None:
-            continue
-        for key, node in node.value.items():
-            if node.is_ignored():
-                continue
-            try:
-                cast_value = ast.literal_eval(node.value)
-            except Exception:
-                cast_value = node.value
-            globals()[key.replace("-", "_").upper()] = cast_value
-
-
-load_override_config()
+load_override_config(["rosie-browse", "rosie-go"], my_globals=globals())


### PR DESCRIPTION
This handles errors for site or user configuration for `rosie go` and `rose edit`.

If a user had e.g.:
```
[rose-config-edit]
should-show-custom-description=false
```
then this would evaluate to the string `'false'` instead of a boolean. This kind of error can be hard to debug. This change raises an exception if the (cast) type for an override option differs from the default
value's type, unless the default value is `None`.

I've also consolidated the override functionality since it was basically the same for `rosie go` and `rose edit`.

@arjclark, @oliver-sanders please review.