### PR TITLE
Fix breakage by cylc/cylc#1953 and cylc/cylc#1958

### DIFF
--- a/lib/python/rose/suite_engine_procs/cylc.py
+++ b/lib/python/rose/suite_engine_procs/cylc.py
@@ -1117,7 +1117,7 @@ class CylcProcessor(SuiteEngineProcessor):
             task_cycle_time = None
         task_log_root = os.environ["CYLC_TASK_LOG_ROOT"]
         task_is_cold_start = "false"
-        if os.environ["CYLC_TASK_IS_COLDSTART"] == "True":
+        if os.environ.get("CYLC_TASK_IS_COLDSTART", "True") == "True":
             task_is_cold_start = "true"
 
         return TaskProps(suite_name=suite_name,

--- a/t/rose-suite-restart/02-basic.t
+++ b/t/rose-suite-restart/02-basic.t
@@ -33,13 +33,13 @@ rose suite-run --debug -q \
 TEST_KEY="${TEST_KEY_BASE}"
 run_pass "${TEST_KEY}" \
     rose suite-restart --debug --name="${NAME}" --no-gcontrol -- --debug
-file_grep "${TEST_KEY}.out.1" \
+file_grep "${TEST_KEY}.out" \
     "\\[INFO\\] ${NAME}: will restart on localhost" \
     "${TEST_KEY}.out"
 # N.B. This relies on output from "cylc restart"
-file_grep "${TEST_KEY}.out.2" \
-    "\\[INFO\\] cylc jobs-submit --debug -- ${SUITE_RUN_DIR}/log/job 1/t2/01" \
-    "${TEST_KEY}.out"
+file_grep "${TEST_KEY}.log" \
+    "\\[jobs-submit cmd\\] cylc jobs-submit --debug -- ${SUITE_RUN_DIR}/log/job 1/t2/01" \
+    "${SUITE_RUN_DIR}/log/suite/log"
 file_cmp "${TEST_KEY}.err" "${TEST_KEY}.err" '/dev/null'
 #-------------------------------------------------------------------------------
 rose suite-clean -q -y "${NAME}"

--- a/t/rose-suite-restart/03-host.t
+++ b/t/rose-suite-restart/03-host.t
@@ -43,13 +43,13 @@ TEST_KEY="${TEST_KEY_BASE}"
 run_pass "${TEST_KEY}" rose suite-restart \
     --debug --name="${NAME}" --host="${HOST}" --no-gcontrol \
     -- --debug
-file_grep "${TEST_KEY}.out.1" \
+file_grep "${TEST_KEY}.out" \
     "\\[INFO\\] ${NAME}: will restart on ${HOST}" \
     "${TEST_KEY}.out"
 # N.B. This relies on output from "cylc restart"
-file_grep "${TEST_KEY}.out.2" \
-    "\\[INFO\\] cylc jobs-submit --debug -- ${SUITE_RUN_DIR}/log/job 1/t2/01" \
-    "${TEST_KEY}.out"
+file_grep "${TEST_KEY}.log" \
+    "\\[jobs-submit cmd\\] cylc jobs-submit --debug -- ${SUITE_RUN_DIR}/log/job 1/t2/01" \
+    "${SUITE_RUN_DIR}/log/suite/log"
 file_cmp "${TEST_KEY}.err" "${TEST_KEY}.err" '/dev/null'
 #-------------------------------------------------------------------------------
 rose suite-clean -q -y "${NAME}"


### PR DESCRIPTION
cylc/cylc#1953 breaks `rose task-env` (and its derivatives). cylc/cylc#1958 breaks 2 similar tests. This change should fix both issues.

@arjclark please review or reassign.