### PR TITLE
t: app-run 14: improve stability

### DIFF
--- a/t/rose-app-run/14-file-source-optional.t
+++ b/t/rose-app-run/14-file-source-optional.t
@@ -129,10 +129,9 @@ file_cmp "$TEST_KEY-sub0.txt" "sub0.txt" </dev/null
 file_cmp "$TEST_KEY-sub1.txt" "sub1.txt" <<'__TXT__'
 I can see the periscope.
 __TXT__
-ls -l hello*.nl foo*.txt sub*.txt | LANG=C sort >"$TEST_KEY-ls-l-before"
-run_pass "$TEST_KEY" rose app-run --config=../config -q
-ls -l hello*.nl foo*.txt sub*.txt | LANG=C sort >"$TEST_KEY-ls-l-after"
-file_cmp "$TEST_KEY-ls-l" "$TEST_KEY-ls-l-before" "$TEST_KEY-ls-l-after"
+sha1sum hello*.nl foo*.txt sub*.txt >"${TEST_KEY}.sha1sum"
+run_pass "${TEST_KEY}" rose app-run --config='../config' -q
+run_pass "${TEST_KEY}.sha1sum" sha1sum -c "${TEST_KEY}.sha1sum"
 test_teardown
 #-------------------------------------------------------------------------------
 exit


### PR DESCRIPTION
A `namelist:` source is always considered out of date, so target is
always rebuilt, and so the modification time (via `ls -l`) of the target is not
something we should compare. The test should be stable if we only compare the files' SHA1 sums.