### PR TITLE
Update command line help for rose-stem

### DIFF
--- a/bin/rose-stem
+++ b/bin/rose-stem
@@ -59,13 +59,24 @@
 #     Note that <project> refers to the FCM keyword name of the repository in
 #     upper case.
 #
+#     HOST_SOURCE_<project>
+#         The complete list of source trees for a given project. Working copies
+#         in this list have their hostname prefixed, e.g. host:/path/wc.
+#     HOST_SOURCE_<project>_BASE
+#         The base of the project specified on the command line. This is
+#         intended to specify the location of 'fcm-make' config files. Working 
+#         copies in this list have their hostname prefixed.
 #     RUN_NAMES
 #         A list of groups to run in the rose-stem suite.
 #     SOURCE_<project>
-#         The complete list of source trees for a given project.
+#         The complete list of source trees for a given project. Unlike the 
+#         HOST_ variable of similar name, paths to working copies do NOT 
+#         include the host name.
 #     SOURCE_<project>_BASE
 #         The base of the project specified on the command line. This is
-#         intended to specify the location of 'fcm-make' config files.
+#         intended to specify the location of 'fcm-make' config files.Unlike 
+#         the  HOST_ variable of similar name, paths to working copies do NOT
+#         include the host name.
 #     SOURCE_<project>_REV
 #         The revision of the project specified on the command line. This
 #         is intended to specify the revision of 'fcm-make' config files.

--- a/doc/rose-command.html
+++ b/doc/rose-command.html
@@ -2114,6 +2114,19 @@ launcher-preopts.mpiexec=-n $NPROC
             upper case.
 
             <dl>
+              <dt><kbd>HOST_SOURCE_project</kbd></dt>
+              
+              <dd>The complete list of source trees for a given
+              project. Working copies in this list have their
+              hostname prefixed, e.g. host:/path/wc.</dd>
+
+              <dt><kbd>HOST_SOURCE_project_BASE</kbd></dt>
+              
+              <dd>The base of the project specified on the command
+              line. This is intended to specify the location of 
+              <kbd>fcm-make</kbd> config files. Working copies in
+              this list have their hostname prefixed.</dd>
+
               <dt><kbd>RUN_NAMES</kbd></dt>
 
               <dd>A list of groups to run in the rose-stem
@@ -2122,13 +2135,17 @@ launcher-preopts.mpiexec=-n $NPROC
               <dt><kbd>SOURCE_project</kbd></dt>
 
               <dd>The complete list of source trees for a given
-              project.</dd>
+              project.Unlike the HOST_ variable of similar name, 
+              paths to working copies do NOT include the host 
+              name.</dd>
 
               <dt><kbd>SOURCE_project_BASE</kbd></dt>
 
               <dd>The base of the project specified on the command
               line. This is intended to specify the location of
-              <kbd>fcm-make</kbd> config files.</dd>
+              <kbd>fcm-make</kbd> config files. Unlike the HOST_ 
+              variable of similar name, paths to working copies 
+              do NOT include the host name.</dd>
 
               <dt><kbd>SOURCE_project_REV</kbd></dt>
 


### PR DESCRIPTION
The command line help for rose-stem is missing the HOST_ variables introduced in issue #1898 .