### PR TITLE
Fix t: rose-bush/00, broken since cylc/cylc#1827

### DIFF
--- a/t/rose-bush/00-basic.t
+++ b/t/rose-bush/00-basic.t
@@ -159,7 +159,7 @@ rose_ws_json_greps "${TEST_KEY}.out" "${TEST_KEY}.out" \
 # A suite run directory with only a "cylc-suite.db", and nothing else
 SUITE_DIR2="$(mktemp -d --tmpdir="${HOME}/cylc-run" "rtb-rose-bush-00-XXXXXXXX")"
 SUITE_NAME2="$(basename "${SUITE_DIR2}")"
-cp -pr "${SUITE_DIR}/cylc-suite.db" "${SUITE_DIR2}/"
+cp "${SUITE_DIR}/cylc-suite.db" "${SUITE_DIR2}/"
 run_pass "${TEST_KEY}-bare" \
     curl "${TEST_ROSE_WS_URL}/jobs/${USER}/${SUITE_NAME2}?form=json"
 rose_ws_json_greps "${TEST_KEY}-bare.out" "${TEST_KEY}-bare.out" \


### PR DESCRIPTION
Fix test broken since cylc/cylc#1827. The `-p` option means that we are copying the symbolic link. The `-r` option is unnecessary. @arjclark please review.