### PR TITLE
rose config, rose edit: reduce memory use

### DIFF
--- a/lib/python/rose/config.py
+++ b/lib/python/rose/config.py
@@ -81,6 +81,9 @@ class ConfigNode(object):
 
     """Represent a node in a configuration file."""
 
+    __slots__ = ["STATE_NORMAL", "STATE_USER_IGNORED",
+                 "STATE_SYST_IGNORED", "value", "state", "comments"]
+
     STATE_NORMAL = ""
     STATE_USER_IGNORED = "!"
     STATE_SYST_IGNORED = "!!"
@@ -326,6 +329,22 @@ class ConfigNode(object):
         diff = ConfigNodeDiff()
         diff.set_from_configs(other_config_node, self)
         return diff
+
+    def __getstate__(self):
+        """Avoid pickling the STATE constants within a deepcopy.
+
+        This avoids a read-only error and allows __slots__ compatibility.
+
+        """
+        return {"state": self.state,
+                "value": self.value,
+                "comments": self.comments}
+
+    def __setstate__(self, state):
+        """Read in the results of __getstate__."""
+        self.state = state["state"]
+        self.value = state["value"]
+        self.comments = state["comments"]
 
 
 class ConfigNodeDiff(object):

--- a/lib/python/rose/variable.py
+++ b/lib/python/rose/variable.py
@@ -59,6 +59,10 @@ class Variable(object):
 
     """
 
+    __slots__ = ["name", "value", "metadata", "old_value",
+                 "flags", "ignored_reason", "error", "warning",
+                 "comments"]
+
     def __init__(self, name, value, metadata=None, ignored_reason=None,
                  error=None, warning=None, flags=None, comments=None):
         self.name = name


### PR DESCRIPTION
These changes reduce the memory footprint of rose.config.ConfigNode objects and
rose.variable.Variable objects. It saves around 20% for `rose edit` memory use for a UM app I've tested, although I think we have further to go...

@arjclark, @matthewrmshin please review.