### PR TITLE
rose edit: fix info dialog for variables

### DIFF
--- a/lib/python/rose/config_editor/util.py
+++ b/lib/python/rose/config_editor/util.py
@@ -117,7 +117,11 @@ def launch_node_info_dialog(node, changes, search_function):
         text += (rose.config_editor.DIALOG_NODE_INFO_CHANGES.format(changes) +
                  "\n")
     text += rose.config_editor.DIALOG_NODE_INFO_DATA
-    att_list = vars(node).items()
+    try:
+        att_list = vars(node).items()
+    except TypeError:
+        # vars will fail when __slots__ are used.
+        att_list = node.getattrs()
     att_list.sort()
     att_list.sort(lambda x, y: (y[0] in ['name', 'value']) -
                                (x[0] in ['name', 'value']))

--- a/lib/python/rose/variable.py
+++ b/lib/python/rose/variable.py
@@ -127,6 +127,13 @@ class Variable(object):
         new_variable.old_value = self.old_value
         return new_variable
 
+    def getattrs(self):
+        """Return a list of attributes and values."""
+        attrs = []
+        for name in self.__slots__:
+            attrs.append((name, getattr(self, name)))
+        return attrs
+
     def __repr__(self):
         text = '<rose.variable :- name: ' + self.name + ', value: '
         text += (


### PR DESCRIPTION
This fixes #1969.

@matthewrmshin, please review.