### PR TITLE
rose bush: only count cycles with things in for cycle counts.

### DIFF
--- a/lib/python/rose/suite_engine_procs/cylc.py
+++ b/lib/python/rose/suite_engine_procs/cylc.py
@@ -806,9 +806,10 @@ class CylcProcessor(SuiteEngineProcessor):
 
         """
         of_n_entries = 0
+        stmt = ("SELECT COUNT(DISTINCT cycle) FROM task_states where " +
+                "status is not 'waiting'")
         for row in self._db_exec(
-                self.SUITE_DB, user_name, suite_name,
-                "SELECT COUNT(DISTINCT cycle) FROM task_states"):
+                self.SUITE_DB, user_name, suite_name, stmt):
             of_n_entries = row[0]
             break
         if not of_n_entries:

--- a/lib/python/rose/suite_engine_procs/cylc.py
+++ b/lib/python/rose/suite_engine_procs/cylc.py
@@ -806,8 +806,8 @@ class CylcProcessor(SuiteEngineProcessor):
 
         """
         of_n_entries = 0
-        stmt = ("SELECT COUNT(DISTINCT cycle) FROM task_states where " +
-                "status is not 'waiting'")
+        stmt = ("SELECT COUNT(DISTINCT cycle) FROM task_states WHERE " +
+                "submit_num > 0")
         for row in self._db_exec(
                 self.SUITE_DB, user_name, suite_name, stmt):
             of_n_entries = row[0]

--- a/t/rose-bush/00-basic.t
+++ b/t/rose-bush/00-basic.t
@@ -106,7 +106,7 @@ rose_ws_json_greps "${TEST_KEY}.out" "${TEST_KEY}.out" \
     "[('order',), None]" \
     "[('states', 'is_running',), False]" \
     "[('states', 'is_failed',), False]" \
-    "[('of_n_entries',), 2]" \
+    "[('of_n_entries',), 1]" \
     "[('entries', {'cycle': '20000101T0000Z'}, 'n_states', 'success',), 2]"
 
 TEST_KEY="${TEST_KEY_BASE}-200-curl-jobs"

--- a/t/rose-bush/07-cycles-page.t
+++ b/t/rose-bush/07-cycles-page.t
@@ -67,27 +67,27 @@ done
 rose_ws_json_greps "${TEST_KEY_PREFIX}1.out" "${TEST_KEY_PREFIX}1.out" \
     "[('page',), 1]" \
     "[('per_page',), 3]" \
-    "[('of_n_entries',), 11]" \
+    "[('of_n_entries',), 10]" \
     "[('entries', 0, 'cycle'), '20090101T0000Z']" \
     "[('entries', 1, 'cycle'), '20080101T0000Z']"
 rose_ws_json_greps "${TEST_KEY_PREFIX}2.out" "${TEST_KEY_PREFIX}2.out" \
     "[('page',), 2]" \
     "[('per_page',), 3]" \
-    "[('of_n_entries',), 11]" \
+    "[('of_n_entries',), 10]" \
     "[('entries', 0, 'cycle'), '20070101T0000Z']" \
     "[('entries', 1, 'cycle'), '20060101T0000Z']" \
     "[('entries', 2, 'cycle'), '20050101T0000Z']"
 rose_ws_json_greps "${TEST_KEY_PREFIX}3.out" "${TEST_KEY_PREFIX}3.out" \
     "[('page',), 3]" \
     "[('per_page',), 3]" \
-    "[('of_n_entries',), 11]" \
+    "[('of_n_entries',), 10]" \
     "[('entries', 0, 'cycle'), '20040101T0000Z']" \
     "[('entries', 1, 'cycle'), '20030101T0000Z']" \
     "[('entries', 2, 'cycle'), '20020101T0000Z']"
 rose_ws_json_greps "${TEST_KEY_PREFIX}4.out" "${TEST_KEY_PREFIX}4.out" \
     "[('page',), 4]" \
     "[('per_page',), 3]" \
-    "[('of_n_entries',), 11]" \
+    "[('of_n_entries',), 10]" \
     "[('entries', 0, 'cycle'), '20010101T0000Z']" \
     "[('entries', 1, 'cycle'), '20000101T0000Z']"
 #-------------------------------------------------------------------------------
@@ -103,28 +103,28 @@ done
 rose_ws_json_greps "${TEST_KEY_PREFIX}1.out" "${TEST_KEY_PREFIX}1.out" \
     "[('page',), 1]" \
     "[('per_page',), 3]" \
-    "[('of_n_entries',), 11]" \
+    "[('of_n_entries',), 10]" \
     "[('entries', 0, 'cycle'), '20000101T0000Z']" \
     "[('entries', 1, 'cycle'), '20010101T0000Z']" \
     "[('entries', 2, 'cycle'), '20020101T0000Z']"
 rose_ws_json_greps "${TEST_KEY_PREFIX}2.out" "${TEST_KEY_PREFIX}2.out" \
     "[('page',), 2]" \
     "[('per_page',), 3]" \
-    "[('of_n_entries',), 11]" \
+    "[('of_n_entries',), 10]" \
     "[('entries', 0, 'cycle'), '20030101T0000Z']" \
     "[('entries', 1, 'cycle'), '20040101T0000Z']" \
     "[('entries', 2, 'cycle'), '20050101T0000Z']"
 rose_ws_json_greps "${TEST_KEY_PREFIX}3.out" "${TEST_KEY_PREFIX}3.out" \
     "[('page',), 3]" \
     "[('per_page',), 3]" \
-    "[('of_n_entries',), 11]" \
+    "[('of_n_entries',), 10]" \
     "[('entries', 0, 'cycle'), '20060101T0000Z']" \
     "[('entries', 1, 'cycle'), '20070101T0000Z']" \
     "[('entries', 2, 'cycle'), '20080101T0000Z']"
 rose_ws_json_greps "${TEST_KEY_PREFIX}4.out" "${TEST_KEY_PREFIX}4.out" \
     "[('page',), 4]" \
     "[('per_page',), 3]" \
-    "[('of_n_entries',), 11]" \
+    "[('of_n_entries',), 10]" \
     "[('entries', 0, 'cycle'), '20090101T0000Z']"
 #-------------------------------------------------------------------------------
 # Tidy up

--- a/t/rose-bush/12-cycle-counts.t
+++ b/t/rose-bush/12-cycle-counts.t
@@ -1,0 +1,80 @@
+#!/bin/bash
+#-------------------------------------------------------------------------------
+# (C) British Crown Copyright 2012-6 Met Office.
+#
+# This file is part of Rose, a framework for meteorological suites.
+#
+# Rose is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Rose is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Rose. If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test for "rose bush", cycles list, paging.
+#-------------------------------------------------------------------------------
+. "$(dirname "$0")/test_header"
+if ! python -c 'import cherrypy' 2>'/dev/null'; then
+    skip_all '"cherrypy" not installed'
+fi
+
+tests 3
+
+ROSE_CONF_PATH= rose_ws_init 'rose' 'bush'
+if [[ -z "${TEST_ROSE_WS_PORT}" ]]; then
+    exit 1
+fi
+
+#-------------------------------------------------------------------------------
+# Run a quick cylc suite
+mkdir -p "${HOME}/cylc-run"
+SUITE_DIR="$(mktemp -d --tmpdir="${HOME}/cylc-run" "rtb-rose-bush-12-XXXXXXXX")"
+SUITE_NAME="$(basename "${SUITE_DIR}")"
+cat >"${SUITE_DIR}/suite.rc" <<'__SUITE_RC__'
+#!Jinja2
+[cylc]
+UTC mode = True
+[scheduling]
+initial cycle point = 20100101T0000Z
+final cycle point = 20100101T0000Z
+[[dependencies]]
+[[[T00]]]
+    graph = foo => bar
+[[[T06]]]
+    graph = bar[-PT6H] => baz
+[runtime]
+[[foo]]
+    script = cylc stop $CYLC_SUITE_NAME bar.20100101T0000Z; sleep 5
+[[bar, baz]]
+    script = true
+__SUITE_RC__
+export CYLC_CONF_PATH=
+cylc register "${SUITE_NAME}" "${SUITE_DIR}"
+cylc run --debug "${SUITE_NAME}" 2>'/dev/null'
+
+#-------------------------------------------------------------------------------
+# Sort by time_desc
+TEST_KEY_PREFIX="${TEST_KEY_BASE}-200-curl-cycles-page-"
+TEST_KEY="${TEST_KEY_PREFIX}1"
+PAGE_OPT="&page=1&per_page=3"
+run_pass "${TEST_KEY}" curl \
+    "${TEST_ROSE_WS_URL}/cycles/${USER}/${SUITE_NAME}?form=json${PAGE_OPT}"
+
+# N.B. Extra cycle at the end, due to spawn-held task beyond final cycle point
+rose_ws_json_greps "${TEST_KEY_PREFIX}1.out" "${TEST_KEY_PREFIX}1.out" \
+    "[('page',), 1]" \
+    "[('per_page',), 3]" \
+    "[('of_n_entries',), 1]" \
+    "[('entries', 0, 'cycle'), '20100101T0000Z']"
+#-------------------------------------------------------------------------------
+# Tidy up
+rose_ws_kill
+cylc unregister "${SUITE_NAME}" 1>'/dev/null' 2>&1
+rm -fr "${SUITE_DIR}" "${HOME}/.cylc/ports/${SUITE_NAME}" 2>'/dev/null'
+exit 0


### PR DESCRIPTION
Currently, if a cycle has waiting task proxies but no tasks in it that have run then it doesn't get displayed on the cycles page of rose bush. However, it does get counted at the bottom of the page "Entries X of Y" part. This can result in rose bush pages where the cycle counts are dramatically different from those being displayed.

This tweaks the query used to generate that count.

@matthewrmshin - please review (fixes the rose bush part of the problem seen in the VER suite the other day)