### PR TITLE
rosie ls, go: handle corrupt working copy edge case

### DIFF
--- a/lib/python/rosie/suite_id.py
+++ b/lib/python/rosie/suite_id.py
@@ -449,9 +449,11 @@ class SuiteId(object):
         else:
             if self.branch != location_suite_id.branch:
                 self.statuses[user] = self.STATUS_SW
-            elif int(self.revision) > int(location_suite_id.revision):
+            elif (location_suite_id.revision and
+                      int(self.revision) > int(location_suite_id.revision)):
                 self.statuses[user] = self.STATUS_UP
-            elif int(self.revision) < int(location_suite_id.revision):
+            elif (location_suite_id.revision and
+                      int(self.revision) < int(location_suite_id.revision)):
                 self.statuses[user] = self.STATUS_DO
             else:
                 try:


### PR DESCRIPTION
This handles a local suite Subversion problem where the working copy's files and directories are all missing and the `.svn/wc.db` file is itself corrupt (missing all of 'NODES' table entries). The svn status gives:
```
!       .
```
and `rosie ls` or `rosie go` crashes with:
```
  File "/opt/python/runpy.py", line 122, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/opt/python/runpy.py", line 34, in _run_code
    exec code in run_globals
  File "/opt/rose/lib/python/rosie/ws_client_cli.py", line 279, in <module>
    main()
  File "/opt/rose/lib/python/rosie/ws_client_cli.py", line 270, in main
    sys.exit(func(argv[1:]))
  File "/opt/rose/lib/python/rosie/ws_client_cli.py", line 124, in list_local_suites
    _display_maps(opts, ws_client, ws_client.query_local_copies(opts.user))
  File "/opt/rose/lib/python/rosie/ws_client_cli.py", line 215, in _display_maps
    getattr(opts, "user", None))
  File "/opt/rose/lib/python/rosie/suite_id.py", line 452, in get_status
    elif int(self.revision) > int(location_suite_id.revision):
TypeError: int() argument must be a string or a number, not 'NoneType'
```

There is no `commit:revision` entry in `svn info --xml`, which ultimately gives a `None` for the location suite id revision and crashes the revision comparison in the code above. I've modified the code to check that the revision is not None.

@arjclark, @matthewrmshin please review.