### PR TITLE
rose edit: fix source file page widget traceback

### DIFF
--- a/lib/python/rose/config_editor/valuewidget/source.py
+++ b/lib/python/rose/config_editor/valuewidget/source.py
@@ -36,18 +36,18 @@ class SourceValueWidget(gtk.HBox):
     """This class generates a special widget for the file source variable.
 
     It cheats by passing in a special VariableOperations instance as
-    custom_arg. This is used for search and getting and updating the
+    arg_str. This is used for search and getting and updating the
     available sections.
 
     """
 
-    def __init__(self, value, metadata, set_value, hook, custom_arg=None):
+    def __init__(self, value, metadata, set_value, hook, arg_str=None):
         super(SourceValueWidget, self).__init__(homogeneous=False, spacing=0)
         self.value = value
         self.metadata = metadata
         self.set_value = set_value
         self.hook = hook
-        self.var_ops = custom_arg
+        self.var_ops = arg_str
         formats = [f for f in rose.formats.__dict__ if not f.startswith('__')]
         self.formats = formats
         self.formats_ok = None


### PR DESCRIPTION
This fixes a traceback in rose edit where opening a `file` page results in:
```
Traceback (most recent call last):
  File "/opt/rose/lib/python/rose/config_editor/nav_panel.py", line 491, in handle_activation
    self._launch_ns_func(self.get_name(path), as_new=False)
  File "/opt/rose/lib/python/rose/config_editor/main.py", line 733, in handle_launch_request
    page = self.make_page(namespace_name)
  File "/opt/rose/lib/python/rose/config_editor/main.py", line 867, in make_page
    launch_macro_func=self.main_handle.handle_run_custom_macro
  File "/opt/rose/lib/python/rose/config_editor/page.py", line 101, in __init__
    self.generate_main_container()
  File "/opt/rose/lib/python/rose/config_editor/page.py", line 674, in generate_main_container
    self.show_modes)
  File "/opt/rose/lib/python/rose/config_editor/pagewidget/table.py", line 58, in __init__
    self.attach_variable_widgets(variable_is_ghost_list, start_index=0)
  File "/opt/rose/lib/python/rose/config_editor/pagewidget/table.py", line 109, in attach_variable_widgets
    variable_widget = self.get_variable_widget(variable, is_ghost)
  File "/opt/rose/lib/python/rose/config_editor/pagewidget/table.py", line 120, in get_variable_widget
    show_modes=self.show_modes)
  File "/opt/rose/lib/python/rose/config_editor/variable.py", line 72, in __init__
    self.generate_valuewidget(variable)
  File "/opt/rose/lib/python/rose/config_editor/variable.py", line 163, in generate_valuewidget
    arg_str=custom_arg)
TypeError: __init__() got an unexpected keyword argument 'arg_str'
```

@arjclark, please review.