### PR TITLE
Suites II doc tweaks and fixes.

### DIFF
--- a/doc/rose-rug-suites-II.html
+++ b/doc/rose-rug-suites-II.html
@@ -281,14 +281,14 @@
                   <li>more namespace (family) triggers - triggers
                   based on groups</li>
 
-                  <li>message triggers - triggers based on task
-                  output</li>
-
                   <li>clock-triggered tasks - tasks triggered at
                   certain wallclock times</li>
 
                   <li>runahead limit - prevent too many cycles
                   being active at any one time</li>
+
+                  <li>message triggers - triggers based on task
+                  output</li>
                 </ul>
               </div>
 
@@ -300,11 +300,11 @@
                 <ul class="incremental">
                   <li>inserting tasks at runtime</li>
 
-                  <li>spawning tasks on-demand (asynchronous
-                  tasks)</li>
-
                   <li>limiting the number of tasks in a family
                   running at any one time (queues)</li>
+
+                  <li>giving manual control over the status of
+                  tasks</li>
                 </ul>
               </div>
 
@@ -320,9 +320,6 @@
                   <li>automatically resubmitting tasks when
                   <em>submission</em> fails (submission
                   retries)</li>
-
-                  <li>giving manual control over the status of
-                  tasks</li>
 
                   <li>restarting suites</li>
                 </ul>
@@ -560,9 +557,9 @@
                   <code>cylc gui SUITE-NAME</code>.</li>
 
                   <li>Three views - <a href=
-                  "graph-view.png">graph</a>, <a href=
-                  "dot-view.png">dot</a> (square now!), <a href=
-                  "text-view.png">tree</a>.</li>
+                  "img/graph-view.png">graph</a>, <a href=
+                  "img/dot-view.png">dot</a> (square now!), <a href=
+                  "img/text-view.png">tree</a>.</li>
 
                   <li>Easy interface to start, pause (hold) and
                   stop the suite.</li>


### PR DESCRIPTION
Makes the following changes to suites II tutorial:

 * re-order some bullet points
 * remove incorrect statement about spawn on demand
 * fix broken image links