### PR TITLE
Update retry delays tutorial to new cylc 6.11.x [[[job]]] syntax

### DIFF
--- a/doc/rose-rug-advanced-tutorials-retries.html
+++ b/doc/rose-rug-advanced-tutorials-retries.html
@@ -215,9 +215,9 @@ rose suite-run
             <div class="slide">
               <h3 class="alwayshidden">Explanation</h3>
 
-              <p><samp>retry delays</samp> can have varying amounts
-              (e.g. <samp>retry delays = PT15S, PT10M, PT1H,
-              PT3H</samp> to perform the first retry after 15
+              <p><samp>execution retry delays</samp> can have varying
+              amounts (e.g. <samp>execution retry delays = PT15S, PT10M,
+              PT1H, PT3H</samp> to perform the first retry after 15
               seconds, the second after 10 minutes, then an hour,
               then three hours).</p>
 

--- a/doc/rose-rug-advanced-tutorials-retries.html
+++ b/doc/rose-rug-advanced-tutorials-retries.html
@@ -202,13 +202,14 @@ rose suite-run
               <samp>suite.rc</samp> file with:</p>
               <pre class="prettyprint lang-cylc">
     [[roll_doubles]]
-        retry delays = 5*PT6S
+        [[[job]]]
+            execution retry delays = 5*PT6S
 </pre>
 
               <p>This means that if the <samp>roll_doubles</samp>
-              task fails, cylc expects to retry it 5 times before
-              finally failing. Each retry will have a delay of
-              <samp>6</samp> seconds.</p>
+              task fails, cylc expects to retry running it 5 times
+              before finally failing. Each retry will have a delay
+              of <samp>6</samp> seconds.</p>
             </div>
 
             <div class="slide">


### PR DESCRIPTION
Updates the retry delays advanced tutorial to use `[[[job]]] -> execution retry delays`

@matthewrmshin - please review.