### PR TITLE
t: remove debug foo files

### DIFF
--- a/t/rose-bush/00-basic.t
+++ b/t/rose-bush/00-basic.t
@@ -116,7 +116,6 @@ FOO0="{'cycle': '20000101T0000Z', 'name': 'foo0', 'submit_num': 1}"
 FOO0_JOB='log/job/20000101T0000Z/foo0/01/job'
 FOO1="{'cycle': '20000101T0000Z', 'name': 'foo1', 'submit_num': 1}"
 FOO1_JOB='log/job/20000101T0000Z/foo1/01/job'
-cat "${TEST_KEY}.out" >~/foo
 rose_ws_json_greps "${TEST_KEY}.out" "${TEST_KEY}.out" \
     "[('rose_version',), '$(rose version | cut -d' ' -f 2)']" \
     "[('title',), 'Rose Bush']" \

--- a/t/rose-suite-log/06-archive-star.t
+++ b/t/rose-suite-log/06-archive-star.t
@@ -78,7 +78,6 @@ log/job/20130102T0000Z/my_task_1/01/job.err||job.err
 log/job/20130102T0000Z/my_task_1/01/job.out||job.out
 __OUT__
 N_JOB_LOGS=$(wc -l "$TEST_KEY-list-job-logs-before.out" | cut -d' ' -f1)
-(cd $SUITE_RUN_DIR/log && ls job/*) | LANG=C sort >foo
 run_pass "$TEST_KEY-command" rose suite-log -n $NAME --archive '*' --debug
 run_fail "$TEST_KEY-list-job-logs-after" ls $SUITE_RUN_DIR/log/job/*
 if [[ -n ${JOB_HOST:-} ]]; then


### PR DESCRIPTION
Don't leave behind debug `foo` files.

@oliver-sanders please review.