### PR TITLE
rosa svn-post-commit: fix ignored settings decode

### DIFF
--- a/lib/python/rosie/svn_post_commit.py
+++ b/lib/python/rosie/svn_post_commit.py
@@ -422,9 +422,12 @@ class RosieSvnPostCommitHook(object):
         for name in branch_attribs[info_key].value:
             if name in ["owner", "project", "title"]:
                 continue
-            value = branch_attribs[info_key].get_value([name]).decode("utf-8")
+            value = branch_attribs[info_key].get_value([name])
+            if value is None:  # setting may have ignore flag (!)
+                continue
             cols = dict(vc_attrs)
-            cols.update({"name": name.decode("utf-8"), "value": value})
+            cols.update({
+                "name": name.decode("utf-8"), "value": value.decode("utf-8")})
             dao.insert(OPTIONAL_TABLE_NAME, **cols)
 
     def _update_known_keys(self, dao, changeset_attribs):

--- a/t/rosa-svn-post-commit/03-unicode.t
+++ b/t/rosa-svn-post-commit/03-unicode.t
@@ -64,6 +64,7 @@ owner=ivy
 project=euro
 title=The euro symbol € requires unicode
 more-title=We may lose € if we can't handle unicode
+!whatever=
 __ROSE_SUITE_INFO
 rosie create -q -y --info-file='rose-suite.info'
 file_cmp "${TEST_KEY}-hook.out" "${PWD}/rosa-svn-post-commit.out" <'/dev/null'
@@ -90,6 +91,7 @@ owner=ivy
 project=euro
 title=Euro symbol € requires unicode
 more-title=We will lose € if we can't handle unicode
+!whatever=
 __ROSE_SUITE_INFO
 set -e
 svn commit -q -m 't' "${PWD}/roses/foo-aa000"


### PR DESCRIPTION
This fixes the attempt to decode value (always None) of an ignored
setting.

Fix #1981. @arjclark @oliver-sanders please review.