### PR TITLE
rose bunch: Correct typo in rose bunch error message.

### DIFF
--- a/lib/python/rose/apps/rose_bunch.py
+++ b/lib/python/rose/apps/rose_bunch.py
@@ -207,7 +207,7 @@ class RoseBunchApp(BuiltinApp):
 
         if instances and arglength != len(instances):
             raise ConfigValueError([self.BUNCH_SECTION, "command-instances"],
-                                   instances, "inconsitent arg lengths")
+                                   instances, "inconsistent arg lengths")
 
         # Set max number of processes to run at once
         max_procs = conf_tree.node.get_value([self.BUNCH_SECTION, "pool-size"])


### PR DESCRIPTION
Corrects a typo.

@matthewrmshin - please review. Only needs one reviewer.