### PR TITLE
Rose Bush: use muted text style for zero size file links

### DIFF
--- a/lib/html/template/rose-bush/job-entry.html
+++ b/lib/html/template/rose-bush/job-entry.html
@@ -72,7 +72,7 @@
                   {{key}}
                 {% else -%}
                   <a
-                  {% if log.size == "?" -%}class="text-muted"{% endif -%}
+                  {% if log.size == "?" or not log.size -%}class="text-muted"{% endif -%}
                   href="{{script}}/view/{{user}}/{{suite}}?path={{log.path|replace('+', '%2B')}}&amp;path_in_tar={{log.path_in_tar}}"
                   title="{{log.size}} bytes">{{key}}{% if log.size == "?" -%}?{% endif -%}</a>
                 {% endif -%}
@@ -81,7 +81,7 @@
                   {{key}}
                 {% else -%}
                   <a
-                  {% if log.size == "?" -%}class="text-muted"{% endif -%}
+                  {% if log.size == "?" or not log.size -%}class="text-muted"{% endif -%}
                   href="{{script}}/view/{{user}}/{{suite}}?path={{log.path|replace('+', '%2B')}}"
                   title="{{log.size}} bytes">{{key}}{% if log.size == "?" -%}?{% endif -%}</a>
                 {% endif -%}

--- a/lib/html/template/rose-bush/job-entry.html
+++ b/lib/html/template/rose-bush/job-entry.html
@@ -87,7 +87,7 @@
                 {% endif -%}
               {% endif -%}
             {% else -%}
-              <span class="text-muted" title="{{log.size}} bytes, gone">{{key}}</span>
+                  <del class="text-muted" title="{{log.size}} bytes, gone">{{key}}</del>
             {% endif -%}
           </li>
         {% endfor -%}


### PR DESCRIPTION
Use the greyed-out style for zero size file links.

There are two other situations where a file currently has the greyed-out text-muted style:
 1) files whose transfer is in progress - but they already have a question mark to distinguish them
 2) deleted files - these now have a strikethough to distingush empty from deleted.

@matthewrmshin, please review.