### PR TITLE
rose bush: use file system for job logs listing

### DIFF
--- a/lib/html/template/rose-bush/job-entry.html
+++ b/lib/html/template/rose-bush/job-entry.html
@@ -73,7 +73,7 @@
                 {% else -%}
                   <a
                   {% if log.size == "?" or not log.size -%}class="text-muted"{% endif -%}
-                  href="{{script}}/view/{{user}}/{{suite}}?path={{log.path|replace('+', '%2B')}}&amp;path_in_tar={{log.path_in_tar}}"
+                  href="{{script}}/view/{{user}}/{{suite}}?path={{log.path|replace('+', '%2B')}}&amp;path_in_tar={{log.path_in_tar|replace('+', '%2B')}}"
                   title="{{log.size}} bytes">{{key}}{% if log.size == "?" -%}?{% endif -%}</a>
                 {% endif -%}
               {% else -%}

--- a/lib/python/rose/bush.py
+++ b/lib/python/rose/bush.py
@@ -533,10 +533,10 @@ class RoseBushService(object):
                 f.close()
         name = path
         if path_in_tar:
-            name = path_in_tar
+            name = "log/" + path_in_tar
         job_entry = None
         entry = None
-        if name.startswith("log/job/"):
+        if name.startswith("log/job"):
             names = self.suite_engine_proc.parse_job_log_rel_path(name)
             if len(names) == 4:
                 cycle, task, submit_num, ext = names

--- a/t/rose-bush/02-no-job-out.t
+++ b/t/rose-bush/02-no-job-out.t
@@ -43,7 +43,7 @@ cylc run --debug "${SUITE_NAME}"
 
 # Remove the "job.out" entry from the suite's public database.
 sqlite3 "${SUITE_DIR}/cylc-suite.db" \
-    'DELETE FROM task_job_logs WHERE filename=="job.out";'
+    'DELETE FROM task_job_logs WHERE filename=="job.out";' 2>'/dev/null' || true
 
 #-------------------------------------------------------------------------------
 


### PR DESCRIPTION
Instead of using the suite runtime database table, use file system
listing and/or the listing of the members in relevant
`log/job-CYCLE.tar.gz` files.
* The change does not appear to have much performance impact for the job lists.
* It appears to be much faster when viewing a job log file.
* The only behaviour change is that jobs with their logs removed will no longer have their log files listed.

In view mode, fix no job entry display when file is TAR-GZ archived.

@arjclark @oliver-sanders please review.