### PR TITLE
rose bush: add rotated log files to the "cylc files" menu

### DIFF
--- a/ACKNOWLEDGEMENT.md
+++ b/ACKNOWLEDGEMENT.md
@@ -66,6 +66,11 @@ lib/html/static/js/bootstrap.min.js:
   released under the Apache 2.0 license.
   See <http://getbootstrap.com/>.
 
+lib/html/static/css/rose-bush.css
+* Contains modified code from Twitter Bootstrap v2.3.1 released
+  under the Apache 2.0 licence.
+  See <http://getbootstrap.com/2.3.2/>.
+
 lib/html/static/css/jquery.dataTables.???:
 lib/html/static/images/sort_???:
 lib/html/static/js/jquery.dataTables.???:

--- a/lib/html/static/css/rose-bush.css
+++ b/lib/html/static/css/rose-bush.css
@@ -41,5 +41,67 @@ pre {
      }
     .page_entries select {
         width: 300px;
-     } 
+     }
+}
+
+
+/* dropdown-submenu code from bootstrap v2.3.1 (removed in v3.x)
+   see boostrap v2.3.1 docs/assets/css/boostrap.css #3031->3075 */
+.dropdown-submenu {
+  position: relative;
+}
+
+.dropdown-submenu > .dropdown-menu {
+  top: 0;
+  left: 100%;
+  margin-top: -6px;
+  margin-left: -1px;
+  -webkit-border-radius: 0 6px 6px 6px;
+     -moz-border-radius: 0 6px 6px 6px;
+          border-radius: 0 6px 6px 6px;
+}
+
+.dropdown-submenu:hover > .dropdown-menu {
+  display: block;
+}
+
+.dropup .dropdown-submenu > .dropdown-menu {
+  top: auto;
+  bottom: 0;
+  margin-top: 0;
+  margin-bottom: -2px;
+  -webkit-border-radius: 5px 5px 5px 0;
+     -moz-border-radius: 5px 5px 5px 0;
+          border-radius: 5px 5px 5px 0;
+}
+
+.dropdown-submenu > a:after {
+  display: block;
+  float: right;
+  width: 0;
+  height: 0;
+  margin-top: 5px;
+  margin-right: -10px;
+  border-color: transparent;
+  border-left-color: #cccccc;
+  border-style: solid;
+  border-width: 5px 0 5px 5px;
+  content: " ";
+}
+
+.dropdown-submenu:hover > a:after {
+  //border-left-color: #ffffff;
+  border-left-color: #222222;  // make the right arrow visible on hover
+}
+
+.dropdown-submenu.pull-left {
+  float: none;
+}
+
+.dropdown-submenu.pull-left > .dropdown-menu {
+  left: -100%;
+  margin-left: 10px;
+  -webkit-border-radius: 6px 0 6px 6px;
+     -moz-border-radius: 6px 0 6px 6px;
+          border-radius: 6px 0 6px 6px;
 }

--- a/lib/html/template/rose-bush/suite-base.html
+++ b/lib/html/template/rose-bush/suite-base.html
@@ -69,9 +69,23 @@ rel="stylesheet" media="screen" />
           </a>
           <ul class="dropdown-menu">
         {% for key, log in scheme_files|dictsort -%}
+        {% if log.paths and log.paths|length > 1 -%}
+            <li class="dropdown-submenu">
+              <a href="#">{{log.path}}</a>
+              <ul class="dropdown-menu">
+        {% for log_path in log.paths -%}
+                <li>
+                  <a href="{{script}}/view/{{user}}/{{suite}}?path={{log_path}}"
+                  title="{{log.size}} bytes">{{log_path}}</a>
+                </li>
+        {% endfor -%}
+              </ul>
+            </li>
+        {% else -%}
             <li>
               <a href="{{script}}/view/{{user}}/{{suite}}?path={{log.path}}"
               title="{{log.size}} bytes">{{key}}</a></li>
+        {% endif -%}
         {% endfor -%}
           </ul>
         </li>


### PR DESCRIPTION
This adds a submenu to the "cylc files" menu listing all log file (newest at the top). If there are no older log files it displays as before.

To be merged before https://github.com/cylc/cylc/pull/1958.

@benfitzpatrick Please review
@arjclark Please review