### PR TITLE
rose bush: improve tasks and jobs filtering

### DIFF
--- a/lib/html/static/css/rose-bush.css
+++ b/lib/html/static/css/rose-bush.css
@@ -105,3 +105,12 @@ pre {
      -moz-border-radius: 6px 0 6px 6px;
           border-radius: 6px 0 6px 6px;
 }
+
+@-moz-document url-prefix() {
+  fieldset { display: table-cell; }
+}
+
+th,
+.livestamp {
+  white-space: nowrap;
+}

--- a/lib/html/static/js/rose-bush.js
+++ b/lib/html/static/js/rose-bush.js
@@ -155,4 +155,8 @@ $(function() {
     $("#per_page_max").click(function() {
         $("#per_page").prop("disabled", $(this).prop("checked"));
     });
+    $("#all_task_statuses").change(function() {
+        $("input.task_status").prop("disabled", $(this).prop("checked"))
+    });
+    $("#all_task_statuses").change();
 });

--- a/lib/html/static/js/rose-bush.js
+++ b/lib/html/static/js/rose-bush.js
@@ -22,27 +22,6 @@ $(function() {
     $(".livestamp").each(function() {
         $(this).livestamp($(this).attr("title"));
     });
-    $(".entry:even").each(function() {
-        $(this).addClass("even");
-    });
-    $(".entry .cycle").each(function() {
-        var cycle = $(this).text();
-        if (/^\d{10}$/.test(cycle)) { // Classic Cylc YYYYmmDDHH cycle time
-            $(this).html(
-                "<code>" + cycle.substr(0, 8) + "</code> " // year month day
-                + "<code>" + cycle.substr(8, 2) + "</code>" // hour of day
-            );
-            $(this).attr("title",
-                cycle.substr(0, 4) // year
-                + "-"
-                + cycle.substr(4, 2) // month of year
-                + "-"
-                + cycle.substr(6, 2) // day of month
-                + " "
-                + cycle.substr(8, 2) // hour of day
-            );
-        }
-    });
     $(".entry select.seq_log").change(function() {
         this.form.submit();
     });
@@ -71,6 +50,8 @@ $(function() {
             $(".livestamp").each(function() {
                 $(this).livestamp($(this).attr("title"));
             });
+            $(".job-entry-head-init-time").html("queue \&Delta;t");
+            $(".job-entry-head-exit-time").html("run \&Delta;t");
             $(".entry").each(function() {
                 var s_init = $(".t_init", this).attr("title");
                 if (s_init == null) {
@@ -82,9 +63,6 @@ $(function() {
                 if (m_init.isBefore(m_submit)) {
                     m_init = m_submit;
                 }
-                $(".t_init", this).prev().removeClass("icon-play");
-                $(".t_init", this).prev().addClass("icon-time");
-                $(".t_init", this).prev().attr("title", "Queue duration");
                 var dt_q = moment.duration(m_init.diff(m_submit));
                 $(".t_init", this).text(dt_as_m_and_s(dt_q));
                 var s_exit = $(".t_exit", this).attr("title");
@@ -95,9 +73,6 @@ $(function() {
                 if (m_exit.isBefore(m_init)) {
                     m_exit = m_init;
                 }
-                $(".t_exit", this).prev().removeClass("icon-stop");
-                $(".t_exit", this).prev().addClass("icon-play-circle");
-                $(".t_exit", this).prev().attr("title", "Run duration");
                 var dt_r = moment.duration(m_exit.diff(m_init));
                 $(".t_exit", this).text(dt_as_m_and_s(dt_r));
             });
@@ -109,15 +84,14 @@ $(function() {
             $(".livestamp").each(function() {
                 $(this).livestamp("destroy");
             });
+            $(".job-entry-head-init-time").text("start time");
+            $(".job-entry-head-exit-time").text("exit time");
             $(".entry").each(function() {
                 var s_init = $(".t_init", this).attr("title");
                 if (s_init == null) {
                     return;
                 }
                 var m_submit = moment($(".t_submit", this).attr("title"));
-                $(".t_init", this).prev().removeClass("icon-time");
-                $(".t_init", this).prev().addClass("icon-play");
-                $(".t_init", this).prev().attr("title", "Started");
                 var m_init = moment(s_init);
                 if (m_init.isSame(m_submit, "day")) {
                     m_init.utc();
@@ -128,9 +102,6 @@ $(function() {
                 if (s_exit == null) {
                     return;
                 }
-                $(".t_exit", this).prev().removeClass("icon-play-circle");
-                $(".t_exit", this).prev().addClass("icon-stop");
-                $(".t_exit", this).prev(toggle_fuzzy_time).attr("title", "Exited");
                 var m_exit = moment(s_exit);
                 if (m_exit.isSame(m_submit, "day")) {
                     m_exit.utc();

--- a/lib/html/template/rose-bush/cycles.html
+++ b/lib/html/template/rose-bush/cycles.html
@@ -21,7 +21,7 @@
             <input type="hidden" name="no_fuzzy_time" value="{{no_fuzzy_time}}" />
 
             <div class="row">
-              <div class="col-md-3">
+              <div class="form-group col-sm-12 col-md-6 col-lg-4">
                 <div class="input-group">
                   <label for="per_page">Entries/Page (Default=100)</label>
                   <input id="per_page" type="text" name="per_page"
@@ -34,7 +34,7 @@
                 </div>
               </div>
 
-              <div class="col-md-2">
+              <div class="form-group col-sm-12 col-md-6 col-lg-4">
                 <div class="input-group">
                   <label for="order">Sort Order</label>
                   <select name="order" title="Sort Order" class="form-control">
@@ -48,7 +48,7 @@
                 </div>
               </div>
 
-              <div class="col-md-7">
+              <div class="form-group col-sm-12 col-md-12 col-lg-4">
                 <div class="btn-group pull-right">
                   <input type="reset" class="btn btn-default" value="reset"
                   title="Reset Display Options"/>
@@ -82,31 +82,89 @@
 </div>
 
 <div class="container-fluid"><!-- entries -->
-  {% for entry in entries -%}
-    <div class="row entry">
-      <div class="col-md-2">
-        <a href="{{script}}/jobs/{{user}}/{{suite}}?cycles={{entry.cycle|replace('+', '%2B')}}" class="cycle" title="{{entry.cycle}}">{{entry.cycle}}</a>
-      </div>
-      {% for state, icon, label, title in [("active", "play", "info", "active tasks"), ("success", "ok", "success", "succeeded tasks"), ("fail", "warning-sign", "danger", "failed tasks")] -%}
-        {% set n_state = entry.n_states[state] -%}
-        <div class="col-md-2">
-          {% if n_state -%}
-            {% set state_url = script ~ "/jobs/" ~ user ~ "/" ~ suite ~ "?cycles=" ~ entry.cycle|replace('+', '%2B') -%}
-            <a href="{{state_url}}{% for no_state in ["active", "success", "fail"] if no_state != state %}&amp;no_status={{no_state}}{% endfor %}">
-          {% endif -%}
-          <span class="label{% if n_state %} label-{{label}}{% else %} label-default{% endif %}"><i class="glyphicon glyphicon-{{icon}}" title="{{state}}"></i></span>
-          <span class="label badge-label {% if n_state %}label-{{label}}{% else -%}label-default{% endif %}" title="{{title}}">{{entry.n_states[state]}}</span>
-          {% if n_state %}</a>{% endif %}
-          {% if state=="fail" and entry.n_states["job_fails"] > 0 %}(<span class="badge  badge-{{label}}" title="job failures">{{entry.n_states["job_fails"]}}</span>){% endif %}
-      </div>
-      {% endfor -%}
+{% for entry in entries -%}
+  {% set cycle_in_url = entry.cycle|replace('+', '%2B') -%}
+  {% set task_jobs_url = (
+      script ~ "/taskjobs/" ~ user ~ "/" ~ suite ~ "?cycles=" ~ cycle_in_url
+  ) -%}
+  <div class="row entry">
 
-      <div class="col-md-4">
-        <span class="label label-default"><i class="glyphicon glyphicon-time" title="last active"></i> last active</span>
-        <abbr class="livestamp" title="{{entry.max_time_updated}}">{{entry.max_time_updated}}</abbr>
-      </div>
-
+    <div class="col-xs-6 col-md-3">
+      <a href="{{task_jobs_url}}"
+      class="cycle" title="{{entry.cycle}}">{{entry.cycle}}</a>
     </div>
-  {% endfor -%}
+
+    <div class="col-xs-6 col-md-3">
+      last active
+      <abbr class="livestamp"
+      title="{{entry.max_time_updated}}">{{entry.max_time_updated}}</abbr>
+    </div>
+
+  {# task and jobs states -#}
+  {% for state, icon, label, title_, unit1, unit2, url_arg in [
+      ("active", "play", "info", "active", "task", "tasks",
+       "&amp;task_status=" ~
+       task_status_groups["active"]|join("&amp;task_status=")),
+      ("job_active", "play-circle", "info", "active", "job", "jobs",
+       "&amp;job_status=submitted,running"),
+      ("success", "ok", "success", "succeeded", "task", "tasks",
+       "&amp;task_status=" ~
+       task_status_groups["success"]|join("&amp;task_status=")),
+      ("job_success", "ok-circle", "success", "succeeded", "job", "jobs",
+       "&amp;job_status=succeeded"),
+      ("fail", "remove", "danger", "failed", "task", "tasks",
+       "&amp;task_status=" ~
+       task_status_groups["fail"]|join("&amp;task_status=")),
+      ("job_fail", "remove-circle", "danger", "failed", "job", "jobs",
+       "&amp;job_status=submission-failed,failed"),
+  ] -%}
+    {% set n_state = entry.n_states[state] -%}
+    {% set unit = unit1 -%}
+    {% if n_state -%}
+      {% set more_label = "label-" ~ label -%}
+      {% if n_state > 1 -%}
+        {% set unit = unit2 -%}
+      {% endif -%}
+    {% else -%}
+      {% set more_label = "label-default" -%}
+    {% endif -%}
+
+    <div class="col-xs-2 col-md-1">
+    {% if n_state -%}
+      <a href="{{task_jobs_url}}{{url_arg}}">
+        <span class="label {{more_label}}"
+        title="{{n_state}} {{title_}} {{unit}}">
+          <i class="glyphicon glyphicon-{{icon}}"></i>
+          {{n_state}}
+        </span>
+      </a>
+    {% else -%}
+      <span class="label {{more_label}}"
+      title="{{n_state}} {{title_}} {{unit}}">
+        <i class="glyphicon glyphicon-{{icon}}"></i>
+        {{n_state}}
+      </span>
+    {% endif -%}
+    </div>
+
+  {% endfor -%}{# task and jobs states -#}
+
+  {% if entry.has_log_job_tar_gz -%}
+    {% set download_text = "path=log/job-" ~ entry.cycle ~ ".tar.gz" -%}
+    {% set download = (
+        script ~ "/view/" ~ user ~ "/" ~ suite ~ "?path=log/job-" ~
+        cycle_in_url ~ ".tar.gz&amp;mode=download"
+    ) -%}
+    <div class="col-xs-12 col-md-12">
+      <small>
+        <a href="{{download}}"
+        download="{{user}}-{{suite}}-log-job-{{entry.cycle}}.tar.gz">download
+        {{download_text}}</a>
+      </small>
+    </div>
+  {% endif -%}
+
+  </div>
+{% endfor -%}{# for entry in entries -#}
 </div>
 {% endblock %}

--- a/lib/html/template/rose-bush/cycles.html
+++ b/lib/html/template/rose-bush/cycles.html
@@ -81,24 +81,82 @@
   </div>
 </div>
 
-<div class="container-fluid"><!-- entries -->
+<table summary="cycles entries"
+class="table table-bordered table-condensed table-striped">
+  <thead>
+    <tr>
+      <th>cycle point</th>
+
+      <th>last active time</th>
+
+      <th>
+        <span class="pull-right"># tasks</span>
+        <span class="label label-info">
+          <i class="glyphicon glyphicon-play" title="# active tasks"></i>
+        </span>
+      </th>
+
+      <th>
+        <span class="pull-right"># jobs</span>
+        <span class="label label-info">
+          <i class="glyphicon glyphicon-play-circle" title="# active jobs"></i>
+        </span>
+      </th>
+
+      <th>
+        <span class="pull-right"># tasks</span>
+        <span class="label label-success">
+          <i class="glyphicon glyphicon-ok" title="# succeeded tasks"></i>
+        </span>
+      </th>
+
+      <th>
+        <span class="pull-right"># jobs</span>
+        <span class="label label-success">
+          <i class="glyphicon glyphicon-ok-circle" title="# succeeded jobs"></i>
+        </span>
+      </th>
+
+      <th>
+        <span class="pull-right"># tasks</span>
+        <span class="label label-danger">
+          <i class="glyphicon glyphicon-remove" title="# failed tasks"></i>
+        </span>
+      </th>
+
+      <th>
+        <span class="pull-right"># jobs</span>
+        <span class="label label-danger">
+          <i class="glyphicon glyphicon-remove-circle"
+          title="# failed jobs"></i>
+        </span>
+      </th>
+
+      <th><i class="glyphicon glyphicon-download"
+      title="download job logs archive"></i> log/job-CYCLE.tar.gz</th>
+    </tr>
+  </thead>
+  <tbody>
 {% for entry in entries -%}
   {% set cycle_in_url = entry.cycle|replace('+', '%2B') -%}
   {% set task_jobs_url = (
       script ~ "/taskjobs/" ~ user ~ "/" ~ suite ~ "?cycles=" ~ cycle_in_url
   ) -%}
-  <div class="row entry">
+    <tr class="entry">
 
-    <div class="col-xs-6 col-md-3">
-      <a href="{{task_jobs_url}}"
-      class="cycle" title="{{entry.cycle}}">{{entry.cycle}}</a>
-    </div>
+      <td>
+        <small>
+          <a href="{{task_jobs_url}}"
+          class="cycle" title="{{entry.cycle}}">{{entry.cycle}}</a>
+        </small>
+      </td>
 
-    <div class="col-xs-6 col-md-3">
-      last active
-      <abbr class="livestamp"
-      title="{{entry.max_time_updated}}">{{entry.max_time_updated}}</abbr>
-    </div>
+      <td>
+        <small>
+          <abbr class="livestamp"
+          title="{{entry.max_time_updated}}">{{entry.max_time_updated}}</abbr>
+        </small>
+      </td>
 
   {# task and jobs states -#}
   {% for state, icon, label, title_, unit1, unit2, url_arg in [
@@ -129,42 +187,40 @@
       {% set more_label = "label-default" -%}
     {% endif -%}
 
-    <div class="col-xs-2 col-md-1">
     {% if n_state -%}
+    <td class="{{label}}">
       <a href="{{task_jobs_url}}{{url_arg}}">
-        <span class="label {{more_label}}"
-        title="{{n_state}} {{title_}} {{unit}}">
+        <span class="label {{more_label}}">
           <i class="glyphicon glyphicon-{{icon}}"></i>
-          {{n_state}}
         </span>
+        <small class="pull-right">{{n_state}}</small>
       </a>
+    </td>
     {% else -%}
-      <span class="label {{more_label}}"
-      title="{{n_state}} {{title_}} {{unit}}">
-        <i class="glyphicon glyphicon-{{icon}}"></i>
-        {{n_state}}
-      </span>
+    <td><small class="pull-right">{{n_state}}</span></small></td>
     {% endif -%}
-    </div>
 
-  {% endfor -%}{# task and jobs states -#}
+  {% endfor -%}{# end task and jobs states -#}
 
+    <td>
   {% if entry.has_log_job_tar_gz -%}
-    {% set download_text = "path=log/job-" ~ entry.cycle ~ ".tar.gz" -%}
     {% set download = (
         script ~ "/view/" ~ user ~ "/" ~ suite ~ "?path=log/job-" ~
         cycle_in_url ~ ".tar.gz&amp;mode=download"
     ) -%}
-    <div class="col-xs-12 col-md-12">
-      <small>
-        <a href="{{download}}"
-        download="{{user}}-{{suite}}-log-job-{{entry.cycle}}.tar.gz">download
-        {{download_text}}</a>
-      </small>
-    </div>
+      <a href="{{download}}"
+      download="{{user}}-{{suite}}-log-job-{{entry.cycle}}.tar.gz">
+        <i class="glyphicon glyphicon-download"
+        title="download log/job-{{entry.cycle}}.tar.gz"></i>
+        <small>
+          log/job-{{entry.cycle}}.tar.gz
+        </small>
+      </a>
   {% endif -%}
+    </td>
 
-  </div>
-{% endfor -%}{# for entry in entries -#}
-</div>
+    </tr><!-- end table row for entry -->
+{% endfor -%}{# end for entry in entries -#}
+  </tbody><!-- end cycles entries -->
+</table>
 {% endblock %}

--- a/lib/html/template/rose-bush/index.html
+++ b/lib/html/template/rose-bush/index.html
@@ -22,7 +22,7 @@ rel="stylesheet" media="screen" />
 <div class="row">
 <div class="col-md-4">
 <form action="{{script}}/suites" class="form-inline">
-<fieldset>
+<fieldset class="form-group">
 <legend>User's Suites List:</legend>
 <input id="user" name="user" type="text" class="form-control"
 placeholder="User ID" required="1" />
@@ -31,8 +31,8 @@ placeholder="User ID" required="1" />
 </form>
 </div>
 <div class="col-md-8">
-<form action="{{script}}/jobs" class="form-inline">
-<fieldset>
+<form action="{{script}}/taskjobs" class="form-inline">
+<fieldset class="form-group">
 <legend>User's Suite Cycles or Jobs List:</legend>
 <input id="user" name="user" type="text" class="input-short form-control"
 placeholder="User ID" required="1" />

--- a/lib/html/template/rose-bush/job-entry-head.html
+++ b/lib/html/template/rose-bush/job-entry-head.html
@@ -1,0 +1,25 @@
+<thead>
+  <tr>
+    <th>task status</th>
+
+    <th>job status</th>
+
+    <th>cycle point</th>
+
+    <th>task name</th>
+
+    <th>job #</th>
+
+    <th>submit time</th>
+
+    <th class="job-entry-head-init-time">start time</th>
+
+    <th class="job-entry-head-exit-time">exit time</th>
+
+    <th>job host</th>
+
+    <th>job batch</th>
+
+    <th>job logs</th>
+  </tr>
+</thead>

--- a/lib/html/template/rose-bush/job-entry.html
+++ b/lib/html/template/rose-bush/job-entry.html
@@ -1,181 +1,203 @@
+{% if no_fuzzy_time -%}
+  {% set no_fuzzy_time_str = "&amp;no_fuzzy_time=" + no_fuzzy_time -%}
+{% else -%}
+  {% set no_fuzzy_time_str = "" -%}
+{% endif -%}
+{% set cycle_str = entry.cycle|replace('+', '%2B') -%}
 <div class="row entry"><!-- entry row -->
-  <div class="col-md-4">
-    <!-- entry: cycle, name, submit_num, files -->
-    <!-- entry: status -->
-    {% if entry.status and "fail" in entry.status -%}
-      <span class="label label-danger"><i
-      class="glyphicon glyphicon-warning-sign"
-      title="{{entry.status}}"></i></span>
-      {% if entry.status != "fail" and entry.status != "fail(ERR)" -%}
-        <span class="label label-danger">{{entry.status[5:-1]}}</span>
-      {% endif -%}
-    {% elif entry.status == "success" -%}
-      <span class="label label-success"><i
-      class="glyphicon glyphicon-ok"
-      title="{{entry.status}}"></i></span>
-    {% elif entry.status == "init" -%}
-      <span class="label label-info"><i
-      class="glyphicon glyphicon-play"
-      title="{{entry.status}}"></i></span>
-    {% elif entry.status -%}
-      <span class="label label-default"><i
-      class="glyphicon glyphicon-info-sign" title="{{entry.status}}"></i></span>
-    {% endif -%}
-    <!-- entry: status -->
-    {% if no_fuzzy_time -%}
-      {% set no_fuzzy_time_str = "&no_fuzzy_time=" + no_fuzzy_time -%}
+  <div class="col-xs-6 col-sm-1 col-md-1 col-lg-1">
+    <!-- entry: task status, submit_num -->
+    {% if entry.task_status == "succeeded" -%}
+      {% set icon = "ok" %}
+      {% set label_class = "label-success" %}
+    {% elif entry.task_status in ["failed", "submission failed"] -%}
+      {% set icon = "remove" %}
+      {% set label_class = "label-danger" %}
     {% else -%}
-      {% set no_fuzzy_time_str = "" -%}
+      {% set icon = "play" %}
+      {% set label_class = "label-info" %}
     {% endif -%}
-    {% set cycle_str = entry.cycle|replace('+', '%2B') -%}
-    {% if entry.cycle != "1" -%}
-      <a
-      href="{{script}}/jobs/{{user}}/{{suite}}?cycles={{cycle_str}}{{no_fuzzy_time_str}}"
-      class="cycle" title="{{entry.cycle}}">{{entry.cycle}}</a>
-    {% endif -%}
-    <a
-    href="{{script}}/jobs/{{user}}/{{suite}}?tasks={{entry.name}}{{no_fuzzy_time_str}}"
-    title="{{entry.name}}">{{entry.name}}</a>
-    {% if entry.submit_num_max > 1 -%}
-      {% if entry.task_status == "success" -%}
-        {% set badge_class = "label-success" %}
-      {% elif entry.task_status == "fail" -%}
-        {% set badge_class = "label-danger" %}
-      {% else -%}
-        {% set badge_class = "label-default" %}
-      {% endif -%}
-      <a
-      href="{{script}}/jobs/{{user}}/{{suite}}?cycles={{cycle_str}}&tasks={{entry.name}}{{no_fuzzy_time_str}}"
-      title="submit {{entry.submit_num}}">
-        <span class="label {{badge_class}} badge-label">
-          {{entry.submit_num}} / {{entry.submit_num_max}}
-        </span>
+    {% set link = (
+        script ~ "/taskjobs/" ~ user ~ "/" ~ suite ~ "?cycles=" ~
+        cycle_str ~ "&amp;tasks=" ~ entry.name ~ no_fuzzy_time_str
+    ) -%}
+    <a href="{{link}}"
+    title="submit {{entry.submit_num}}, task {{entry.task_status}}"
+    class="label {{label_class}}">
+      <i class="glyphicon glyphicon-{{icon}}"></i>
+      {{entry.submit_num}} / {{entry.submit_num_max}}
+    </a>
+  </div>
+  <div class="col-xs-6 col-sm-1 col-md-1 col-lg-1">
+    <!-- entry: submit_status, run_status -->
+    {% set link = (
+        script ~ "/taskjobs/" ~ user ~ "/" ~ suite ~ "?" ~
+        no_fuzzy_time_str
+    ) -%}
+    {% if entry.run_status == 0 -%}
+      <a href="{{link}}&amp;job_status=succeeded" class="label label-success">
+        <i class="glyphicon glyphicon-ok-circle" title="job succeeded"></i>
       </a>
+    {% elif entry.run_status == 1 -%}
+      <a href="{{link}}&amp;job_status=failed"
+      class="label label-danger">
+        <i class="glyphicon glyphicon-remove-circle" title="job failed"></i>
+        {% if entry.run_signal and entry.run_signal != "ERR" -%}
+          {{entry.run_signal}}
+        {% endif -%}
+      </a>
+    {% elif entry.events[1] -%}
+      <a href="{{link}}&amp;job_status=running" class="label label-info">
+        <i class="glyphicon glyphicon-play-circle" title="job running"></i>
+      </a>
+    {% elif entry.submit_status == 0 -%}
+      <a href="{{link}}&amp;job_status=submitted" class="label label-info">
+        <i class="glyphicon glyphicon-time" title="job submitted"></i>
+      </a>
+    {% elif entry.submit_status == 1 -%}
+      <a href="{{link}}&amp;job_status=submission-failed"
+      class="label label-danger">
+        <i class="glyphicon glyphicon-remove-sign"
+        title="job submission failed"></i>
+      </a>
+    {% else -%}
+      <span class="label label-default">
+        <i class="glyphicon glyphicon-info-sign" title="job ready"></i>
+      </span>
     {% endif -%}
   </div>
-
-  <div class="col-md-3">
-    {% if entry.logs -%}
-      <ul class="list-inline">
-        {% for key, log in entry.logs|dictsort if not log.seq_key -%}
-          <li>
-            {% if key == "00-script" -%}
-              {% set key = "script" -%}
-            {% elif key == "01-out" -%}
-              {% set key = "out" -%}
-            {% elif key == "02-err" -%}
-              {% set key = "err" -%}
-            {% endif -%}
-            {% if log.exists -%}
-              {% if log.path_in_tar -%}
-                {% if path_in_tar is defined and path_in_tar == log.path_in_tar -%}
-                  {{key}}
-                {% else -%}
-                  <a
-                  {% if log.size == "?" or not log.size -%}class="text-muted"{% endif -%}
-                  href="{{script}}/view/{{user}}/{{suite}}?path={{log.path|replace('+', '%2B')}}&amp;path_in_tar={{log.path_in_tar|replace('+', '%2B')}}"
-                  title="{{log.size}} bytes">{{key}}{% if log.size == "?" -%}?{% endif -%}</a>
-                {% endif -%}
-              {% else -%}
-                {% if path is defined and path == log.path -%}
-                  {{key}}
-                {% else -%}
-                  <a
-                  {% if log.size == "?" or not log.size -%}class="text-muted"{% endif -%}
-                  href="{{script}}/view/{{user}}/{{suite}}?path={{log.path|replace('+', '%2B')}}"
-                  title="{{log.size}} bytes">{{key}}{% if log.size == "?" -%}?{% endif -%}</a>
-                {% endif -%}
-              {% endif -%}
-            {% else -%}
-                  <del class="text-muted" title="{{log.size}} bytes, gone">{{key}}</del>
-            {% endif -%}
-          </li>
-        {% endfor -%}
-
-        {% for seq_key, indexes in entry.seq_logs_indexes|dictsort -%}
-          <li>
-            <form action="{{script}}/view" class="form-inline">
-              <input type="hidden" name="user" value="{{user}}"/>
-              <input type="hidden" name="suite" value="{{suite}}"/>
-              {% if entry.logs[indexes.values()|first].path_in_tar -%}
-                <input type="hidden" name="path"
-                value="{{entry.logs[indexes.values()|first].path}}"/>
-                <select class="seq_log" name="path_in_tar">
-                  <option disabled="disabled"
-                  selected="selected">{{seq_key}}</option>
-                  {% for index, key in indexes|dictsort -%}
-                    {% set log = entry.logs[key] -%}
-                    <option title="{{log.size}} bytes"
-                    value="{{log.path_in_tar}}">{{key}}</option>
-                  {% endfor -%}
-                </select>
-              {% else -%}
-                <select class="seq_log" name="path">
-                  <option disabled="disabled"
-                  selected="selected">{{seq_key}}</option>
-                  {% for index, key in indexes|dictsort -%}
-                    {% set log = entry.logs[key] -%}
-                    <option title="{{log.size}} bytes"
-                    value="{{log.path}}">{{key}}</option>
-                  {% endfor -%}
-                </select>
-              {% endif -%}
-            </form>
-          </li>
-        {% endfor -%}
-      </ul>
-    {% endif -%}<!-- entry.logs -->
-  </div>
-
-  <div class="col-md-5">
+  <div class="col-sm-10 col-md-10 col-lg-10">
     <div class="container-fluid">
-      <div class="row">
-        <div class="col-md-5">
+      <div class="col-sm-12 col-md-12 col-lg-5">
+        <!-- entry: cycle, name, files -->
+        {% if entry.cycle != "1" -%}
+          <a
+          href="{{script}}/taskjobs/{{user}}/{{suite}}?cycles={{cycle_str}}{{no_fuzzy_time_str}}"
+          class="cycle" title="{{entry.cycle}}">{{entry.cycle}}</a>
+        {% endif -%}
+        <a
+        href="{{script}}/taskjobs/{{user}}/{{suite}}?tasks={{entry.name}}{{no_fuzzy_time_str}}"
+        title="{{entry.name}}">{{entry.name}}</a>
+      </div>
+
+      <div class="col-sm-4 col-md-3 col-lg-3">
+        <small>
+          <i class="glyphicon glyphicon-info-sign" title="Submitted"></i>
+          <abbr class="t_submit livestamp"
+          title="{{entry.events[0]}}">{{entry.events[0]}}</abbr>
+          <!-- entry: submit time -->
+        </small>
+      </div>
+      <div class="col-sm-4 col-md-3 col-lg-2">
+        <!-- entry: init time -->
+        {% if entry.events[1] -%}
           <small>
-            <!-- entry: host, submit_method and submit_method_id -->
-            {% if entry.host -%}
-              <i class="glyphicon glyphicon-map-marker" title="Location"></i>
-              {{entry.host}}:
-              {% if entry.submit_method -%}
-                {{entry.submit_method}}
-                {% if entry.submit_method_id -%}
-                  {{entry.submit_method_id}}
-                {% endif -%}
-              {% endif -%}
+            <i class="glyphicon glyphicon-play" title="Started"></i>
+            <abbr class="t_init"
+            title="{{entry.events[1]}}">{{entry.events[1]}}</abbr>
+          </small>
+        {% endif -%}
+      </div>
+      <div class="col-sm-4 col-md-6 col-lg-2">
+        <!-- entry: exit time -->
+        {% if entry.events[2] -%}
+          <small>
+            <i class="glyphicon glyphicon-stop" title="Exited"></i>
+            <abbr class="t_exit"
+            title="{{entry.events[2]}}">{{entry.events[2]}}</abbr>
+          </small>
+        {% endif -%}
+        <!-- entry: exit time -->
+      </div>
+      <div class="clearfix"></div>
+
+      <div class="col-sm-4 col-md-3 col-lg-2">
+        <!-- entry: host, submit_method and submit_method_id -->
+        {% if entry.host -%}
+          <small>
+            <i class="glyphicon glyphicon-map-marker" title="Location"></i>
+           {{entry.host}}
+         </small>
+       {% endif -%}
+      </div>
+      <div class="col-sm-4 col-md-3 col-lg-3">
+        {% if entry.submit_method -%}
+          <small>
+            <i class="glyphicon glyphicon-cloud" title="Scheduler"></i>
+            {{entry.submit_method}}
+            {% if entry.submit_method_id -%}
+              {{entry.submit_method_id}}
             {% endif -%}
           </small>
-        </div>
-        <div class="col-md-3">
-          <small>
-            <i class="glyphicon glyphicon-info-sign" title="Submitted"></i>
-            <abbr class="t_submit livestamp"
-            title="{{entry.events[0]}}">{{entry.events[0]}}</abbr>
-            <!-- entry: submit time -->
-          </small>
-        </div>
-        <div class="col-md-2">
-          <small>
-            <!-- entry: init time -->
-            {% if entry.events[1] -%}
-              <i class="glyphicon glyphicon-play" title="Started"></i>
-              <abbr class="t_init"
-              title="{{entry.events[1]}}">{{entry.events[1]}}</abbr>
-            {% endif -%}
-          </small>
-        </div>
-        <div class="col-md-2">
-          <small>
-            <!-- entry: exit time -->
-            {% if entry.events[2] -%}
-              <i class="glyphicon glyphicon-stop" title="Exited"></i>
-              <abbr class="t_exit"
-              title="{{entry.events[2]}}">{{entry.events[2]}}</abbr>
-            {% endif -%}
-            <!-- entry: exit time -->
-          </small>
-        </div>
+        {% endif -%}
+      </div>
+
+      <div class="col-sm-12 col-md-12 col-lg-7">
+        <small>
+          {% if entry.logs -%}
+            <ul class="list-inline">
+              {% for key, log in entry.logs|dictsort if not log.seq_key -%}
+                <li>
+                  {% if log.exists -%}
+                    {% if log.path_in_tar -%}
+                      {% if path_in_tar is defined and path_in_tar == log.path_in_tar -%}
+                        {{key}}
+                      {% else -%}
+                        <a
+                        {% if log.size == "?" or not log.size -%}class="text-muted"{% endif -%}
+                        href="{{script}}/view/{{user}}/{{suite}}?path={{log.path|replace('+', '%2B')}}&amp;path_in_tar={{log.path_in_tar|replace('+', '%2B')}}"
+                        title="{{log.size}} bytes">{{key}}{% if log.size == "?" -%}?{% endif -%}</a>
+                      {% endif -%}
+                    {% else -%}
+                      {% if path is defined and path == log.path -%}
+                        {{key}}
+                      {% else -%}
+                        <a
+                        {% if log.size == "?" or not log.size -%}class="text-muted"{% endif -%}
+                        href="{{script}}/view/{{user}}/{{suite}}?path={{log.path|replace('+', '%2B')}}"
+                        title="{{log.size}} bytes">{{key}}{% if log.size == "?" -%}?{% endif -%}</a>
+                      {% endif -%}
+                    {% endif -%}
+                  {% else -%}
+                        <del class="text-muted" title="{{log.size}} bytes, gone">{{key}}</del>
+                  {% endif -%}
+                </li>
+              {% endfor -%}
+              {% for seq_key, indexes in entry.seq_logs_indexes|dictsort -%}
+                <li>
+                  <form action="{{script}}/view" class="form-inline">
+                    <input type="hidden" name="user" value="{{user}}"/>
+                    <input type="hidden" name="suite" value="{{suite}}"/>
+                    {% if entry.logs[indexes.values()|first].path_in_tar -%}
+                      <input type="hidden" name="path"
+                      value="{{entry.logs[indexes.values()|first].path}}"/>
+                      <select class="seq_log" name="path_in_tar">
+                        <option disabled="disabled"
+                        selected="selected">{{seq_key}}</option>
+                        {% for index, key in indexes|dictsort -%}
+                          {% set log = entry.logs[key] -%}
+                          <option title="{{log.size}} bytes"
+                          value="{{log.path_in_tar}}">{{key}}</option>
+                        {% endfor -%}
+                      </select>
+                    {% else -%}
+                      <select class="seq_log" name="path">
+                        <option disabled="disabled"
+                        selected="selected">{{seq_key}}</option>
+                        {% for index, key in indexes|dictsort -%}
+                          {% set log = entry.logs[key] -%}
+                          <option title="{{log.size}} bytes"
+                          value="{{log.path}}">{{key}}</option>
+                        {% endfor -%}
+                      </select>
+                    {% endif -%}
+                  </form>
+                </li>
+              {% endfor -%}
+            </ul>
+          {% endif -%}<!-- entry.logs -->
+        </small>
       </div>
     </div>
   </div>
-
 </div><!-- entry row -->

--- a/lib/html/template/rose-bush/job-entry.html
+++ b/lib/html/template/rose-bush/job-entry.html
@@ -4,200 +4,230 @@
   {% set no_fuzzy_time_str = "" -%}
 {% endif -%}
 {% set cycle_str = entry.cycle|replace('+', '%2B') -%}
-<div class="row entry"><!-- entry row -->
-  <div class="col-xs-6 col-sm-1 col-md-1 col-lg-1">
-    <!-- entry: task status, submit_num -->
+{% set taskjobs_link = (
+    script ~ "/taskjobs/" ~ user ~ "/" ~ suite ~ "?" ~ no_fuzzy_time_str
+) -%}
+{% set view_link = (
+    script ~ "/view/" ~ user ~ "/" ~ suite ~ "?" ~ no_fuzzy_time_str
+) -%}
+<tr class="entry"><!-- entry row -->
+  <td>
+    <!-- entry: task status -->
     {% if entry.task_status == "succeeded" -%}
       {% set icon = "ok" %}
       {% set label_class = "label-success" %}
+      {% set url_arg = (
+        "&amp;task_status=" ~
+        task_status_groups["success"]|join("&amp;task_status=")
+      ) -%}
     {% elif entry.task_status in ["failed", "submission failed"] -%}
       {% set icon = "remove" %}
       {% set label_class = "label-danger" %}
+      {% set url_arg = (
+        "&amp;task_status=" ~
+        task_status_groups["fail"]|join("&amp;task_status=")
+      ) -%}
     {% else -%}
       {% set icon = "play" %}
       {% set label_class = "label-info" %}
+      {% set url_arg = (
+        "&amp;task_status=" ~
+        task_status_groups["active"]|join("&amp;task_status=")
+      ) -%}
     {% endif -%}
-    {% set link = (
-        script ~ "/taskjobs/" ~ user ~ "/" ~ suite ~ "?cycles=" ~
-        cycle_str ~ "&amp;tasks=" ~ entry.name ~ no_fuzzy_time_str
-    ) -%}
-    <a href="{{link}}"
-    title="submit {{entry.submit_num}}, task {{entry.task_status}}"
-    class="label {{label_class}}">
-      <i class="glyphicon glyphicon-{{icon}}"></i>
-      {{entry.submit_num}} / {{entry.submit_num_max}}
-    </a>
-  </div>
-  <div class="col-xs-6 col-sm-1 col-md-1 col-lg-1">
+    <small>
+      <a href="{{taskjobs_link}}{{url_arg}}">
+        <span class="label {{label_class}}">
+          <i class="glyphicon glyphicon-{{icon}}"></i>
+        </span>&nbsp;{{entry.task_status}}
+      </a>
+    </small>
+  </td>
+  <td>
     <!-- entry: submit_status, run_status -->
+    <small>
     {% set link = (
         script ~ "/taskjobs/" ~ user ~ "/" ~ suite ~ "?" ~
         no_fuzzy_time_str
     ) -%}
     {% if entry.run_status == 0 -%}
-      <a href="{{link}}&amp;job_status=succeeded" class="label label-success">
-        <i class="glyphicon glyphicon-ok-circle" title="job succeeded"></i>
+      <a href="{{taskjobs_link}}&amp;job_status=succeeded"
+      class="label label-success">
+        <i class="glyphicon glyphicon-ok-circle" title="succeeded"></i>
       </a>
     {% elif entry.run_status == 1 -%}
-      <a href="{{link}}&amp;job_status=failed"
+      <a href="{{taskjobs_link}}&amp;job_status=failed"
       class="label label-danger">
-        <i class="glyphicon glyphicon-remove-circle" title="job failed"></i>
+        <i class="glyphicon glyphicon-remove-circle" title="failed"></i>
         {% if entry.run_signal and entry.run_signal != "ERR" -%}
           {{entry.run_signal}}
         {% endif -%}
       </a>
     {% elif entry.events[1] -%}
-      <a href="{{link}}&amp;job_status=running" class="label label-info">
-        <i class="glyphicon glyphicon-play-circle" title="job running"></i>
+      <a href="{{taskjobs_link}}&amp;job_status=running"
+      class="label label-info">
+        <i class="glyphicon glyphicon-play-circle" title="running"></i>
       </a>
     {% elif entry.submit_status == 0 -%}
-      <a href="{{link}}&amp;job_status=submitted" class="label label-info">
-        <i class="glyphicon glyphicon-time" title="job submitted"></i>
+      <a href="{{taskjobs_link}}&amp;job_status=submitted"
+      class="label label-info">
+        <i class="glyphicon glyphicon-time" title="submitted"></i>
       </a>
     {% elif entry.submit_status == 1 -%}
-      <a href="{{link}}&amp;job_status=submission-failed"
+      <a href="{{taskjobs_link}}&amp;job_status=submission-failed"
       class="label label-danger">
         <i class="glyphicon glyphicon-remove-sign"
-        title="job submission failed"></i>
+        title="submission failed"></i>
       </a>
     {% else -%}
       <span class="label label-default">
-        <i class="glyphicon glyphicon-info-sign" title="job ready"></i>
+        <i class="glyphicon glyphicon-info-sign" title="ready"></i>
       </span>
     {% endif -%}
-  </div>
-  <div class="col-sm-10 col-md-10 col-lg-10">
-    <div class="container-fluid">
-      <div class="col-sm-12 col-md-12 col-lg-5">
-        <!-- entry: cycle, name, files -->
-        {% if entry.cycle != "1" -%}
-          <a
-          href="{{script}}/taskjobs/{{user}}/{{suite}}?cycles={{cycle_str}}{{no_fuzzy_time_str}}"
-          class="cycle" title="{{entry.cycle}}">{{entry.cycle}}</a>
-        {% endif -%}
-        <a
-        href="{{script}}/taskjobs/{{user}}/{{suite}}?tasks={{entry.name}}{{no_fuzzy_time_str}}"
-        title="{{entry.name}}">{{entry.name}}</a>
-      </div>
-
-      <div class="col-sm-4 col-md-3 col-lg-3">
-        <small>
-          <i class="glyphicon glyphicon-info-sign" title="Submitted"></i>
-          <abbr class="t_submit livestamp"
-          title="{{entry.events[0]}}">{{entry.events[0]}}</abbr>
-          <!-- entry: submit time -->
-        </small>
-      </div>
-      <div class="col-sm-4 col-md-3 col-lg-2">
-        <!-- entry: init time -->
-        {% if entry.events[1] -%}
-          <small>
-            <i class="glyphicon glyphicon-play" title="Started"></i>
-            <abbr class="t_init"
-            title="{{entry.events[1]}}">{{entry.events[1]}}</abbr>
-          </small>
-        {% endif -%}
-      </div>
-      <div class="col-sm-4 col-md-6 col-lg-2">
-        <!-- entry: exit time -->
-        {% if entry.events[2] -%}
-          <small>
-            <i class="glyphicon glyphicon-stop" title="Exited"></i>
-            <abbr class="t_exit"
-            title="{{entry.events[2]}}">{{entry.events[2]}}</abbr>
-          </small>
-        {% endif -%}
-        <!-- entry: exit time -->
-      </div>
-      <div class="clearfix"></div>
-
-      <div class="col-sm-4 col-md-3 col-lg-2">
-        <!-- entry: host, submit_method and submit_method_id -->
-        {% if entry.host -%}
-          <small>
-            <i class="glyphicon glyphicon-map-marker" title="Location"></i>
-           {{entry.host}}
-         </small>
-       {% endif -%}
-      </div>
-      <div class="col-sm-4 col-md-3 col-lg-3">
-        {% if entry.submit_method -%}
-          <small>
-            <i class="glyphicon glyphicon-cloud" title="Scheduler"></i>
-            {{entry.submit_method}}
-            {% if entry.submit_method_id -%}
-              {{entry.submit_method_id}}
+    </small>
+  </td>
+  <td>
+    <!-- entry: cycle -->
+    <small>
+    {% if entry.cycle != "1" -%}
+      <a
+      href="{{taskjobs_link}}&amp;cycles={{cycle_str}}"
+      title="{{entry.cycle}}">{{entry.cycle}}</a>
+    {% endif -%}
+    </small>
+  </td>
+  <td>
+    <!-- entry: name -->
+    <small>
+      <a
+      href="{{taskjobs_link}}&amp;tasks={{entry.name}}"
+      title="{{entry.name}}">{{entry.name}}</a>
+    </small>
+  </td>
+  <td>
+    <!-- entry: submi_num -->
+    <small>
+      <a
+      href="{{taskjobs_link}}&amp;cycles={{cycle_str}}&amp;tasks={{entry.name}}"
+      >{{entry.submit_num}} of {{entry.submit_num_max}}</a>
+    </small>
+  </td>
+  <td>
+    <!-- entry: submit time -->
+    <small>
+      <abbr class="t_submit livestamp"
+      title="{{entry.events[0]}}">{{entry.events[0]}}</abbr>
+    </small>
+  </td>
+  <td class="text-right">
+    <!-- entry: start time -->
+    {% if entry.events[1] -%}
+      <small>
+        <abbr class="t_init"
+        title="{{entry.events[1]}}">{{entry.events[1]}}</abbr>
+      </small>
+    {% endif -%}
+  </td>
+  <td class="text-right">
+    <!-- entry: exit time -->
+    {% if entry.events[2] -%}
+      <small>
+        <abbr class="t_exit"
+        title="{{entry.events[2]}}">{{entry.events[2]}}</abbr>
+      </small>
+    {% endif -%}
+    <!-- entry: exit time -->
+  </td>
+  <td>
+    <!-- entry: host -->
+    {% if entry.host -%}
+      <small>
+       {{entry.host}}
+     </small>
+   {% endif -%}
+  </td>
+  <td>
+    <!-- entry: submit_method and submit_method_id -->
+    {% if entry.submit_method -%}
+      <small>
+        {{entry.submit_method}}{% if entry.submit_method_id -%}[{{entry.submit_method_id}}]{% endif -%}
+      </small>
+    {% endif -%}
+  </td>
+  <td>
+    <!-- entry: logs -->
+    <small>
+      {% if entry.logs -%}
+        <ul class="list-inline">
+          {% for key, log in entry.logs|dictsort if not log.seq_key -%}
+            {% if key in ["job.out", "job.err"] -%}
+              {% set key_str = "<strong>" ~ key ~ "</strong>" -%}
+            {% else -%}
+              {% set key_str = key -%}
             {% endif -%}
-          </small>
-        {% endif -%}
-      </div>
-
-      <div class="col-sm-12 col-md-12 col-lg-7">
-        <small>
-          {% if entry.logs -%}
-            <ul class="list-inline">
-              {% for key, log in entry.logs|dictsort if not log.seq_key -%}
-                <li>
-                  {% if log.exists -%}
-                    {% if log.path_in_tar -%}
-                      {% if path_in_tar is defined and path_in_tar == log.path_in_tar -%}
-                        {{key}}
-                      {% else -%}
-                        <a
-                        {% if log.size == "?" or not log.size -%}class="text-muted"{% endif -%}
-                        href="{{script}}/view/{{user}}/{{suite}}?path={{log.path|replace('+', '%2B')}}&amp;path_in_tar={{log.path_in_tar|replace('+', '%2B')}}"
-                        title="{{log.size}} bytes">{{key}}{% if log.size == "?" -%}?{% endif -%}</a>
-                      {% endif -%}
-                    {% else -%}
-                      {% if path is defined and path == log.path -%}
-                        {{key}}
-                      {% else -%}
-                        <a
-                        {% if log.size == "?" or not log.size -%}class="text-muted"{% endif -%}
-                        href="{{script}}/view/{{user}}/{{suite}}?path={{log.path|replace('+', '%2B')}}"
-                        title="{{log.size}} bytes">{{key}}{% if log.size == "?" -%}?{% endif -%}</a>
-                      {% endif -%}
-                    {% endif -%}
-                  {% else -%}
-                        <del class="text-muted" title="{{log.size}} bytes, gone">{{key}}</del>
-                  {% endif -%}
-                </li>
-              {% endfor -%}
-              {% for seq_key, indexes in entry.seq_logs_indexes|dictsort -%}
-                <li>
-                  <form action="{{script}}/view" class="form-inline">
-                    <input type="hidden" name="user" value="{{user}}"/>
-                    <input type="hidden" name="suite" value="{{suite}}"/>
-                    {% if entry.logs[indexes.values()|first].path_in_tar -%}
-                      <input type="hidden" name="path"
-                      value="{{entry.logs[indexes.values()|first].path}}"/>
-                      <select class="seq_log" name="path_in_tar">
-                        <option disabled="disabled"
-                        selected="selected">{{seq_key}}</option>
-                        {% for index, key in indexes|dictsort -%}
-                          {% set log = entry.logs[key] -%}
-                          <option title="{{log.size}} bytes"
-                          value="{{log.path_in_tar}}">{{key}}</option>
-                        {% endfor -%}
-                      </select>
-                    {% else -%}
-                      <select class="seq_log" name="path">
-                        <option disabled="disabled"
-                        selected="selected">{{seq_key}}</option>
-                        {% for index, key in indexes|dictsort -%}
-                          {% set log = entry.logs[key] -%}
-                          <option title="{{log.size}} bytes"
-                          value="{{log.path}}">{{key}}</option>
-                        {% endfor -%}
-                      </select>
-                    {% endif -%}
-                  </form>
-                </li>
-              {% endfor -%}
-            </ul>
-          {% endif -%}<!-- entry.logs -->
-        </small>
-      </div>
-    </div>
-  </div>
-</div><!-- entry row -->
+            <li>
+              {% set path_arg = log.path|replace('+', '%2B') -%}
+              {% if log.path_in_tar -%}
+                {% if path_in_tar is defined and path_in_tar == log.path_in_tar -%}
+                  {{key_str}}
+                {% else -%}
+                  {% set path_in_tar_arg = log.path_in_tar|replace('+', '%2B') -%}
+                  <a
+                  {% if log.size == "?" or not log.size -%}class="text-muted"{% endif -%}
+                  href="{{view_link}}&amp;path={{path_arg}}&amp;path_in_tar={{path_in_tar_arg}}"
+                  title="{{log.size}} bytes">{{key_str}}</a>
+                {% endif -%}
+              {% else -%}
+                {% if path is defined and path == log.path -%}
+                  {{key_str}}
+                {% else -%}
+                  <a
+                  {% if log.size == "?" or not log.size -%}class="text-muted"{% endif -%}
+                  href="{{view_link}}&amp;path={{path_arg}}"
+                  title="{{log.size}} bytes">{{key_str}}</a>
+                {% endif -%}
+              {% endif -%}
+            </li>
+          {% endfor -%}
+        </ul>
+      {% endif -%}<!-- entry.logs -->
+      {% if entry.seq_logs_indexes -%}
+        <ul class="list-inline">
+          {% for seq_key, indexes in entry.seq_logs_indexes|dictsort -%}
+            <li>
+              <form action="{{script}}/view" class="form-inline">
+                <input type="hidden" name="user" value="{{user}}"/>
+                <input type="hidden" name="suite" value="{{suite}}"/>
+                <input type="hidden" name="no_fuzzy_time"
+                value="{{no_fuzzy_time}}"/>
+                {% if entry.logs[indexes.values()|first].path_in_tar -%}
+                  <input type="hidden" name="path"
+                  value="{{entry.logs[indexes.values()|first].path}}"/>
+                  <select class="seq_log" name="path_in_tar">
+                    <option disabled="disabled"
+                    selected="selected">{{seq_key}}</option>
+                    {% for index, key in indexes|dictsort -%}
+                      {% set log = entry.logs[key] -%}
+                      <option title="{{log.size}} bytes"
+                      value="{{log.path_in_tar}}">{{key}}</option>
+                    {% endfor -%}
+                  </select>
+                {% else -%}
+                  <select class="seq_log" name="path">
+                    <option disabled="disabled"
+                    selected="selected">{{seq_key}}</option>
+                    {% for index, key in indexes|dictsort -%}
+                      {% set log = entry.logs[key] -%}
+                      <option title="{{log.size}} bytes"
+                      value="{{log.path}}">{{key}}</option>
+                    {% endfor -%}
+                  </select>
+                {% endif -%}
+              </form>
+            </li>
+          {% endfor -%}
+        </ul>
+      {% endif -%}<!-- entry.seq_logs_indexes -->
+    </small>
+  </td>
+</tr><!-- entry row -->

--- a/lib/html/template/rose-bush/suite-base.html
+++ b/lib/html/template/rose-bush/suite-base.html
@@ -42,7 +42,7 @@ rel="stylesheet" media="screen" />
         <li><a><strong>{{suite}}</strong></a></li>
         {% for method, name, icon in [
             ("cycles", "cycles list", "glyphicon-tasks"),
-            ("jobs", "jobs list", "glyphicon-th-list"),
+            ("taskjobs", "task jobs list", "glyphicon-th-list"),
             ("broadcast_states", "broadcasts list", "glyphicon-bullhorn")] %}
         {% if name == self.title_name() %}
         <li class="active">

--- a/lib/html/template/rose-bush/suite-base.html
+++ b/lib/html/template/rose-bush/suite-base.html
@@ -75,7 +75,7 @@ rel="stylesheet" media="screen" />
               <ul class="dropdown-menu">
         {% for log_path in log.paths -%}
                 <li>
-                  <a href="{{script}}/view/{{user}}/{{suite}}?path={{log_path}}"
+                  <a href="{{script}}/view/{{user}}/{{suite}}?path={{log_path}}&amp;no_fuzzy_time={{no_fuzzy_time}}"
                   title="{{log.size}} bytes">{{log_path}}</a>
                 </li>
         {% endfor -%}
@@ -83,7 +83,7 @@ rel="stylesheet" media="screen" />
             </li>
         {% else -%}
             <li>
-              <a href="{{script}}/view/{{user}}/{{suite}}?path={{log.path}}"
+              <a href="{{script}}/view/{{user}}/{{suite}}?path={{log.path}}&amp;no_fuzzy_time={{no_fuzzy_time}}"
               title="{{log.size}} bytes">{{key}}</a></li>
         {% endif -%}
         {% endfor -%}

--- a/lib/html/template/rose-bush/suite-state.html
+++ b/lib/html/template/rose-bush/suite-state.html
@@ -2,7 +2,7 @@
   Suite
   {% if states.is_failed -%}
     <span class="label label-danger"><i
-    class="glyphicon glyphicon-warning-sign"
+    class="glyphicon glyphicon-remove"
     title="failed task(s)"></i></span>
     has failed tasks,
   {% endif -%}

--- a/lib/html/template/rose-bush/suites.html
+++ b/lib/html/template/rose-bush/suites.html
@@ -137,63 +137,67 @@ rel="stylesheet" media="screen" />
   </div>
 </div>
 
-<div class="container-fluid">
-{% for entry in entries -%}
-<div class="row entry">
-{% set maxlen=23 -%}
-<div class="col-md-2">
-{% if entry.name|length > maxlen -%}
-<abbr title="{{entry.name}}">{{entry.name|truncate(maxlen,true)}}</abbr>
-{% else -%}
-{{entry.name}}
-{% endif -%}
-</div>
-<div class="col-md-1">
-  <a href="{{script}}/cycles/{{user}}/{{entry.name}}">
-    <button type="button" class="btn btn-default btn-sm">
-      <span class="glyphicon glyphicon-tasks" aria-hidden="true"></span>
-      cycles list
-    </button>
-  </a>
-</div>
-<div class="col-md-1">
-  <a href="{{script}}/taskjobs/{{user}}/{{entry.name}}">
-    <button type="button" class="btn btn-default btn-sm">
-      <span class="glyphicon glyphicon-list" aria-hidden="true"></span>
-      jobs list
-    </button>
-  </a>
-</div>
-<div class="col-md-2">
-{% if entry.last_activity_time -%}
-  <span class="text-info"><i class="glyphicon glyphicon-time" title="last active"></i>
-    <abbr class="livestamp"
-      title="{{entry.last_activity_time}}">{{entry.last_activity_time}}</abbr>
-  </span>
-{% endif -%}{# entry.last_activity_time #}
-</div>
-{% for key, icon, span, maxlen in [("project", "tag", "2", 18), ("title", "comment", "4", 80)] -%}
-<div class="col-md-{{span}}">
-  <i class="glyphicon glyphicon-{{icon}}" title="{{key}}"></i>
-{% if entry.info[key]|length > maxlen -%}
-  <abbr title="{{entry.info[key]}}">{{entry.info[key]|truncate(maxlen,true)}}</abbr>
-{% else -%}
-{{entry.info[key]}}
-{% endif -%}
-</div>
-{% endfor -%}
-</div>
-{% endfor -%}{# entry in entries #}
-</div>
+<table summary="suites entries"
+class="table table-bordered table-condensed table-striped">
+  <thead>
+    <tr>
+      <th>suite name</th>
 
-<div class="container-fluid">
-<div class="row">
-<div class="col-md-12 text-right">
+      <th>
+        cycles list
+      </th>
+
+      <th>
+        task jobs list
+      </th>
+
+      <th>
+        last active time
+      </th>
+
+      <th>
+        project
+      </th>
+
+      <th>
+        title
+      </th>
+    </tr>
+  </thead>
+  <tbody>
+{% for entry in entries -%}
+    <tr>
+      <td><small>{{entry.name}}</small></td>
+      <td>
+        <small>
+          <a href="{{script}}/cycles/{{user}}/{{entry.name}}">cycles list</a>
+        </small>
+      </td>
+
+      <td>
+        <small>
+          <a href="{{script}}/taskjobs/{{user}}/{{entry.name}}">task jobs list</a>
+        </small>
+      </td>
+
+      <td>
+        <small>
+          <abbr class="livestamp"
+          title="{{entry.last_activity_time}}">{{entry.last_activity_time}}</abbr>
+        </small>
+      </td>
+
+      <td><small>{{entry.info["project"]}}</small></td>
+
+      <td><small>{{entry.info["title"]}}</small></td>
+
+    </tr>
+{% endfor -%}{# entry in entries #}
+  </tbody>
+</table>
+
 <hr/>
-<address><small>Rose {{rose_version}}</small></address>
-</div>
-</div>
-</div>
+<address text-right><small>Rose {{rose_version}}</small></address>
 
 <script type="text/javascript" src="{{script}}/js/jquery.min.js"></script>
 <script type="text/javascript" src="{{script}}/js/bootstrap.min.js">

--- a/lib/html/template/rose-bush/suites.html
+++ b/lib/html/template/rose-bush/suites.html
@@ -148,15 +148,16 @@ rel="stylesheet" media="screen" />
 {{entry.name}}
 {% endif -%}
 </div>
-<div class="col-md-2">
+<div class="col-md-1">
   <a href="{{script}}/cycles/{{user}}/{{entry.name}}">
     <button type="button" class="btn btn-default btn-sm">
       <span class="glyphicon glyphicon-tasks" aria-hidden="true"></span>
       cycles list
     </button>
   </a>
-
-  <a href="{{script}}/jobs/{{user}}/{{entry.name}}">
+</div>
+<div class="col-md-1">
+  <a href="{{script}}/taskjobs/{{user}}/{{entry.name}}">
     <button type="button" class="btn btn-default btn-sm">
       <span class="glyphicon glyphicon-list" aria-hidden="true"></span>
       jobs list

--- a/lib/html/template/rose-bush/taskjobs.html
+++ b/lib/html/template/rose-bush/taskjobs.html
@@ -1,5 +1,5 @@
 {% extends "suite-base.html" %}
-{% block title_name %}jobs list{% endblock %}
+{% block title_name %}task jobs list{% endblock %}
 {% block content %}
 <div class="page-header">
 
@@ -23,7 +23,8 @@
         <fieldset class="container-fluid">
           <div class="row">
 {% for key, name, value in [
-    ("cycles", "Cycles: &gt;CYCLE|&lt;CYCLE|CYCLE-GLOB ...", cycles),
+    ("cycles",
+     "Cycles (before, after or patterns): &gt;CYCLE | &lt;CYCLE | GLOB ...", cycles),
     ("tasks", "Task Name Globs", tasks),
 ] -%}
             <div class="form-group col-sm-12 col-md-6">
@@ -194,9 +195,14 @@
   </div>
 </div>
 
-<div class="container-fluid"><!-- entries -->
+<!-- entries -->
+<table summary="task job entries"
+class="table table-bordered table-condensed table-striped">
+  {% include "job-entry-head.html" %}
+  <tbody>
 {% for entry in entries -%}
-{% include "job-entry.html" %}
+  {% include "job-entry.html" %}
 {% endfor -%}
-</div><!-- entries -->
+  </tbody>
+</table><!-- entries -->
 {% endblock %}

--- a/lib/html/template/rose-bush/taskjobs.html
+++ b/lib/html/template/rose-bush/taskjobs.html
@@ -22,65 +22,84 @@
         <input type="hidden" name="no_fuzzy_time" value="{{no_fuzzy_time}}" />
         <fieldset class="container-fluid">
           <div class="row">
-            <div class="col-md-6">
-              <input id="cycles" type="text" name="cycles" class="form-control"
-              title="Cycle globs, &quot;before|after CYCLE&quot;"
-              placeholder="Cycle globs, &quot;before|after CYCLE&quot;"
-{% if cycles -%}
-              value="{{cycles|escape}}"
+{% for key, name, value in [
+    ("cycles", "Cycles: &gt;CYCLE|&lt;CYCLE|CYCLE-GLOB ...", cycles),
+    ("tasks", "Task Name Globs", tasks),
+] -%}
+            <div class="form-group col-sm-12 col-md-6">
+              <label for="{{key}}">{{name}}</label>
+              <input id="{{key}}" type="text" name="{{key}}" class="form-control"
+              title="{{name}}" placeholder="{{name}}"
+{% if value -%}
+              value="{{value|escape}}"
 {% endif -%}
               />
             </div>
-            <div class="col-md-6">
-              <input id="tasks" type="text" name="tasks" class="form-control"
-              title="Task names globs"
-              placeholder="Task names globs"
-{% if tasks -%}
-              value="{{tasks|escape}}"
-{% endif -%}
-              />
-            </div>
+{% endfor -%}
           </div>
-          <br />
           <div class="row">
-            <div class="col-md-1">
-              <label class="checkbox-inline" for="per_page_max">
-                <input id="per_page_max" type="checkbox" name="per_page"
-                value="{{per_page_max}}"
-                title="Display maximum {{per_page_max}} number of entries"
-{% if per_page_max <= per_page -%}
+            <div class="col-sm-12 col-md-12">
+              <label class="checkbox-inline" for="all_task_statuses">
+                <input id="all_task_statuses" type="checkbox"
+                name="task_status"
+                value=""
+                title="Display jobs of all tasks"
+{% if all_task_statuses -%}
                 checked="checked"
 {% endif -%}
                 />
-                Max
+                <strong>Select by Any Task Status</strong>
               </label>
             </div>
-            <div class="col-md-2">
-              <input id="per_page" type="text" name="per_page"
-              class="form-control"
-              title="Entries/Page, 0=unlimited" placeholder="Entries/Page"
-{% if per_page_max <= per_page -%}
-              disabled="disabled"
-{% elif per_page is defined and per_page != per_page_default -%}
-              value="{{per_page}}"
+          </div>
+          <div class="form-group row">
+{% for key, value in task_statuses -%}
+            <div class="col-sm-6 col-md-2">
+              <label class="checkbox-inline" for="task_status_{{key}}">
+                <input class="task_status" type="checkbox"
+                name="task_status"
+                value="{{key}}"
+                title="Display jobs of {{key}} tasks"
+{% if value == "1" -%}
+                checked="checked"
 {% endif -%}
-              />
+                />
+                {{key}}
+              </label>
             </div>
-            <div class="col-md-3">
-{% for status, title in [["active", "active tasks"], ["success",
-"succeeded tasks"], ["fail", "failed tasks"]] -%}
-              <label class="checkbox-inline" for="no_status_{{status}}"
-              title="Hide {{title}}">
-              <input id="no_status_{{status}}" type="checkbox" name="no_status"
-{% if no_statuses and status in no_statuses -%}
-              checked="checked"
-{% endif -%}
-              value="{{status}}" />
-              No {{status}}?</label>
 {% endfor -%}
+          </div>
+          <div class="row">
+            <div class="form-group col-sm-12 col-md-6">
+              <label for="job_status">Select by Job Status</label>
+              <select id="job_status" name="job_status"
+              title="Select by Job Status" class="form-control">
+{% for key in [
+    "all",
+    "submitted",
+    "submitted,running",
+    "submission-failed",
+    "submission-failed,failed",
+    "running",
+    "running,succeeded,failed",
+    "succeeded",
+    "succeeded,failed",
+    "failed",
+]
+ -%}
+                <option
+{% if job_status and key == job_status -%}
+                selected="selected"
+{% endif -%}
+                value="{% if key != "all" -%}{{key}}{% endif -%}">{{key}}
+                </option>
+{% endfor -%}
+              </select>
             </div>
-            <div class="col-md-4">
-              <select name="order" title="Sort order" class="form-control">
+            <div class="form-group col-sm-12 col-md-6">
+              <label for="order">Sort Order</label>
+              <select id="order" name="order" title="Sort Order"
+              class="form-control">
 {% for k, v in [
     ("time_desc", "new-&gt;old"),
     ("time_asc", "old-&gt;new"),
@@ -114,7 +133,35 @@
 {% endfor -%}
               </select>
             </div>
-            <div class="col-md-2 btn-toolbar">
+          </div>
+          <div class="form-group row">
+            <div class="col-sm-12 col-md-12">
+              <label for="per_page">Entries/Page, max=300</label>
+            </div>
+            <div class="col-sm-6 col-md-2">
+              <input id="per_page" type="text" name="per_page"
+              class="form-control"
+              title="Entries/Page, 0=unlimited" placeholder="Entries/Page"
+{% if per_page_max <= per_page -%}
+              disabled="disabled"
+{% elif per_page is defined and per_page != per_page_default -%}
+              value="{{per_page}}"
+{% endif -%}
+              />
+            </div>
+            <div class="col-sm-2 col-md-8">
+              <label class="checkbox-inline" for="per_page_max">
+                <input id="per_page_max" type="checkbox" name="per_page"
+                value="{{per_page_max}}"
+                title="Display maximum {{per_page_max}} number of entries"
+{% if per_page_max <= per_page -%}
+                checked="checked"
+{% endif -%}
+                />
+                Max
+              </label>
+            </div>
+            <div class="form-group col-sm-4 col-md-2 btn-toolbar">
               <div class="btn-group pull-right">
                 <input type="reset" class="btn btn-default" value="reset"
                 title="Reset Display Options"/>

--- a/lib/html/template/rose-bush/view.html
+++ b/lib/html/template/rose-bush/view.html
@@ -4,29 +4,48 @@
 {% block content %}
 <div class="page-header">
 {% include "search-form.html" -%}
+
 {% if path_in_tar -%}
-<h1>{{path_in_tar}}
-<small>&lt; {{path}}</small>
-</h1>
-<div><small>
-<a href="{{script}}/view/{{user}}/{{suite}}?path={{path}}">{{f_name}}</a>
-<span class="label label-default">Content loaded
-<abbr class="livestamp" title="{{time}}">{{time}}</abbr></span>
-</small></div>
+  <h1>{{path_in_tar}}
+    <small>&lt; {{path}}</small>
+  </h1>
+  <div class="pull-right">
+    <a id="toggle-fuzzy-time" data-no-fuzzy-time="{{no_fuzzy_time}}" href="#">
+      <small>toggle &Delta;t</small>
+    </a>
+  </div>
+  <div>
+    <small>
+      <a href="{{script}}/view/{{user}}/{{suite}}?path={{path}}">{{f_name}}</a>
+      <span class="label label-default">Content loaded
+      <abbr class="livestamp" title="{{time}}">{{time}}</abbr></span>
+    </small>
+  </div>
 {% else -%}
-<h1>{{path}}</h1>
-<div><small>
-{{f_name}}
-<span class="label label-default">Content loaded
-<abbr class="livestamp" title="{{time}}">{{time}}</abbr></span>
-</small></div>
+  <h1>{{path}}</h1>
+  <div class="pull-right">
+    <a id="toggle-fuzzy-time" data-no-fuzzy-time="{{no_fuzzy_time}}" href="#">
+      <small>toggle &Delta;t</small>
+    </a>
+  </div>
+  <div>
+    <small>
+      {{f_name}}
+      <span class="label label-default">Content loaded
+      <abbr class="livestamp" title="{{time}}">{{time}}</abbr></span>
+    </small>
+  </div>
 {% endif -%}
 
 {% if entry -%}
-<hr />
-<div class="container-fluid">
-{% include "job-entry.html" %}
-</div>
+  <hr />
+  <table summary="task job entry"
+  class="table table-bordered table-condensed table-striped">
+  {% include "job-entry-head.html" %}
+    <tbody>
+  {% include "job-entry.html" %}
+    </tbody>
+  </table>
 {% endif -%}
 </div>
 

--- a/lib/python/rose/bush.py
+++ b/lib/python/rose/bush.py
@@ -317,6 +317,7 @@ class RoseBushService(object):
             "states": {},
             "suite": suite,
             "tasks": tasks,
+            "task_status_groups": self.bush_dao.TASK_STATUS_GROUPS,
             "title": self.title,
             "user": user,
         }
@@ -628,7 +629,8 @@ class RoseBushService(object):
         )
 
     @cherrypy.expose
-    def view(self, user, suite, path, path_in_tar=None, mode=None):
+    def view(self, user, suite, path, path_in_tar=None, mode=None,
+             no_fuzzy_time="0"):
         """View a text log file."""
         # get file or serve raw data
         file_output = self.get_file(
@@ -657,9 +659,11 @@ class RoseBushService(object):
             path_in_tar=path_in_tar,
             f_name=f_name,
             mode=mode,
+            no_fuzzy_time=no_fuzzy_time,
             file_content=file_content,
             lines=lines,
             entry=job_entry,
+            task_status_groups=self.bush_dao.TASK_STATUS_GROUPS,
             **data)
 
     def _get_suite_logs_info(self, user, suite):

--- a/lib/python/rose/bush_dao.py
+++ b/lib/python/rose/bush_dao.py
@@ -1,0 +1,683 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2012-6 Met Office.
+#
+# This file is part of Rose, a framework for meteorological suites.
+#
+# Rose is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Rose is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Rose. If not, see <http://www.gnu.org/licenses/>.
+# -----------------------------------------------------------------------------
+"""Rose Bush: data access to cylc suite runtime databases."""
+
+from fnmatch import fnmatch
+from glob import glob
+import os
+import re
+import tarfile
+
+from rose.suite_engine_procs.cylc import CylcProcessor, CylcSuiteDAO
+
+
+class RoseBushDAO(object):
+
+    """Rose Bush: data access to cylc suite runtime databases."""
+
+    CYCLE_ORDERS = {"time_desc": " DESC", "time_asc": " ASC"}
+    JOB_ORDERS = {
+        "time_desc": "time DESC, submit_num DESC, name DESC, cycle DESC",
+        "time_asc": "time ASC, submit_num ASC, name ASC, cycle ASC",
+        "cycle_desc_name_asc": "cycle DESC, name ASC, submit_num DESC",
+        "cycle_desc_name_desc": "cycle DESC, name DESC, submit_num DESC",
+        "cycle_asc_name_asc": "cycle ASC, name ASC, submit_num DESC",
+        "cycle_asc_name_desc": "cycle ASC, name DESC, submit_num DESC",
+        "name_asc_cycle_asc": "name ASC, cycle ASC, submit_num DESC",
+        "name_desc_cycle_asc": "name DESC, cycle ASC, submit_num DESC",
+        "name_asc_cycle_desc": "name ASC, cycle DESC, submit_num DESC",
+        "name_desc_cycle_desc": "name DESC, cycle DESC, submit_num DESC",
+        "time_submit_desc": (
+            "time_submit DESC, submit_num DESC, name DESC, cycle DESC"),
+        "time_submit_asc": (
+            "time_submit ASC, submit_num DESC, name DESC, cycle DESC"),
+        "time_run_desc": (
+            "time_run DESC, submit_num DESC, name DESC, cycle DESC"),
+        "time_run_asc": (
+            "time_run ASC, submit_num DESC, name DESC, cycle DESC"),
+        "time_run_exit_desc": (
+            "time_run_exit DESC, submit_num DESC, name DESC, cycle DESC"),
+        "time_run_exit_asc": (
+            "time_run_exit ASC, submit_num DESC, name DESC, cycle DESC"),
+        "duration_queue_desc": (
+            "(CAST(strftime('%s', time_run) AS NUMERIC) -" +
+            " CAST(strftime('%s', time_submit) AS NUMERIC)) DESC, " +
+            "submit_num DESC, name DESC, cycle DESC"),
+        "duration_queue_asc": (
+            "(CAST(strftime('%s', time_run) AS NUMERIC) -" +
+            " CAST(strftime('%s', time_submit) AS NUMERIC)) ASC, " +
+            "submit_num DESC, name DESC, cycle DESC"),
+        "duration_run_desc": (
+            "(CAST(strftime('%s', time_run_exit) AS NUMERIC) -" +
+            " CAST(strftime('%s', time_run) AS NUMERIC)) DESC, " +
+            "submit_num DESC, name DESC, cycle DESC"),
+        "duration_run_asc": (
+            "(CAST(strftime('%s', time_run_exit) AS NUMERIC) -" +
+            " CAST(strftime('%s', time_run) AS NUMERIC)) ASC, " +
+            "submit_num DESC, name DESC, cycle DESC"),
+        "duration_queue_run_desc": (
+            "(CAST(strftime('%s', time_run_exit) AS NUMERIC) -" +
+            " CAST(strftime('%s', time_submit) AS NUMERIC)) DESC, " +
+            "submit_num DESC, name DESC, cycle DESC"),
+        "duration_queue_run_asc": (
+            "(CAST(strftime('%s', time_run_exit) AS NUMERIC) -" +
+            " CAST(strftime('%s', time_submit) AS NUMERIC)) ASC, " +
+            "submit_num DESC, name DESC, cycle DESC"),
+    }
+    JOB_STATUS_COMBOS = {
+        "all": "",
+        "submitted": "submit_status == 0 AND time_run IS NULL",
+        "submitted,running": "submit_status == 0 AND run_status IS NULL",
+        "submission-failed": "submit_status == 1",
+        "submission-failed,failed": "submit_status == 1 OR run_status == 1",
+        "running": "time_run IS NOT NULL AND run_status IS NULL",
+        "running,succeeded,failed": "time_run IS NOT NULL",
+        "succeeded": "run_status == 0",
+        "succeeded,failed": "run_status IS NOT NULL",
+        "failed": "run_status == 1",
+    }
+    REC_CYCLE_QUERY_OP = re.compile(r"\A(before |after |[<>]=?)(.+)\Z")
+    REC_SEQ_LOG = re.compile(r"\A(.+\.)([^\.]+)(\.[^\.]+)\Z")
+    SUITE_CONF = CylcProcessor.SUITE_CONF
+    SUITE_DB = CylcProcessor.SUITE_DB
+    SUITE_DIR_REL_ROOT = CylcProcessor.SUITE_DIR_REL_ROOT
+    TASK_STATUS_GROUPS = {
+        "active": [
+            "ready", "queued", "submitting", "submitted", "submit-retrying",
+            "running", "retrying"],
+        "fail": ["submission failed", "failed"],
+        "success": ["expired", "succeeded"]}
+    TASK_STATUSES = (
+        "runahead", "waiting", "held", "queued", "ready", "expired",
+        "submitted", "submit-failed", "submit-retrying", "running",
+        "succeeded", "failed", "retrying")
+
+    def __init__(self):
+        self.daos = {}
+
+    def get_suite_broadcast_states(self, user_name, suite_name):
+        """Return broadcast states of a suite.
+
+        [[point, name, key, value], ...]
+
+        """
+        # Check if "broadcast_states" table is available or not
+        if not self._db_has_table(user_name, suite_name, "broadcast_states"):
+            return
+
+        broadcast_states = []
+        for row in self._db_exec(
+                user_name, suite_name,
+                "SELECT point,namespace,key,value FROM broadcast_states" +
+                " ORDER BY point ASC, namespace ASC, key ASC"):
+            point, namespace, key, value = row
+            broadcast_states.append([point, namespace, key, value])
+        return broadcast_states
+
+    def get_suite_broadcast_events(self, user_name, suite_name):
+        """Return broadcast events of a suite.
+
+        [[time, change, point, name, key, value], ...]
+
+        """
+        # Check if "broadcast_events" table is available or not
+        if not self._db_has_table(user_name, suite_name, "broadcast_events"):
+            return {}
+
+        broadcast_events = []
+        for row in self._db_exec(
+                user_name, suite_name,
+                "SELECT time,change,point,namespace,key,value" +
+                " FROM broadcast_events" +
+                " ORDER BY time DESC, point DESC, namespace DESC, key DESC"):
+            time_, change, point, namespace, key, value = row
+            broadcast_events.append(
+                (time_, change, point, namespace, key, value))
+        return broadcast_events
+
+    @staticmethod
+    def get_suite_dir_rel(suite_name, *paths):
+        """Return the relative path to the suite running directory.
+
+        paths -- if specified, are added to the end of the path.
+        """
+        return CylcProcessor.get_suite_dir_rel(suite_name, *paths)
+
+    def get_suite_job_entries(
+            self, user_name, suite_name, cycles, tasks, task_status,
+            job_status, order, limit, offset):
+        """Query suite runtime databsae to return a listing of task jobs.
+
+        user -- A string containing a valid user ID
+        suite -- A string containing a valid suite ID
+        cycles -- If specified, display only task jobs matching these cycles.
+                  A value in the list can be a cycle, the string "before|after
+                  CYCLE", or a glob to match cycles.
+        tasks -- If specified, display only jobs with task names matching
+                 these names. Values can be a valid task name or a glob like
+                 pattern for matching valid task names.
+        task_status -- If specified, it should be a list of task statuses.
+                       Display only jobs in the specified list. If not
+                       specified, display all jobs.
+        job_status -- If specified, must be a string matching a key in
+                      RoseBushDAO.JOB_STATUS_COMBOS. Select jobs by their
+                      statuses.
+        order -- Order search in a predetermined way. A valid value is one of
+                 the keys in RoseBushDAO.ORDERS.
+        limit -- Limit number of returned entries
+        offset -- Offset entry number
+
+        Return (entries, of_n_entries) where:
+        entries -- A list of matching entries
+        of_n_entries -- Total number of entries matching query
+
+        Each entry is a dict:
+            {"cycle": cycle, "name": name, "submit_num": submit_num,
+             "events": [time_submit, time_init, time_exit],
+             "task_status": task_status,
+             "logs": {"script": {"path": path, "path_in_tar", path_in_tar,
+                                 "size": size, "mtime": mtime},
+                      "out": {...},
+                      "err": {...},
+                      ...}}
+        """
+        where_expr, where_args = self._get_suite_job_entries_where(
+            cycles, tasks, task_status, job_status)
+
+        # Get number of entries
+        of_n_entries = 0
+        stmt = ("SELECT COUNT(*)" +
+                " FROM task_jobs JOIN task_states USING (name, cycle)" +
+                where_expr)
+        for row in self._db_exec(user_name, suite_name, stmt, where_args):
+            of_n_entries = row[0]
+            break
+        else:
+            self._db_close(user_name, suite_name)
+            return ([], 0)
+
+        # Get entries
+        entries = []
+        entry_of = {}
+        stmt = ("SELECT" +
+                " task_states.time_updated AS time," +
+                " cycle, name," +
+                " task_jobs.submit_num AS submit_num," +
+                " task_states.submit_num AS submit_num_max," +
+                " task_states.status AS task_status," +
+                " time_submit, submit_status," +
+                " time_run, time_run_exit, run_signal, run_status," +
+                " user_at_host, batch_sys_name, batch_sys_job_id" +
+                " FROM task_jobs JOIN task_states USING (cycle, name)" +
+                where_expr +
+                " ORDER BY " +
+                self.JOB_ORDERS.get(order, self.JOB_ORDERS["time_desc"]))
+        limit_args = []
+        if limit:
+            stmt += " LIMIT ? OFFSET ?"
+            limit_args = [limit, offset]
+        for row in self._db_exec(
+                user_name, suite_name, stmt, where_args + limit_args):
+            (
+                cycle, name, submit_num, submit_num_max, task_status,
+                time_submit, submit_status,
+                time_run, time_run_exit, run_signal, run_status,
+                user_at_host, batch_sys_name, batch_sys_job_id
+            ) = row[1:]
+            entry = {
+                "cycle": cycle,
+                "name": name,
+                "submit_num": submit_num,
+                "submit_num_max": submit_num_max,
+                "events": [time_submit, time_run, time_run_exit],
+                "task_status": task_status,
+                "submit_status": submit_status,
+                "run_signal": run_signal,
+                "run_status": run_status,
+                "host": user_at_host,
+                "submit_method": batch_sys_name,
+                "submit_method_id": batch_sys_job_id,
+                "logs": {},
+                "seq_logs_indexes": {}}
+            entries.append(entry)
+            entry_of[(cycle, name, submit_num)] = entry
+        self._db_close(user_name, suite_name)
+        if entries:
+            self._get_job_logs(user_name, suite_name, entries, entry_of)
+        return (entries, of_n_entries)
+
+    def _get_suite_job_entries_where(
+            self, cycles, tasks, task_status, job_status):
+        """Helper for get_suite_job_entries.
+
+        Get query's "WHERE" expression and its arguments.
+        """
+        where_exprs = []
+        where_args = []
+        if cycles:
+            cycle_where_exprs = []
+            for cycle in cycles:
+                match = self.REC_CYCLE_QUERY_OP.match(cycle)
+                if match:
+                    operator, operand = match.groups()
+                    where_args.append(operand)
+                    if operator == "before ":
+                        cycle_where_exprs.append("cycle <= ?")
+                    elif operator == "after ":
+                        cycle_where_exprs.append("cycle >= ?")
+                    else:
+                        cycle_where_exprs.append("cycle %s ?" % operator)
+                else:
+                    where_args.append(cycle)
+                    cycle_where_exprs.append("cycle GLOB ?")
+            where_exprs.append(" OR ".join(cycle_where_exprs))
+        if tasks:
+            where_exprs.append(" OR ".join(["name GLOB ?"] * len(tasks)))
+            where_args += tasks
+        if task_status:
+            task_status_where_exprs = []
+            for item in task_status:
+                task_status_where_exprs.append("task_states.status == ?")
+                where_args.append(item)
+            where_exprs.append(" OR ".join(task_status_where_exprs))
+        try:
+            job_status_where = self.JOB_STATUS_COMBOS[job_status]
+        except KeyError:
+            pass
+        else:
+            if job_status_where:
+                where_exprs.append(job_status_where)
+        if where_exprs:
+            return (" WHERE (" + ") AND (".join(where_exprs) + ")", where_args)
+        else:
+            return ("", where_args)
+
+    def _get_job_logs(self, user_name, suite_name, entries, entry_of):
+        """Helper for "get_suite_job_entries". Get job logs.
+
+        Recent job logs are likely to be in the file system, so we can get a
+        listing of the relevant "log/job/CYCLE/NAME/SUBMI_NUM/" directory.
+        Older job logs may be archived in "log/job-CYCLE.tar.gz", we should
+        only open each relevant TAR file once to obtain a listing for all
+        relevant entries of that cycle.
+
+        Modify each entry in entries.
+        """
+        prefix = "~"
+        if user_name:
+            prefix += user_name
+        user_suite_dir = os.path.expanduser(os.path.join(
+            prefix, self.get_suite_dir_rel(suite_name)))
+        try:
+            fs_log_cycles = os.listdir(
+                os.path.join(user_suite_dir, "log", "job"))
+        except OSError:
+            fs_log_cycles = []
+        targzip_log_cycles = []
+        for name in glob(os.path.join(user_suite_dir, "log", "job-*.tar.gz")):
+            targzip_log_cycles.append(os.path.basename(name)[4:-7])
+
+        relevant_targzip_log_cycles = []
+        for entry in entries:
+            if entry["cycle"] in fs_log_cycles:
+                pathd = "log/job/%(cycle)s/%(name)s/%(submit_num)02d" % entry
+                try:
+                    filenames = os.listdir(os.path.join(user_suite_dir, pathd))
+                except OSError:
+                    pass
+                for filename in filenames:
+                    try:
+                        stat = os.stat(
+                            os.path.join(user_suite_dir, pathd, filename))
+                    except OSError:
+                        pass
+                    entry["logs"][filename] = {
+                        "path": "/".join([pathd, filename]),
+                        "path_in_tar": None,
+                        "mtime": int(stat.st_mtime),  # too precise otherwise
+                        "size": stat.st_size,
+                        "exists": True,
+                        "seq_key": None}
+            elif entry["cycle"] in targzip_log_cycles:
+                if entry["cycle"] not in relevant_targzip_log_cycles:
+                    relevant_targzip_log_cycles.append(entry["cycle"])
+
+        for cycle in relevant_targzip_log_cycles:
+            path = os.path.join("log", "job-%s.tar.gz" % cycle)
+            tar = tarfile.open(os.path.join(user_suite_dir, path), "r:gz")
+            for member in tar.getmembers():
+                # member.name expected to be "job/cycle/task/submit_num/*"
+                if not member.isfile():
+                    continue
+                try:
+                    cycle_str, name, submit_num_str = (
+                        member.name.split("/", 4)[1:4])
+                    entry = entry_of[(cycle_str, name, int(submit_num_str))]
+                except (KeyError, ValueError):
+                    continue
+                entry["logs"][os.path.basename(member.name)] = {
+                    "path": path,
+                    "path_in_tar": member.name,
+                    "mtime": int(member.mtime),  # too precise otherwise
+                    "size": member.size,
+                    "exists": True,
+                    "seq_key": None}
+
+        # Sequential logs
+        for entry in entries:
+            for filename, filename_items in entry["logs"].items():
+                seq_log_match = self.REC_SEQ_LOG.match(filename)
+                if not seq_log_match:
+                    continue
+                head, index_str, tail = seq_log_match.groups()
+                seq_key = head + "*" + tail
+                filename_items["seq_key"] = seq_key
+                if seq_key not in entry["seq_logs_indexes"]:
+                    entry["seq_logs_indexes"][seq_key] = {}
+                entry["seq_logs_indexes"][seq_key][index_str] = filename
+            for seq_key, indexes in entry["seq_logs_indexes"].items():
+                # Only one item, not a sequence
+                if len(indexes) <= 1:
+                    entry["seq_logs_indexes"].pop(seq_key)
+                # All index_str are numbers, convert key to integer so
+                # the template can sort them as numbers
+                try:
+                    int_indexes = {}
+                    for index_str, filename in indexes.items():
+                        int_indexes[int(index_str)] = filename
+                    entry["seq_logs_indexes"][seq_key] = int_indexes
+                except ValueError:
+                    pass
+            for filename, log_dict in entry["logs"].items():
+                # Unset seq_key for singular items
+                if log_dict["seq_key"] not in entry["seq_logs_indexes"]:
+                    log_dict["seq_key"] = None
+
+    def get_suite_logs_info(self, user_name, suite_name):
+        """Return the information of the suite logs.
+
+        Return a tuple that looks like:
+            ("cylc-run",
+             {"err": {"path": "log/suite/err", "mtime": mtime, "size": size},
+              "log": {"path": "log/suite/log", "mtime": mtime, "size": size},
+              "out": {"path": "log/suite/out", "mtime": mtime, "size": size}})
+
+        """
+        logs_info = {}
+        prefix = "~"
+        if user_name:
+            prefix += user_name
+        d_rel = self.get_suite_dir_rel(suite_name)
+        dir_ = os.path.expanduser(os.path.join(prefix, d_rel))
+        # Get cylc files.
+        cylc_files = ["cylc-suite-env", "suite.rc", "suite.rc.processed"]
+        for key in cylc_files:
+            f_name = os.path.join(dir_, key)
+            if os.path.isfile(f_name):
+                f_stat = os.stat(f_name)
+                logs_info[key] = {"path": key,
+                                  "mtime": f_stat.st_mtime,
+                                  "size": f_stat.st_size}
+        # Get cylc suite log files.
+        log_files = ["log/suite/err", "log/suite/log", "log/suite/out"]
+        for key in log_files:
+            f_name = os.path.join(dir_, key)
+            if os.path.isfile(f_name):
+                try:
+                    link_path = os.readlink(f_name)
+                except OSError:
+                    link_path = f_name
+                old_logs = []  # Old log naming system.
+                new_logs = []  # New log naming system.
+                # TODO: Post migration to cylc this logic can be replaced by:
+                # `from cylc.suite_logging import get_logs` (superior)
+                for log in glob(f_name + '.*'):
+                    log_name = os.path.basename(log)
+                    if log_name == link_path:
+                        continue
+                    if len(log_name.split('.')[1]) > 3:
+                        new_logs.append(os.path.join("log", "suite", log_name))
+                    else:
+                        old_logs.append(os.path.join("log", "suite", log_name))
+                new_logs.sort(reverse=True)
+                old_logs.sort()
+                f_stat = os.stat(f_name)
+                logs_info[key] = {"path": key,
+                                  "paths": [key] + new_logs + old_logs,
+                                  "mtime": f_stat.st_mtime,
+                                  "size": f_stat.st_size}
+        return ("cylc", logs_info)
+
+    def get_suite_cycles_summary(
+            self, user_name, suite_name, order, limit, offset):
+        """Return a the state summary (of each cycle) of a user's suite.
+
+        user -- A string containing a valid user ID
+        suite -- A string containing a valid suite ID
+        limit -- Limit number of returned entries
+        offset -- Offset entry number
+
+        Return (entries, of_n_entries), where entries is a data structure that
+        looks like:
+            [   {   "cycle": cycle,
+                    "n_states": {
+                        "active": N, "success": M, "fail": L, "job_fails": K,
+                    },
+                    "max_time_updated": T2,
+                },
+                # ...
+            ]
+        where:
+        * cycle is a date-time cycle label
+        * N, M, L, K are the numbers of tasks in given states
+        * T2 is the time when last update time of (a task in) the cycle
+
+        and of_n_entries is the total number of entries.
+
+        """
+        of_n_entries = 0
+        stmt = ("SELECT COUNT(DISTINCT cycle) FROM task_states WHERE " +
+                "submit_num > 0")
+        for row in self._db_exec(user_name, suite_name, stmt):
+            of_n_entries = row[0]
+            break
+        if not of_n_entries:
+            return ([], 0)
+
+        # Not strictly correct, if cycle is in basic date-only format,
+        # but should not matter for most cases
+        integer_mode = False
+        stmt = "SELECT cycle FROM task_states LIMIT 1"
+        for row in self._db_exec(user_name, suite_name, stmt):
+            integer_mode = row[0].isdigit()
+            break
+
+        prefix = "~"
+        if user_name:
+            prefix += user_name
+        user_suite_dir = os.path.expanduser(os.path.join(
+            prefix, self.get_suite_dir_rel(suite_name)))
+        targzip_log_cycles = []
+        try:
+            for item in os.listdir(os.path.join(user_suite_dir, "log")):
+                if item.startswith("job-") and item.endswith(".tar.gz"):
+                    targzip_log_cycles.append(item[4:-7])
+        except OSError:
+            pass
+
+        states_stmt = {}
+        for key, names in self.TASK_STATUS_GROUPS.items():
+            states_stmt[key] = " OR ".join(
+                ["status=='%s'" % (name) for name in names])
+        stmt = (
+            "SELECT" +
+            " cycle," +
+            " max(time_updated)," +
+            " sum(" + states_stmt["active"] + ") AS n_active," +
+            " sum(" + states_stmt["success"] + ") AS n_success,"
+            " sum(" + states_stmt["fail"] + ") AS n_fail"
+            " FROM task_states" +
+            " GROUP BY cycle")
+        if integer_mode:
+            stmt += " ORDER BY cast(cycle as number)"
+        else:
+            stmt += " ORDER BY cycle"
+        stmt += self.CYCLE_ORDERS.get(order, self.CYCLE_ORDERS["time_desc"])
+        stmt_args = []
+        if limit:
+            stmt += " LIMIT ? OFFSET ?"
+            stmt_args += [limit, offset]
+        entry_of = {}
+        entries = []
+        for row in self._db_exec(user_name, suite_name, stmt, stmt_args):
+            cycle, max_time_updated, n_active, n_success, n_fail = row
+            if n_active or n_success or n_fail:
+                entry_of[cycle] = {
+                    "cycle": cycle,
+                    "has_log_job_tar_gz": cycle in targzip_log_cycles,
+                    "max_time_updated": max_time_updated,
+                    "n_states": {
+                        "active": n_active,
+                        "success": n_success,
+                        "fail": n_fail,
+                        "job_active": 0,
+                        "job_success": 0,
+                        "job_fail": 0,
+                    },
+                }
+                entries.append(entry_of[cycle])
+
+        # Check if "task_jobs" table is available or not.
+        # Note: A single query with a JOIN is probably a more elegant solution.
+        # However, timing tests suggest that it is cheaper with 2 queries.
+        # This 2nd query may return more results than is necessary, but should
+        # be a very cheap query as it does not have to do a lot of work.
+        if self._db_has_table(user_name, suite_name, "task_jobs"):
+            stmt = (
+                "SELECT cycle," +
+                " sum(" + self.JOB_STATUS_COMBOS["submitted,running"] +
+                ") AS n_job_active," +
+                " sum(" + self.JOB_STATUS_COMBOS["succeeded"] +
+                ") AS n_job_success," +
+                " sum(" + self.JOB_STATUS_COMBOS["submission-failed,failed"] +
+                ") AS n_job_fail" +
+                " FROM task_jobs GROUP BY cycle")
+        else:
+            fail_events_stmt = " OR ".join(
+                ["event=='%s'" % (name)
+                 for name in self.TASK_STATUS_GROUPS["fail"]])
+            stmt = (
+                "SELECT cycle," +
+                " sum(" + fail_events_stmt + ") AS n_job_fail" +
+                " FROM task_events GROUP BY cycle")
+        for cycle, n_job_active, n_job_success, n_job_fail in self._db_exec(
+                user_name, suite_name, stmt):
+            try:
+                entry_of[cycle]["n_states"]["job_active"] = n_job_active
+                entry_of[cycle]["n_states"]["job_success"] = n_job_success
+                entry_of[cycle]["n_states"]["job_fail"] = n_job_fail
+            except KeyError:
+                pass
+            else:
+                del entry_of[cycle]
+                if not entry_of:
+                    break
+        self._db_close(user_name, suite_name)
+
+        return entries, of_n_entries
+
+    def get_suite_state_summary(self, user_name, suite_name):
+        """Return a the state summary of a user's suite.
+
+        Return {"is_running": b, "is_failed": b, "server": s}
+        where:
+        * is_running is a boolean to indicate if the suite is running
+        * is_failed: a boolean to indicate if any tasks (submit) failed
+        * server: host:port of server, if available
+
+        """
+        ret = {
+            "is_running": False,
+            "is_failed": False,
+            "server": None}
+        dao = self._db_init(user_name, suite_name)
+        if not os.access(dao.db_f_name, os.F_OK | os.R_OK):
+            return ret
+
+        port_file_path = os.path.expanduser(
+            os.path.join("~" + user_name, ".cylc", "ports", suite_name))
+        try:
+            port_str, host = open(port_file_path).read().splitlines()
+        except (IOError, ValueError):
+            pass
+        else:
+            ret["is_running"] = True
+            ret["server"] = host.split(".", 1)[0] + ":" + port_str
+
+        stmt = "SELECT status FROM task_states WHERE status GLOB ? LIMIT 1"
+        stmt_args = ["*failed"]
+        for _ in self._db_exec(user_name, suite_name, stmt, stmt_args):
+            ret["is_failed"] = True
+            break
+        self._db_close(user_name, suite_name)
+
+        return ret
+
+    @staticmethod
+    def is_conf(path):
+        """Return "cylc-suite-rc" if path is a Cylc suite.rc file."""
+        if fnmatch(os.path.basename(path), "suite*.rc*"):
+            return "cylc-suite-rc"
+
+    @classmethod
+    def parse_job_log_rel_path(cls, f_name):
+        """Return (cycle, task, submit_num, ext)."""
+        return CylcProcessor.parse_job_log_rel_path(f_name)
+
+    def _db_close(self, user_name, suite_name):
+        """Close a named database connection."""
+        key = (user_name, suite_name)
+        if self.daos.get(key) is not None:
+            self.daos[key].close()
+
+    def _db_exec(self, user_name, suite_name, stmt, stmt_args=None):
+        """Execute a query on a named database connection."""
+        daos = self._db_init(user_name, suite_name)
+        return daos.execute(stmt, stmt_args)
+
+    def _db_has_table(self, user_name, suite_name, table_name):
+        """Return True if table_name exists in the suite database."""
+        cursor = self._db_exec(
+            user_name, suite_name,
+            "SELECT name FROM sqlite_master WHERE name==?", [table_name])
+        return cursor.fetchone() is not None
+
+    def _db_init(self, user_name, suite_name):
+        """Initialise a named database connection."""
+        key = (user_name, suite_name)
+        if key not in self.daos:
+            prefix = "~"
+            if user_name:
+                prefix += user_name
+            db_f_name = os.path.expanduser(os.path.join(
+                prefix,
+                self.get_suite_dir_rel(suite_name, CylcProcessor.SUITE_DB)))
+            self.daos[key] = CylcSuiteDAO(db_f_name)
+        return self.daos[key]

--- a/lib/python/rose/bush_dao.py
+++ b/lib/python/rose/bush_dao.py
@@ -341,7 +341,7 @@ class RoseBushDAO(object):
                 try:
                     filenames = os.listdir(os.path.join(user_suite_dir, pathd))
                 except OSError:
-                    pass
+                    continue
                 for filename in filenames:
                     try:
                         stat = os.stat(

--- a/lib/python/rose/bush_dao.py
+++ b/lib/python/rose/bush_dao.py
@@ -348,14 +348,16 @@ class RoseBushDAO(object):
                             os.path.join(user_suite_dir, pathd, filename))
                     except OSError:
                         pass
-                    entry["logs"][filename] = {
-                        "path": "/".join([pathd, filename]),
-                        "path_in_tar": None,
-                        "mtime": int(stat.st_mtime),  # too precise otherwise
-                        "size": stat.st_size,
-                        "exists": True,
-                        "seq_key": None}
-            elif entry["cycle"] in targzip_log_cycles:
+                    else:
+                        entry["logs"][filename] = {
+                            "path": "/".join([pathd, filename]),
+                            "path_in_tar": None,
+                            "mtime": int(stat.st_mtime),  # int precise enough
+                            "size": stat.st_size,
+                            "exists": True,
+                            "seq_key": None}
+                        continue
+            if entry["cycle"] in targzip_log_cycles:
                 if entry["cycle"] not in relevant_targzip_log_cycles:
                     relevant_targzip_log_cycles.append(entry["cycle"])
 

--- a/lib/python/rose/suite_engine_proc.py
+++ b/lib/python/rose/suite_engine_proc.py
@@ -424,42 +424,6 @@ class SuiteEngineProcessor(object):
         """Return host(s) where suite_name is running."""
         raise NotImplementedError()
 
-    def get_suite_job_events(self, user_name, suite_name, cycles, tasks,
-                             no_statuses, order, limit, offset):
-        """Return suite job events.
-
-        user -- A string containing a valid user ID
-        suite -- A string containing a valid suite ID
-        cycles -- Display only task jobs matching these cycles. A value in the
-                  list can be a cycle, the string "before|after CYCLE", or a
-                  glob to match cycles.
-        tasks -- Display only jobs for task names matching these names. Values
-                 can be a valid task name or a glob like pattern for matching
-                 valid task names.
-        no_statues -- Do not display jobs with these statuses. Valid values are
-                      the keys of CylcProcessor.STATUSES.
-        order -- Order search in a predetermined way. A valid value is one of
-                 the keys in CylcProcessor.ORDERS.
-        limit -- Limit number of returned entries
-        offset -- Offset entry number
-
-        Return (entries, of_n_entries) where:
-        entries -- A list of matching entries
-        of_n_entries -- Total number of entries matching query
-
-        Each entry is a dict:
-            {"cycle": cycle, "name": name, "submit_num": submit_num,
-             "events": [time_submit, time_init, time_exit],
-             "status": None|"submit|fail(submit)|init|success|fail|fail(%s)",
-             "logs": {"script": {"path": path, "path_in_tar", path_in_tar,
-                                 "size": size, "mtime": mtime},
-                      "out": {...},
-                      "err": {...},
-                      ...}}
-
-        """
-        raise NotImplementedError()
-
     def get_suite_log_url(self, user_name, suite_name):
         """Return the "rose bush" URL for a user's suite."""
         prefix = "~"
@@ -490,32 +454,7 @@ class SuiteEngineProcessor(object):
             rose_bush_url += "/"
         if not user_name:
             user_name = pwd.getpwuid(os.getuid()).pw_name
-        return rose_bush_url + "/".join(["list", user_name, suite_name])
-
-    def get_suite_logs_info(self, user_name, suite_name):
-        """Return the information of the suite logs.
-
-        Return a tuple that looks like:
-            ("cylc-run",
-             {"err": {"path": "log/suite/err", "mtime": mtime, "size": size},
-              "log": {"path": "log/suite/log", "mtime": mtime, "size": size},
-              "out": {"path": "log/suite/out", "mtime": mtime, "size": size}})
-
-        """
-        raise NotImplementedError()
-
-    def get_suite_state_summary(self, user_name, suite_name):
-        """Return a the state summary of a user's suite.
-
-        Return {"last_activity_time": s, "is_running": b, "is_failed": b}
-        where:
-        * last_activity_time is a string in %Y-%m-%dT%H:%M:%S format,
-          the time of the latest activity in the suite
-        * is_running is a boolean to indicate if the suite is running
-        * is_failed: a boolean to indicate if any tasks (submit) failed
-
-        """
-        raise NotImplementedError()
+        return rose_bush_url + "/".join(["taskjobs", user_name, suite_name])
 
     def get_task_auth(self, suite_name, task_name):
         """Return [user@]host for a remote task in a suite."""
@@ -642,10 +581,6 @@ class SuiteEngineProcessor(object):
         """Launch control GUI for a suite_name running at a host."""
         raise NotImplementedError()
 
-    def is_conf(self, path):
-        """Return the file type if path is a config of this suite engine."""
-        raise NotImplementedError()
-
     def is_suite_registered(self, suite_name):
         """Return whether or not a suite is registered."""
         raise NotImplementedError()
@@ -657,10 +592,6 @@ class SuiteEngineProcessor(object):
         items -- A list of relevant items.
 
         """
-        raise NotImplementedError()
-
-    def job_logs_db_create(self, suite_name, close=False):
-        """Create the job logs database."""
         raise NotImplementedError()
 
     def job_logs_pull_remote(self, suite_name, items,

--- a/lib/python/rose/suite_engine_procs/cylc.py
+++ b/lib/python/rose/suite_engine_procs/cylc.py
@@ -20,7 +20,6 @@
 """Logic specific to the Cylc suite engine."""
 
 import filecmp
-from fnmatch import fnmatch
 from glob import glob
 import os
 from pipes import quote
@@ -40,7 +39,7 @@ import socket
 import sqlite3
 import tarfile
 from tempfile import mkstemp
-from time import sleep, time, gmtime, strftime
+from time import sleep, time
 from uuid import uuid4
 
 
@@ -52,99 +51,20 @@ class CylcProcessor(SuiteEngineProcessor):
 
     """Logic specific to the cylc suite engine."""
 
-    CYCLE_ORDERS = {"time_desc": " DESC", "time_asc": " ASC"}
-    EVENTS = {"submission succeeded": "submit",
-              "submission failed": "fail(submit)",
-              "submitting now": "submit-init",
-              "incrementing submit number": "submit-init",
-              "started": "init",
-              "succeeded": "success",
-              "failed": "fail",
-              "execution started": "init",
-              "execution succeeded": "success",
-              "execution failed": "fail",
-              "signaled": "fail(%s)"}
-    EVENT_TIME_INDICES = {
-        "submit-init": 0, "init": 1, "success": 2, "fail": 2, "fail(%s)": 2}
-    EVENT_RANKS = {"submit-init": 0, "submit": 1, "fail(submit)": 1, "init": 2,
-                   "success": 3, "fail": 3, "fail(%s)": 4}
-    JOB_LOGS_DB = "log/rose-job-logs.db"
-    JOB_ORDERS_OLD = {
-        "time_desc": "time DESC, submit_num DESC, name DESC, cycle DESC",
-        "time_asc": "time ASC, submit_num ASC, name ASC, cycle ASC",
-        "cycle_desc_name_asc": "cycle DESC, name ASC, submit_num DESC",
-        "cycle_desc_name_desc": "cycle DESC, name DESC, submit_num DESC",
-        "cycle_asc_name_asc": "cycle ASC, name ASC, submit_num DESC",
-        "cycle_asc_name_desc": "cycle ASC, name DESC, submit_num DESC",
-        "name_asc_cycle_asc": "name ASC, cycle ASC, submit_num DESC",
-        "name_desc_cycle_asc": "name DESC, cycle ASC, submit_num DESC",
-        "name_asc_cycle_desc": "name ASC, cycle DESC, submit_num DESC",
-        "name_desc_cycle_desc": "name DESC, cycle DESC, submit_num DESC"}
-    JOB_ORDERS = dict(JOB_ORDERS_OLD)
-    JOB_ORDERS.update({
-        "time_submit_desc": (
-            "time_submit DESC, submit_num DESC, name DESC, cycle DESC"),
-        "time_submit_asc": (
-            "time_submit ASC, submit_num DESC, name DESC, cycle DESC"),
-        "time_run_desc": (
-            "time_run DESC, submit_num DESC, name DESC, cycle DESC"),
-        "time_run_asc": (
-            "time_run ASC, submit_num DESC, name DESC, cycle DESC"),
-        "time_run_exit_desc": (
-            "time_run_exit DESC, submit_num DESC, name DESC, cycle DESC"),
-        "time_run_exit_asc": (
-            "time_run_exit ASC, submit_num DESC, name DESC, cycle DESC"),
-        "duration_queue_desc": (
-            "(CAST(strftime('%s', time_run) AS NUMERIC) -" +
-            " CAST(strftime('%s', time_submit) AS NUMERIC)) DESC, " +
-            "submit_num DESC, name DESC, cycle DESC"),
-        "duration_queue_asc": (
-            "(CAST(strftime('%s', time_run) AS NUMERIC) -" +
-            " CAST(strftime('%s', time_submit) AS NUMERIC)) ASC, " +
-            "submit_num DESC, name DESC, cycle DESC"),
-        "duration_run_desc": (
-            "(CAST(strftime('%s', time_run_exit) AS NUMERIC) -" +
-            " CAST(strftime('%s', time_run) AS NUMERIC)) DESC, " +
-            "submit_num DESC, name DESC, cycle DESC"),
-        "duration_run_asc": (
-            "(CAST(strftime('%s', time_run_exit) AS NUMERIC) -" +
-            " CAST(strftime('%s', time_run) AS NUMERIC)) ASC, " +
-            "submit_num DESC, name DESC, cycle DESC"),
-        "duration_queue_run_desc": (
-            "(CAST(strftime('%s', time_run_exit) AS NUMERIC) -" +
-            " CAST(strftime('%s', time_submit) AS NUMERIC)) DESC, " +
-            "submit_num DESC, name DESC, cycle DESC"),
-        "duration_queue_run_asc": (
-            "(CAST(strftime('%s', time_run_exit) AS NUMERIC) -" +
-            " CAST(strftime('%s', time_submit) AS NUMERIC)) ASC, " +
-            "submit_num DESC, name DESC, cycle DESC"),
-    })
     PGREP_CYLC_RUN = r"python.*/bin/cylc-(run|restart)( | .+ )%s( |$)"
-    REASON_KEY_PROC = "process"
-    REASON_KEY_FILE = "port-file"
     REC_CYCLE_TIME = re.compile(
         r"\A[\+\-]?\d+(?:W\d+)?(?:T\d+(?:Z|[+-]\d+)?)?\Z")  # Good enough?
-    REC_SEQ_LOG = re.compile(r"\A(.+\.)([^\.]+)(\.[^\.]+)\Z")
-    REC_SIGNALLED = re.compile(r"Task\sjob\sscript\sreceived\ssignal\s(\S+)")
     SCHEME = "cylc"
-    STATUSES = {"active": ["ready", "queued", "submitting", "submitted",
-                           "submit-retrying", "running", "retrying"],
-                "fail": ["submission failed", "failed"],
-                "success": ["expired", "succeeded"]}
     SUITE_CONF = "suite.rc"
     SUITE_DB = "cylc-suite.db"
     SUITE_DIR_REL_ROOT = "cylc-run"
     TASK_ID_DELIM = "."
+
     TIMEOUT = 60  # seconds
 
     def __init__(self, *args, **kwargs):
         SuiteEngineProcessor.__init__(self, *args, **kwargs)
-        self.daos = {self.SUITE_DB: {}, self.JOB_LOGS_DB: {}}
-        # N.B. Should be considered a constant after initialisation
-        self.state_of = {}
-        for status, names in self.STATUSES.items():
-            for name in names:
-                self.state_of[name] = status
+        self.daos = {}
         self.host = None
         self.user = None
 
@@ -231,474 +151,21 @@ class CylcProcessor(SuiteEngineProcessor):
         self.popen(fmt % (host, suite_name, args_str, os.devnull),
                    env=environ, shell=True)
 
-    def get_suite_broadcast_states(self, user_name, suite_name):
-        """Return broadcast states of a suite.
-
-        [[point, name, key, value], ...]
-
-        """
-        # Check if "broadcast_states" table is available or not
-        if not self._db_has_table(
-                self.SUITE_DB, user_name, suite_name, "broadcast_states"):
-            return
-
-        broadcast_states = []
-        for row in self._db_exec(
-                self.SUITE_DB, user_name, suite_name,
-                "SELECT point,namespace,key,value FROM broadcast_states" +
-                " ORDER BY point ASC, namespace ASC, key ASC"):
-            point, namespace, key, value = row
-            broadcast_states.append([point, namespace, key, value])
-        return broadcast_states
-
-    def get_suite_broadcast_events(self, user_name, suite_name):
-        """Return broadcast events of a suite.
-
-        [[time, change, point, name, key, value], ...]
-
-        """
-        # Check if "broadcast_events" table is available or not
-        if not self._db_has_table(
-                self.SUITE_DB, user_name, suite_name, "broadcast_events"):
-            return {}
-
-        broadcast_events = []
-        for row in self._db_exec(
-                self.SUITE_DB, user_name, suite_name,
-                "SELECT time,change,point,namespace,key,value" +
-                " FROM broadcast_events" +
-                " ORDER BY time DESC, point DESC, namespace DESC, key DESC"):
-            time, change, point, namespace, key, value = row
-            broadcast_events.append(
-                (time, change, point, namespace, key, value))
-        return broadcast_events
-
-    def get_suite_dir_rel(self, suite_name, *paths):
+    @classmethod
+    def get_suite_dir_rel(cls, suite_name, *paths):
         """Return the relative path to the suite running directory.
 
         paths -- if specified, are added to the end of the path.
 
         """
-        return os.path.join(self.SUITE_DIR_REL_ROOT, suite_name, *paths)
-
-    def get_suite_job_events(
-            self, user_name, suite_name, cycles, tasks, no_statuses, order,
-            limit, offset):
-        """Return suite task job events.
-
-        user -- A string containing a valid user ID
-        suite -- A string containing a valid suite ID
-        cycles -- Display only task jobs matching these cycles. A value in the
-                  list can be a cycle, the string "before|after CYCLE", or a
-                  glob to match cycles.
-        tasks -- Display only jobs for task names matching these names. Values
-                 can be a valid task name or a glob like pattern for matching
-                 valid task names.
-        no_statuses -- Do not display jobs with these statuses. Valid values
-                       are the keys of CylcProcessor.STATUSES.
-        order -- Order search in a predetermined way. A valid value is one of
-                 the keys in CylcProcessor.ORDERS.
-        limit -- Limit number of returned entries
-        offset -- Offset entry number
-
-        Return (entries, of_n_entries) where:
-        entries -- A list of matching entries
-        of_n_entries -- Total number of entries matching query
-
-        Each entry is a dict:
-            {"cycle": cycle, "name": name, "submit_num": submit_num,
-             "events": [time_submit, time_init, time_exit],
-             "status": None|"submit|fail(submit)|init|success|fail|fail(%s)",
-             "logs": {"script": {"path": path, "path_in_tar", path_in_tar,
-                                 "size": size, "mtime": mtime},
-                      "out": {...},
-                      "err": {...},
-                      ...}}
-
-        """
-        # Check if "task_jobs" table is available or not
-        if not self._db_has_table(
-                self.SUITE_DB, user_name, suite_name, "task_jobs"):
-            return self._get_suite_job_events_old(
-                user_name, suite_name, cycles, tasks, no_statuses, order,
-                limit, offset)
-
-        # Build the WHERE expression to filter by cycles, tasks, statuses
-        where_exprs = []
-        where_args = []
-        if cycles:
-            cycle_where_exprs = []
-            for cycle in cycles:
-                if cycle.startswith("before "):
-                    where_args.append(cycle.split(None, 1)[-1])
-                    cycle_where_exprs.append("cycle <= ?")
-                elif cycle.startswith("after "):
-                    where_args.append(cycle.split(None, 1)[-1])
-                    cycle_where_exprs.append("cycle >= ?")
-                else:
-                    where_args.append(cycle)
-                    cycle_where_exprs.append("cycle GLOB ?")
-            where_exprs.append(" OR ".join(cycle_where_exprs))
-        if tasks:
-            where_exprs.append(" OR ".join(["name GLOB ?"] * len(tasks)))
-            where_args += tasks
-        if no_statuses:
-            for no_status in no_statuses:
-                statuses = self.STATUSES.get(no_status, [])
-                where_exprs.append(
-                    " AND ".join(["status != ?"] * len(statuses)))
-                where_args += statuses
-        if where_exprs:
-            where_expr = " WHERE (" + ") AND (".join(where_exprs) + ")"
-        else:
-            where_expr = ""
-
-        # Get number of entries
-        of_n_entries = 0
-        stmt = ("SELECT COUNT(*)" +
-                " FROM task_jobs JOIN task_states USING (name, cycle)" +
-                where_expr)
-        for row in self._db_exec(
-                self.SUITE_DB, user_name, suite_name, stmt, where_args):
-            of_n_entries = row[0]
-            break
-        else:
-            self._db_close(self.SUITE_DB, user_name, suite_name)
-            return ([], 0)
-
-        # Get entries
-        entries = []
-        entry_of = {}
-        stmt = ("SELECT" +
-                " task_states.time_updated AS time," +
-                " cycle, name," +
-                " task_jobs.submit_num AS submit_num," +
-                " task_states.submit_num AS submit_num_max," +
-                " task_states.status AS task_status," +
-                " time_submit, submit_status," +
-                " time_run, time_run_exit, run_signal, run_status," +
-                " user_at_host, batch_sys_name, batch_sys_job_id" +
-                " FROM task_jobs JOIN task_states USING (cycle, name)" +
-                where_expr +
-                " ORDER BY " +
-                self.JOB_ORDERS.get(order, self.JOB_ORDERS["time_desc"]))
-        limit_args = []
-        if limit:
-            stmt += " LIMIT ? OFFSET ?"
-            limit_args = [limit, offset]
-        for row in self._db_exec(
-                self.SUITE_DB, user_name, suite_name, stmt,
-                where_args + limit_args):
-            (
-                cycle, name, submit_num, submit_num_max, task_status,
-                time_submit, submit_status,
-                time_run, time_run_exit, run_signal, run_status,
-                user_at_host, batch_sys_name, batch_sys_job_id
-            ) = row[1:]
-            entry = {
-                "cycle": cycle,
-                "name": name,
-                "submit_num": submit_num,
-                "submit_num_max": submit_num_max,
-                "events": [time_submit, time_run, time_run_exit],
-                "task_status": None,
-                "status": None,
-                "host": user_at_host,
-                "submit_method": batch_sys_name,
-                "submit_method_id": batch_sys_job_id,
-                "logs": {},
-                "seq_logs_indexes": {}}
-            try:
-                entry["task_status"] = self.state_of[task_status]
-            except KeyError:
-                pass
-            if run_status and run_signal:
-                entry["status"] = "fail(%s)" % (run_signal)
-            elif run_status:
-                entry["status"] = "fail"
-            elif run_status == 0:
-                entry["status"] = "success"
-            elif submit_status:
-                entry["status"] = "fail(submit)"
-            elif submit_status == 0 and time_run:
-                entry["status"] = "init"
-            elif submit_status == 0:
-                entry["status"] = "submit"
-            else:
-                entry["status"] = "submit-init"
-            entries.append(entry)
-            entry_of[(cycle, name, submit_num)] = entry
-        self._db_close(self.SUITE_DB, user_name, suite_name)
-        if not entries:
-            return (entries, of_n_entries)
-
-        # Job logs
-        # Recent job logs are likely to be in the file system, so we can get a
-        # listing of the relevant "log/job/CYCLE/NAME/SUBMI_NUM/" directory.
-        # Older job logs may be archived in "log/job-CYCLE.tar.gz", we should
-        # only open each relevant TAR file once to obtain a listing for all
-        # relevant entries of that cycle.
-        prefix = "~"
-        if user_name:
-            prefix += user_name
-        user_suite_dir = os.path.expanduser(os.path.join(
-            prefix, self.get_suite_dir_rel(suite_name)))
-        try:
-            fs_log_cycles = os.listdir(
-                os.path.join(user_suite_dir, "log", "job"))
-        except OSError:
-            fs_log_cycles = []
-        targzip_log_cycles = []
-        for name in glob(os.path.join(user_suite_dir, "log", "job-*.tar.gz")):
-            targzip_log_cycles.append(os.path.basename(name)[4:-7])
-
-        relevant_targzip_log_cycles = []
-        for entry in entries:
-            if entry["cycle"] in fs_log_cycles:
-                pathd = "log/job/%(cycle)s/%(name)s/%(submit_num)02d" % entry
-                try:
-                    filenames = os.listdir(os.path.join(user_suite_dir, pathd))
-                except OSError:
-                    pass
-                for filename in filenames:
-                    try:
-                        stat = os.stat(
-                            os.path.join(user_suite_dir, pathd, filename))
-                    except OSError:
-                        pass
-                    entry["logs"][filename] = {
-                        "path": "/".join([pathd, filename]),
-                        "path_in_tar": None,
-                        "mtime": int(stat.st_mtime),  # too precise otherwise
-                        "size": stat.st_size,
-                        "exists": True,
-                        "seq_key": None}
-            elif entry["cycle"] in targzip_log_cycles:
-                if entry["cycle"] not in relevant_targzip_log_cycles:
-                    relevant_targzip_log_cycles.append(entry["cycle"])
-
-        for cycle in relevant_targzip_log_cycles:
-            path = os.path.join("log", "job-%s.tar.gz" % cycle)
-            tar = tarfile.open(os.path.join(user_suite_dir, path), "r:gz")
-            for member in tar.getmembers():
-                # member.name expected to be "job/cycle/task/submit_num/*"
-                if not member.isfile():
-                    continue
-                try:
-                    cycle_str, name, submit_num_str = (
-                        member.name.split("/", 4)[1:4])
-                    entry = entry_of[(cycle_str, name, int(submit_num_str))]
-                except (KeyError, ValueError):
-                    continue
-                entry["logs"][os.path.basename(member.name)] = {
-                    "path": path,
-                    "path_in_tar": member.name,
-                    "mtime": int(member.mtime),  # too precise otherwise
-                    "size": member.size,
-                    "exists": True,
-                    "seq_key": None}
-
-        # Sequential logs
-        for entry in entries:
-            for filename, filename_items in entry["logs"].items():
-                seq_log_match = self.REC_SEQ_LOG.match(filename)
-                if not seq_log_match:
-                    continue
-                head, index_str, tail = seq_log_match.groups()
-                seq_key = head + "*" + tail
-                filename_items["seq_key"] = seq_key
-                if seq_key not in entry["seq_logs_indexes"]:
-                    entry["seq_logs_indexes"][seq_key] = {}
-                entry["seq_logs_indexes"][seq_key][index_str] = filename
-            for seq_key, indexes in entry["seq_logs_indexes"].items():
-                # Only one item, not a sequence
-                if len(indexes) <= 1:
-                    entry["seq_logs_indexes"].pop(seq_key)
-                # All index_str are numbers, convert key to integer so
-                # the template can sort them as numbers
-                try:
-                    int_indexes = {}
-                    for index_str, filename in indexes.items():
-                        int_indexes[int(index_str)] = filename
-                    entry["seq_logs_indexes"][seq_key] = int_indexes
-                except ValueError:
-                    pass
-            for filename, log_dict in entry["logs"].items():
-                # Unset seq_key for singular items
-                if log_dict["seq_key"] not in entry["seq_logs_indexes"]:
-                    log_dict["seq_key"] = None
-
-        return (entries, of_n_entries)
-
-    def _get_suite_job_events_old(
-            self, user_name, suite_name, cycles, tasks, no_statuses, order,
-            limit, offset):
-        """The "get_suite_job_events" method for older cylc versions."""
-        # Build WHERE expression to select by cycles and/or task names
-        where = ""
-        stmt_args = []
-        if cycles:
-            where_fragments = []
-            for cycle in cycles:
-                if cycle.startswith("before "):
-                    stmt_args.append(cycle.split(None, 1)[-1])
-                    where_fragments.append("cycle <= ?")
-                elif cycle.startswith("after "):
-                    stmt_args.append(cycle.split(None, 1)[-1])
-                    where_fragments.append("cycle >= ?")
-                else:
-                    stmt_args.append(cycle)
-                    where_fragments.append("cycle GLOB ?")
-            where += " AND (" + " OR ".join(where_fragments) + ")"
-        if tasks:
-            where_fragments = []
-            for task in tasks:
-                where_fragments.append("name GLOB ?")
-                stmt_args.append(task)
-            where += " AND (" + " OR ".join(where_fragments) + ")"
-        if no_statuses:
-            where_fragments = []
-            for no_status in no_statuses:
-                for status in self.STATUSES.get(no_status, []):
-                    where_fragments.append("status != ?")
-                    stmt_args.append(status)
-            where += " AND (" + " AND ".join(where_fragments) + ")"
-        # Execute query to get number of entries
-        of_n_entries = 0
-        stmt = ("SELECT COUNT(*) FROM"
-                " task_events JOIN task_states USING (name,cycle)"
-                " WHERE event==? OR event==?")
-        if where:
-            stmt += " " + where
-        for row in self._db_exec(
-                self.SUITE_DB, user_name, suite_name, stmt,
-                ["submitting now", "incrementing submit number"] + stmt_args):
-            of_n_entries = row[0]
-            break
-        if not of_n_entries:
-            return ([], 0)
-        # Execute query to get entries
-        entries = []
-        stmt = (
-            "SELECT" +
-            " cycle, name, task_events.submit_num AS submit_num," +
-            " group_concat(time), group_concat(event)," +
-            " group_concat(message) " +
-            " FROM" +
-            " task_events JOIN task_states USING (cycle,name)" +
-            " WHERE" +
-            " (event==? OR event==? OR event==? OR" +
-            "  event==? OR event==? OR event==? OR event==?)" +
-            where +
-            " GROUP BY cycle, name, task_events.submit_num" +
-            " ORDER BY " +
-            self.JOB_ORDERS_OLD.get(order, self.JOB_ORDERS_OLD["time_desc"]))
-        stmt_args_head = [
-            "submitting now", "incrementing submit number",
-            "submission failed", "started", "succeeded", "failed", "signaled"]
-        stmt_args_tail = []
-        if limit:
-            stmt += " LIMIT ? OFFSET ?"
-            stmt_args_tail = [limit, offset]
-        for row in self._db_exec(
-                self.SUITE_DB, user_name, suite_name, stmt,
-                stmt_args_head + stmt_args + stmt_args_tail):
-            cycle, name, submit_num, times_str, events_str, messages_str = row
-            entry = {"cycle": cycle, "name": name, "submit_num": submit_num,
-                     "submit_num_max": 1, "events": [None, None, None],
-                     "status": None, "logs": {}, "seq_logs_indexes": {}}
-            entries.append(entry)
-            events = events_str.split(",")
-            times = times_str.split(",")
-            event_rank = -1
-            for event, time_ in zip(events, times):
-                my_event = self.EVENTS.get(event)
-                if self.EVENT_TIME_INDICES.get(my_event) is not None:
-                    entry["events"][self.EVENT_TIME_INDICES[my_event]] = time_
-                if (self.EVENT_RANKS.get(my_event) is not None and
-                        self.EVENT_RANKS[my_event] > event_rank):
-                    entry["status"] = my_event
-                    event_rank = self.EVENT_RANKS[my_event]
-                    if my_event == "fail(%s)":
-                        match = self.REC_SIGNALLED.search(messages_str)
-                        if match:
-                            entry["status"] = "fail(%s)" % match.group(1)
-                        else:
-                            entry["status"] = "fail(SIGNAL)"
-
-        other_info_of = {}
-        for entry in entries:
-            cycle = entry["cycle"]
-            name = entry["name"]
-            if (cycle, name) not in other_info_of:
-                stmt = ("SELECT" +
-                        " submit_num,host,submit_method,submit_method_id" +
-                        " FROM task_states" +
-                        " WHERE cycle==? AND name==?")
-                for row in self._db_exec(self.SUITE_DB, user_name, suite_name,
-                                         stmt, [cycle, name]):
-                    other_info_of[(cycle, name)] = list(row)
-                    break
-            entry["submit_num_max"] = other_info_of[(cycle, name)][0]
-            if entry["submit_num"] == entry["submit_num_max"]:
-                entry["host"] = other_info_of[(cycle, name)][1]
-                entry["submit_method"] = other_info_of[(cycle, name)][2]
-                entry["submit_method_id"] = other_info_of[(cycle, name)][3]
-
-        self._db_close(self.SUITE_DB, user_name, suite_name)
-
-        # Job logs DB
-        stmt = ("SELECT key,path,path_in_tar,mtime,size FROM log_files " +
-                "WHERE cycle==? AND task==? AND submit_num==?")
-        prefix = "~"
-        if user_name:
-            prefix += user_name
-        user_suite_dir = os.path.join(os.path.expanduser(prefix),
-                                      self.get_suite_dir_rel(suite_name))
-        for entry in entries:
-            stmt_args = [entry["cycle"], entry["name"], entry["submit_num"]]
-            cursor = self._db_exec(self.JOB_LOGS_DB, user_name, suite_name,
-                                   stmt, stmt_args)
-            if cursor is None:
-                continue
-            for row in cursor:
-                key, path, path_in_tar, mtime, size = row
-                abs_path = os.path.join(user_suite_dir, path)
-                entry["logs"][key] = {"path": path,
-                                      "path_in_tar": path_in_tar,
-                                      "mtime": mtime,
-                                      "size": size,
-                                      "exists": os.path.exists(abs_path),
-                                      "seq_key": None}
-                seq_log_match = self.REC_SEQ_LOG.match(key)
-                if not seq_log_match:
-                    continue
-                head, index_str, tail = seq_log_match.groups()
-                if not tail and not index_str.isdigit():
-                    continue
-                if not tail:
-                    tail = ""
-                seq_key = head + "*" + tail
-                entry["logs"][key]["seq_key"] = seq_key
-                if seq_key not in entry["seq_logs_indexes"]:
-                    entry["seq_logs_indexes"][seq_key] = {}
-                entry["seq_logs_indexes"][seq_key][index_str] = key
-
-            for seq_key, indexes in entry["seq_logs_indexes"].items():
-                if len(indexes) <= 1:
-                    entry["seq_logs_indexes"].pop(seq_key)
-            for key, log_dict in entry["logs"].items():
-                if log_dict["seq_key"] not in entry["seq_logs_indexes"]:
-                    log_dict["seq_key"] = None
-        self._db_close(self.JOB_LOGS_DB, user_name, suite_name)
-        return (entries, of_n_entries)
+        return os.path.join(cls.SUITE_DIR_REL_ROOT, suite_name, *paths)
 
     def get_suite_jobs_auths(self, suite_name, cycle_time=None,
                              task_name=None):
         """Return remote ["[user@]host", ...] for submitted jobs."""
         auths = []
         # Check if "task_jobs" table is available or not
-        if self._db_has_table(self.SUITE_DB, None, suite_name, "task_jobs"):
+        if self._db_has_table(suite_name, "task_jobs"):
             stmt = "SELECT DISTINCT user_at_host FROM task_jobs"
             stmt_where_list = []
             stmt_args = []
@@ -712,180 +179,13 @@ class CylcProcessor(SuiteEngineProcessor):
                 stmt_args.append(arg)
         if stmt_where_list:
             stmt += " WHERE " + " AND ".join(stmt_where_list)
-        for row in self._db_exec(
-                self.SUITE_DB, None, suite_name, stmt, stmt_args):
+        for row in self._db_exec(suite_name, stmt, stmt_args):
             if row and row[0]:
                 auth = self._parse_user_host(auth=row[0])
                 if auth:
                     auths.append(auth)
-        self._db_close(self.SUITE_DB, None, suite_name)
+        self._db_close(suite_name)
         return auths
-
-    def get_suite_logs_info(self, user_name, suite_name):
-        """Return the information of the suite logs.
-
-        Return a tuple that looks like:
-            ("cylc-run",
-             {"err": {"path": "log/suite/err", "mtime": mtime, "size": size},
-              "log": {"path": "log/suite/log", "mtime": mtime, "size": size},
-              "out": {"path": "log/suite/out", "mtime": mtime, "size": size}})
-
-        """
-        logs_info = {}
-        prefix = "~"
-        if user_name:
-            prefix += user_name
-        d_rel = self.get_suite_dir_rel(suite_name)
-        dir_ = os.path.expanduser(os.path.join(prefix, d_rel))
-        # Get cylc files.
-        cylc_files = ["cylc-suite-env", "suite.rc", "suite.rc.processed"]
-        for key in cylc_files:
-            f_name = os.path.join(dir_, key)
-            if os.path.isfile(f_name):
-                f_stat = os.stat(f_name)
-                logs_info[key] = {"path": key,
-                                  "mtime": f_stat.st_mtime,
-                                  "size": f_stat.st_size}
-        # Get cylc suite log files.
-        log_files = ["log/suite/err", "log/suite/log", "log/suite/out"]
-        for key in log_files:
-            f_name = os.path.join(dir_, key)
-            if os.path.isfile(f_name):
-                try:
-                    link_path = os.readlink(f_name)
-                except OSError:
-                    link_path = f_name
-                old_logs = []  # Old log naming system.
-                new_logs = []  # New log naming system.
-                # TODO: Post migration to cylc this logic can be replaced by:
-                # `from cylc.suite_logging import get_logs` (superior)
-                for log in glob(f_name + '.*'):
-                    log_name = os.path.basename(log)
-                    if log_name == link_path:
-                        continue
-                    if len(log_name.split('.')[1]) > 3:
-                        new_logs.append(os.path.join("log", "suite", log_name))
-                    else:
-                        old_logs.append(os.path.join("log", "suite", log_name))
-                new_logs.sort(reverse=True)
-                old_logs.sort()
-                f_stat = os.stat(f_name)
-                logs_info[key] = {"path": key,
-                                  "paths": [key] + new_logs + old_logs,
-                                  "mtime": f_stat.st_mtime,
-                                  "size": f_stat.st_size}
-        return ("cylc", logs_info)
-
-    def get_suite_cycles_summary(
-            self, user_name, suite_name, order, limit, offset):
-        """Return a the state summary (of each cycle) of a user's suite.
-
-        user -- A string containing a valid user ID
-        suite -- A string containing a valid suite ID
-        limit -- Limit number of returned entries
-        offset -- Offset entry number
-
-        Return (entries, of_n_entries), where entries is a data structure that
-        looks like:
-            [   {   "cycle": cycle,
-                    "n_states": {
-                        "active": N, "success": M, "fail": L, "job_fails": K,
-                    },
-                    "max_time_updated": T2,
-                },
-                # ...
-            ]
-        where:
-        * cycle is a date-time cycle label
-        * N, M, L, K are the numbers of tasks in given states
-        * T2 is the time when last update time of (a task in) the cycle
-
-        and of_n_entries is the total number of entries.
-
-        """
-        of_n_entries = 0
-        stmt = ("SELECT COUNT(DISTINCT cycle) FROM task_states WHERE " +
-                "submit_num > 0")
-        for row in self._db_exec(
-                self.SUITE_DB, user_name, suite_name, stmt):
-            of_n_entries = row[0]
-            break
-        if not of_n_entries:
-            return ([], 0)
-
-        # FIXME: Not strictly correct, if cycle is in basic date-only format
-        integer_mode = False
-        stmt = "SELECT cycle FROM task_states LIMIT 1"
-        for row in self._db_exec(self.SUITE_DB, user_name, suite_name, stmt):
-            integer_mode = row[0].isdigit()
-            break
-
-        states_stmt = {}
-        for key, names in self.STATUSES.items():
-            states_stmt[key] = " OR ".join(
-                ["status=='%s'" % (name) for name in names])
-        stmt = (
-            "SELECT" +
-            " cycle," +
-            " max(time_updated)," +
-            " sum(" + states_stmt["active"] + ") AS n_active," +
-            " sum(" + states_stmt["success"] + ") AS n_success,"
-            " sum(" + states_stmt["fail"] + ") AS n_fail"
-            " FROM task_states" +
-            " GROUP BY cycle")
-        if integer_mode:
-            stmt += " ORDER BY cast(cycle as number)"
-        else:
-            stmt += " ORDER BY cycle"
-        stmt += self.CYCLE_ORDERS.get(order, self.CYCLE_ORDERS["time_desc"])
-        stmt_args = []
-        if limit:
-            stmt += " LIMIT ? OFFSET ?"
-            stmt_args += [limit, offset]
-        entry_of = {}
-        entries = []
-        for row in self._db_exec(
-                self.SUITE_DB, user_name, suite_name, stmt, stmt_args):
-            cycle, max_time_updated, n_active, n_success, n_fail = row
-            if n_active or n_success or n_fail:
-                entry_of[cycle] = {
-                    "cycle": cycle,
-                    "max_time_updated": max_time_updated,
-                    "n_states": {
-                        "active": n_active,
-                        "success": n_success,
-                        "fail": n_fail,
-                        "job_fails": 0,
-                    },
-                }
-                entries.append(entry_of[cycle])
-
-        # Check if "task_jobs" table is available or not.
-        # Note: A single query with a JOIN is probably a more elegant solution.
-        # However, timing tests suggest that it is cheaper with 2 queries.
-        # This 2nd query may return more results than is necessary, but should
-        # be a very cheap query as it does not have to do a lot of work.
-        if self._db_has_table(
-                self.SUITE_DB, user_name, suite_name, "task_jobs"):
-            stmt = (
-                "SELECT cycle," +
-                " sum(submit_status==1 OR run_status==1) AS n_job_fail" +
-                " FROM task_jobs GROUP BY cycle")
-        else:
-            fail_events_stmt = " OR ".join(
-                ["event=='%s'" % (name) for name in self.STATUSES["fail"]])
-            stmt = (
-                "SELECT cycle," +
-                " sum(" + fail_events_stmt + ") AS n_job_fail" +
-                " FROM task_events GROUP BY cycle")
-        for cycle, n_job_fail in self._db_exec(
-                self.SUITE_DB, user_name, suite_name, stmt):
-            try:
-                entry_of[cycle]["n_states"]["job_fails"] = n_job_fail
-            except KeyError:
-                pass
-
-        return entries, of_n_entries
 
     def get_suite_run_hosts(self, user_name, suite_name, host_names=None):
         """Return a list of host(s) where suite_name has running processes."""
@@ -1009,44 +309,6 @@ class CylcProcessor(SuiteEngineProcessor):
                     fail_list.append(host_name)
         return yes_list, no_list, fail_list
 
-    def get_suite_state_summary(self, user_name, suite_name):
-        """Return a the state summary of a user's suite.
-
-        Return {"is_running": b, "is_failed": b, "server": s}
-        where:
-        * is_running is a boolean to indicate if the suite is running
-        * is_failed: a boolean to indicate if any tasks (submit) failed
-        * server: host:port of server, if available
-
-        """
-        ret = {
-            "is_running": False,
-            "is_failed": False,
-            "server": None}
-        dao = self._db_init(self.SUITE_DB, user_name, suite_name)
-        if not os.access(dao.db_f_name, os.F_OK | os.R_OK):
-            return ret
-
-        port_file_path = os.path.expanduser(
-            os.path.join("~" + user_name, ".cylc", "ports", suite_name))
-        try:
-            port_str, host = open(port_file_path).read().splitlines()
-        except (IOError, ValueError):
-            ret["is_running"] = bool(
-                self._suite_hosts_pgrep(user_name, suite_name)[0])
-        else:
-            ret["is_running"] = True
-            ret["server"] = host.split(".", 1)[0] + ":" + port_str
-
-        stmt = "SELECT status FROM task_states WHERE status GLOB ? LIMIT 1"
-        stmt_args = ["*failed"]
-        for row in self._db_exec(self.SUITE_DB, user_name, suite_name, stmt,
-                                 stmt_args):
-            ret["is_failed"] = True
-            break
-
-        return ret
-
     def get_task_auth(self, suite_name, task_name):
         """
         Return [user@]host for a remote task in a suite.
@@ -1135,11 +397,6 @@ class CylcProcessor(SuiteEngineProcessor):
         """Return Cylc's version."""
         return self.popen("cylc", "--version")[0].strip()
 
-    def is_conf(self, path):
-        """Return "cylc-suite-rc" if path is a Cylc suite.rc file."""
-        if fnmatch(os.path.basename(path), "suite*.rc*"):
-            return "cylc-suite-rc"
-
     def is_suite_registered(self, suite_name):
         """See if a suite is registered
             Return True directory for a suite if it is registered
@@ -1157,9 +414,9 @@ class CylcProcessor(SuiteEngineProcessor):
         cycles = []
         if "*" in items:
             stmt = "SELECT DISTINCT cycle FROM task_events"
-            for row in self._db_exec(self.SUITE_DB, None, suite_name, stmt):
+            for row in self._db_exec(suite_name, stmt):
                 cycles.append(row[0])
-            self._db_close(self.SUITE_DB, None, suite_name)
+            self._db_close(suite_name)
         else:
             for item in items:
                 cycle = self._parse_task_cycle_id(item)[0]
@@ -1169,8 +426,6 @@ class CylcProcessor(SuiteEngineProcessor):
         cwd = os.getcwd()
         self.fs_util.chdir(self.get_suite_dir(suite_name))
         try:
-            stmt = ("UPDATE log_files SET path=?, path_in_tar=? " +
-                    "WHERE cycle==? AND task==? AND submit_num==? AND key==?")
             for cycle in cycles:
                 archive_file_name0 = os.path.join("log",
                                                   "job-" + cycle + ".tar")
@@ -1184,7 +439,7 @@ class CylcProcessor(SuiteEngineProcessor):
                 f_bsize = os.statvfs(".").f_bsize
                 tar = tarfile.open(archive_file_name0, "w", bufsize=f_bsize)
                 for name in names:
-                    cycle, task, s_n, ext = self.parse_job_log_rel_path(name)
+                    cycle, _, s_n, ext = self.parse_job_log_rel_path(name)
                     if s_n == "NN" or ext == "job.status":
                         continue
                     tar.add(name, name.replace("log/", "", 1))
@@ -1194,45 +449,11 @@ class CylcProcessor(SuiteEngineProcessor):
                 self.handle_event(FileSystemEvent(FileSystemEvent.CREATE,
                                                   archive_file_name))
                 self.fs_util.delete(os.path.join("log", "job", cycle))
-                for name in names:
-                    # cycle, task, submit_num, extension
-                    cycle, task, s_n, ext = self.parse_job_log_rel_path(name)
-                    if s_n == "NN" or ext == "job.status":
-                        continue
-                    stmt_args = [
-                        os.path.join(archive_file_name),
-                        name.replace("log/", "", 1),
-                        cycle,
-                        task,
-                        int(s_n),
-                        ext]
-                    self._db_exec(self.JOB_LOGS_DB, None, suite_name,
-                                  stmt, stmt_args, commit=True)
         finally:
             try:
                 self.fs_util.chdir(cwd)
             except OSError:
                 pass
-        self._db_close(self.JOB_LOGS_DB, None, suite_name)
-
-    def job_logs_db_create(self, suite_name, close=False):
-        """Create the job logs database."""
-        if (None, suite_name) in self.daos[self.JOB_LOGS_DB]:
-            return self.daos[self.JOB_LOGS_DB][(None, suite_name)]
-        db_f_name = self.get_suite_dir(suite_name, self.JOB_LOGS_DB)
-        dao = DAO(db_f_name)
-        if os.access(db_f_name, os.R_OK | os.F_OK):
-            return dao
-        self.daos[self.JOB_LOGS_DB][(None, suite_name)] = dao
-        dao.connect(is_new=True)
-        stmt = ("CREATE TABLE log_files(" +
-                "cycle TEXT, task TEXT, submit_num TEXT, key TEXT, " +
-                "path TEXT, path_in_tar TEXT, mtime TEXT, size INTEGER, " +
-                "PRIMARY KEY(cycle, task, submit_num, key))")
-        dao.execute(stmt, commit=True)
-        if close:
-            dao.close()
-        return dao
 
     def job_logs_pull_remote(self, suite_name, items,
                              prune_remote_mode=False, force_mode=False):
@@ -1342,35 +563,6 @@ class CylcProcessor(SuiteEngineProcessor):
         finally:
             self.fs_util.delete(uuid_file_name)
 
-        # Update job log DB
-        dao = self.job_logs_db_create(suite_name)
-        dir_ = self.get_suite_dir(suite_name)
-        stmt = ("REPLACE INTO log_files VALUES(?, ?, ?, ?, ?, ?, ?, ?)")
-        for item in items:
-            cycle, name = self._parse_task_cycle_id(item)
-            if not cycle:
-                cycle = "*"
-            if not name:
-                name = "*"
-            logs_prefix = self.get_suite_dir(
-                suite_name,
-                "log/job/%(cycle)s/%(name)s/*/*" % {
-                    "cycle": cycle, "name": name})
-            for f_name in glob(logs_prefix + "*"):
-                if f_name.endswith("/job.status"):
-                    continue
-                stat = os.stat(f_name)
-                rel_f_name = f_name[len(dir_) + 1:]
-                # cycle, task, submit_num, extension
-                cycle, task, s_n, ext = self.parse_job_log_rel_path(rel_f_name)
-                if s_n == "NN":
-                    continue
-                stmt_args = [cycle, task, int(s_n), ext, rel_f_name, "",
-                             stat.st_mtime, stat.st_size]
-                dao.execute(stmt, stmt_args)
-        dao.commit()
-        dao.close()
-
     def job_logs_remove_on_server(self, suite_name, items):
         """Remove cycle job logs.
 
@@ -1381,9 +573,9 @@ class CylcProcessor(SuiteEngineProcessor):
         cycles = []
         if "*" in items:
             stmt = "SELECT DISTINCT cycle FROM task_events"
-            for row in self._db_exec(self.SUITE_DB, None, suite_name, stmt):
+            for row in self._db_exec(suite_name, stmt):
                 cycles.append(row[0])
-            self._db_close(self.SUITE_DB, None, suite_name)
+            self._db_close(suite_name)
         else:
             for item in items:
                 cycle = self._parse_task_cycle_id(item)[0]
@@ -1415,8 +607,8 @@ class CylcProcessor(SuiteEngineProcessor):
         """Return (cycle, task, submit_num, ext)."""
         return f_name.replace("log/job/", "").split("/", 3)
 
-    @classmethod
-    def process_suite_hook_args(cls, *args, **_):
+    @staticmethod
+    def process_suite_hook_args(*args, **_):
         """Rearrange args for TaskHook.run."""
         task = None
         if len(args) == 3:
@@ -1552,7 +744,7 @@ class CylcProcessor(SuiteEngineProcessor):
             else:
                 ret_code = proc.wait()
                 out, err = proc.communicate()
-                exceptions.append(RosePopenError(keys[2], ret_code, out, err))
+                exceptions.append(RosePopenError(key[2], ret_code, out, err))
         return (sorted(results.values()), exceptions)
 
     def shutdown(self, suite_name, host=None, engine_version=None, args=None,
@@ -1578,36 +770,31 @@ class CylcProcessor(SuiteEngineProcessor):
         self.popen.run_simple(
             *command, env=environ, stderr=stderr, stdout=stdout)
 
-    def _db_close(self, db_name, user_name, suite_name):
+    def _db_close(self, suite_name):
         """Close a named database connection."""
-        key = (user_name, suite_name)
-        if self.daos[db_name].get(key) is not None:
-            self.daos[db_name][key].close()
+        if self.daos.get(suite_name) is not None:
+            self.daos[suite_name].close()
 
-    def _db_exec(self, db_name, user_name, suite_name, stmt, stmt_args=None,
-                 commit=False):
+    def _db_exec(self, suite_name, stmt, stmt_args=None, commit=False):
         """Execute a query on a named database connection."""
-        dao = self._db_init(db_name, user_name, suite_name)
-        return dao.execute(stmt, stmt_args, commit)
+        daos = self._db_init(suite_name)
+        return daos.execute(stmt, stmt_args, commit)
 
-    def _db_has_table(self, db_name, user_name, suite_name, table_name):
+    def _db_has_table(self, suite_name, table_name):
         """Return True if table_name exists in the suite database."""
         cursor = self._db_exec(
-            db_name, user_name, suite_name,
+            suite_name,
             "SELECT name FROM sqlite_master WHERE name==?", [table_name])
         return (cursor and cursor.fetchone() is not None)
 
-    def _db_init(self, db_name, user_name, suite_name):
+    def _db_init(self, suite_name):
         """Initialise a named database connection."""
-        key = (user_name, suite_name)
-        if key not in self.daos[db_name]:
+        if suite_name not in self.daos:
             prefix = "~"
-            if user_name:
-                prefix += user_name
             db_f_name = os.path.expanduser(os.path.join(
-                prefix, self.get_suite_dir_rel(suite_name, db_name)))
-            self.daos[db_name][key] = DAO(db_f_name)
-        return self.daos[db_name][key]
+                prefix, self.get_suite_dir_rel(suite_name, self.SUITE_DB)))
+            self.daos[suite_name] = CylcSuiteDAO(db_f_name)
+        return self.daos[suite_name]
 
     def _parse_task_cycle_id(self, item):
         """Parse name.cycle. Return (cycle, name)."""
@@ -1650,12 +837,12 @@ class CylcProcessor(SuiteEngineProcessor):
         return auth
 
 
-class DAO(object):
+class CylcSuiteDAO(object):
 
     """Generic SQLite Data Access Object."""
 
     CONNECT_RETRY_DELAY = 0.1
-    N_CONNECT_TRIES = 5
+    N_CONNECT_TRIES = 10
 
     def __init__(self, db_f_name):
         self.db_f_name = db_f_name
@@ -1685,7 +872,8 @@ class DAO(object):
             return None
         for _ in range(self.N_CONNECT_TRIES):
             try:
-                self.conn = sqlite3.connect(self.db_f_name)
+                self.conn = sqlite3.connect(
+                    self.db_f_name, self.CONNECT_RETRY_DELAY)
                 self.cursor = self.conn.cursor()
             except sqlite3.OperationalError:
                 sleep(self.CONNECT_RETRY_DELAY)

--- a/lib/python/rose/suite_run.py
+++ b/lib/python/rose/suite_run.py
@@ -249,9 +249,6 @@ class SuiteRunner(Runner):
             self.event_handler.contexts[uuid].handle = log_file
             temp_log_file.close()
 
-        # Create the suite log view
-        self.suite_engine_proc.job_logs_db_create(suite_name, close=True)
-
         # Install share/work directories (local)
         for name in ["share", "share/cycle", "work"]:
             self._run_init_dir_work(

--- a/t/rose-bush/01-title.t
+++ b/t/rose-bush/01-title.t
@@ -47,7 +47,8 @@ SUITE_NAME="$(basename "${SUITE_DIR}")"
 cp -pr "${TEST_SOURCE_DIR}/${TEST_KEY_BASE}/"* "${SUITE_DIR}"
 export CYLC_CONF_PATH=
 cylc register "${SUITE_NAME}" "${SUITE_DIR}"
-cylc run --debug "${SUITE_NAME}"
+cylc run --debug "${SUITE_NAME}" 2>'/dev/null' \
+    || cat "${SUITE_DIR}/log/suite/err" >&2
 
 #-------------------------------------------------------------------------------
 
@@ -75,7 +76,7 @@ rose_ws_json_greps "${TEST_KEY}.out" "${TEST_KEY}.out" \
 
 TEST_KEY="${TEST_KEY_BASE}-200-curl-jobs-json"
 run_pass "${TEST_KEY}" \
-    curl "${TEST_ROSE_WS_URL}/jobs/${USER}/${SUITE_NAME}?form=json"
+    curl "${TEST_ROSE_WS_URL}/taskjobs/${USER}/${SUITE_NAME}?form=json"
 rose_ws_json_greps "${TEST_KEY}.out" "${TEST_KEY}.out" \
     "[('logo',), 'src=\"rose-favicon.png\" alt=\"Rose Logo\"']" \
     "[('title',), 'Humpty Dumpty']" \

--- a/t/rose-bush/02-no-job-out.t
+++ b/t/rose-bush/02-no-job-out.t
@@ -39,7 +39,8 @@ SUITE_NAME="$(basename "${SUITE_DIR}")"
 cp -pr "${TEST_SOURCE_DIR}/${TEST_KEY_BASE}/"* "${SUITE_DIR}"
 export CYLC_CONF_PATH=
 cylc register "${SUITE_NAME}" "${SUITE_DIR}"
-cylc run --debug "${SUITE_NAME}"
+cylc run --debug "${SUITE_NAME}" 2>'/dev/null' \
+    || cat "${SUITE_DIR}/log/suite/err" >&2
 
 # Remove the "job.out" entry from the suite's public database.
 sqlite3 "${SUITE_DIR}/cylc-suite.db" \
@@ -49,7 +50,7 @@ sqlite3 "${SUITE_DIR}/cylc-suite.db" \
 
 TEST_KEY="${TEST_KEY_BASE}-200-curl-jobs"
 run_pass "${TEST_KEY}" \
-    curl "${TEST_ROSE_WS_URL}/jobs/${USER}/${SUITE_NAME}?form=json"
+    curl "${TEST_ROSE_WS_URL}/taskjobs/${USER}/${SUITE_NAME}?form=json"
 FOO0="{'cycle': '20000101T0000Z', 'name': 'foo0', 'submit_num': 1}"
 FOO0_OUT='log/job/20000101T0000Z/foo0/01/job.out'
 FOO0_OUT_MTIME=$(stat -c'%Y' "${SUITE_DIR}/${FOO0_OUT}")

--- a/t/rose-bush/03-no-statuses.t
+++ b/t/rose-bush/03-no-statuses.t
@@ -48,9 +48,8 @@ run_pass "${TEST_KEY}" \
     curl "${TEST_ROSE_WS_URL}/jobs/${USER}/${SUITE_NAME}?form=json${FILTERS}"
 FOO="{'cycle': '20000101T0000Z', 'name': 'foo', 'submit_num': 1}"
 rose_ws_json_greps "${TEST_KEY}.out" "${TEST_KEY}.out" \
-    "[('no_statuses',), ['active', 'fail']]" \
     "[('of_n_entries',), 1]" \
-    "[('entries', ${FOO}, 'status'), 'success']"
+    "[('entries', ${FOO}, 'task_status'), 'succeeded']"
 
 #-------------------------------------------------------------------------------
 # Tidy up

--- a/t/rose-bush/04-time-sort.t
+++ b/t/rose-bush/04-time-sort.t
@@ -40,13 +40,14 @@ SUITE_NAME="$(basename "${SUITE_DIR}")"
 cp -pr "${TEST_SOURCE_DIR}/${TEST_KEY_BASE}/"* "${SUITE_DIR}"
 export CYLC_CONF_PATH=
 cylc register "${SUITE_NAME}" "${SUITE_DIR}"
-cylc run --debug "${SUITE_NAME}" 2>'/dev/null'
+cylc run --debug "${SUITE_NAME}" 2>'/dev/null' \
+    || cat "${SUITE_DIR}/log/suite/err" >&2
 
 #-------------------------------------------------------------------------------
 ORDER='time_submit'
 TEST_KEY="${TEST_KEY_BASE}-200-curl-jobs-${ORDER}"
 run_pass "${TEST_KEY}" curl \
-    "${TEST_ROSE_WS_URL}/jobs/${USER}/${SUITE_NAME}?form=json&order=${ORDER}"
+    "${TEST_ROSE_WS_URL}/taskjobs/${USER}/${SUITE_NAME}?form=json&order=${ORDER}"
 # Note: only qux submit time order is reliable, the others are submitted at the
 # same time, in any order.
 rose_ws_json_greps "${TEST_KEY}.out" "${TEST_KEY}.out" \
@@ -57,7 +58,7 @@ rose_ws_json_greps "${TEST_KEY}.out" "${TEST_KEY}.out" \
 ORDER='time_run_desc'
 TEST_KEY="${TEST_KEY_BASE}-200-curl-jobs-${ORDER}"
 run_pass "${TEST_KEY}" curl \
-    "${TEST_ROSE_WS_URL}/jobs/${USER}/${SUITE_NAME}?form=json&order=${ORDER}"
+    "${TEST_ROSE_WS_URL}/taskjobs/${USER}/${SUITE_NAME}?form=json&order=${ORDER}"
 rose_ws_json_greps "${TEST_KEY}.out" "${TEST_KEY}.out" \
     "[('order',), '${ORDER}']" \
     "[('entries', 0, 'name'), 'qux']" \
@@ -69,7 +70,7 @@ rose_ws_json_greps "${TEST_KEY}.out" "${TEST_KEY}.out" \
 ORDER='time_run_exit_desc'
 TEST_KEY="${TEST_KEY_BASE}-200-curl-jobs-${ORDER}"
 run_pass "${TEST_KEY}" curl \
-    "${TEST_ROSE_WS_URL}/jobs/${USER}/${SUITE_NAME}?form=json&order=${ORDER}"
+    "${TEST_ROSE_WS_URL}/taskjobs/${USER}/${SUITE_NAME}?form=json&order=${ORDER}"
 rose_ws_json_greps "${TEST_KEY}.out" "${TEST_KEY}.out" \
     "[('order',), '${ORDER}']" \
     "[('entries', 0, 'name'), 'qux']" \
@@ -81,7 +82,7 @@ rose_ws_json_greps "${TEST_KEY}.out" "${TEST_KEY}.out" \
 ORDER='duration_queue_desc'
 TEST_KEY="${TEST_KEY_BASE}-200-curl-jobs-${ORDER}"
 run_pass "${TEST_KEY}" curl \
-    "${TEST_ROSE_WS_URL}/jobs/${USER}/${SUITE_NAME}?form=json&order=${ORDER}"
+    "${TEST_ROSE_WS_URL}/taskjobs/${USER}/${SUITE_NAME}?form=json&order=${ORDER}"
 rose_ws_json_greps "${TEST_KEY}.out" "${TEST_KEY}.out" \
     "[('order',), '${ORDER}']" \
     "[('entries', 0, 'name'), 'bar']" \
@@ -93,7 +94,7 @@ rose_ws_json_greps "${TEST_KEY}.out" "${TEST_KEY}.out" \
 ORDER='duration_run_desc'
 TEST_KEY="${TEST_KEY_BASE}-200-curl-jobs-${ORDER}"
 run_pass "${TEST_KEY}" curl \
-    "${TEST_ROSE_WS_URL}/jobs/${USER}/${SUITE_NAME}?form=json&order=${ORDER}"
+    "${TEST_ROSE_WS_URL}/taskjobs/${USER}/${SUITE_NAME}?form=json&order=${ORDER}"
 rose_ws_json_greps "${TEST_KEY}.out" "${TEST_KEY}.out" \
     "[('order',), '${ORDER}']" \
     "[('entries', 0, 'name'), 'baz']" \
@@ -105,7 +106,7 @@ rose_ws_json_greps "${TEST_KEY}.out" "${TEST_KEY}.out" \
 ORDER='duration_queue_run_desc'
 TEST_KEY="${TEST_KEY_BASE}-200-curl-jobs-${ORDER}"
 run_pass "${TEST_KEY}" curl \
-    "${TEST_ROSE_WS_URL}/jobs/${USER}/${SUITE_NAME}?form=json&order=${ORDER}"
+    "${TEST_ROSE_WS_URL}/taskjobs/${USER}/${SUITE_NAME}?form=json&order=${ORDER}"
 rose_ws_json_greps "${TEST_KEY}.out" "${TEST_KEY}.out" \
     "[('order',), '${ORDER}']" \
     "[('entries', 0, 'name'), 'baz']" \

--- a/t/rose-bush/05-cycles-job-fails.t
+++ b/t/rose-bush/05-cycles-job-fails.t
@@ -39,7 +39,8 @@ SUITE_NAME="$(basename "${SUITE_DIR}")"
 cp -pr "${TEST_SOURCE_DIR}/${TEST_KEY_BASE}/"* "${SUITE_DIR}"
 export CYLC_CONF_PATH=
 cylc register "${SUITE_NAME}" "${SUITE_DIR}"
-cylc run --debug "${SUITE_NAME}" 2>'/dev/null'
+cylc run --debug "${SUITE_NAME}" 2>'/dev/null' \
+    || cat "${SUITE_DIR}/log/suite/err" >&2
 
 #-------------------------------------------------------------------------------
 TEST_KEY="${TEST_KEY_BASE}-200-curl-cycles"
@@ -47,7 +48,9 @@ run_pass "${TEST_KEY}" curl \
     "${TEST_ROSE_WS_URL}/cycles/${USER}/${SUITE_NAME}?form=json"
 rose_ws_json_greps "${TEST_KEY}.out" "${TEST_KEY}.out" \
     "[('entries', {'cycle': '20000101T0000Z'}, 'n_states', 'success',), 3]" \
-    "[('entries', {'cycle': '20000101T0000Z'}, 'n_states', 'job_fails',), 1]"
+    "[('entries', {'cycle': '20000101T0000Z'}, 'n_states', 'job_success',), 2]" \
+    "[('entries', {'cycle': '20000101T0000Z'}, 'n_states', 'fail',), 0]" \
+    "[('entries', {'cycle': '20000101T0000Z'}, 'n_states', 'job_fail',), 1]"
 #-------------------------------------------------------------------------------
 # Tidy up
 rose_ws_kill

--- a/t/rose-bush/06-host-port.t
+++ b/t/rose-bush/06-host-port.t
@@ -17,7 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with Rose. If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
-# Test for "rose bush", cycles/jobs list, suite server host:port.
+# Test for "rose bush", cycles/taskjobs list, suite server host:port.
 # Require a version of cylc with cylc/cylc#1705 merged in.
 #-------------------------------------------------------------------------------
 . "$(dirname "$0")/test_header"
@@ -77,7 +77,7 @@ fi
 #-------------------------------------------------------------------------------
 # Tidy up
 cylc stop "${SUITE_NAME}"
-wait "${SUITE_PID}"
+wait "${SUITE_PID}" || cat "${SUITE_DIR}/log/suite/err" >&2
 rose_ws_kill
 cylc unregister "${SUITE_NAME}" 1>'/dev/null' 2>&1
 rm -fr "${SUITE_DIR}" "${HOME}/.cylc/ports/${SUITE_NAME}" 2>'/dev/null'

--- a/t/rose-bush/07-cycles-page.t
+++ b/t/rose-bush/07-cycles-page.t
@@ -52,7 +52,8 @@ cat >"${SUITE_DIR}/suite.rc" <<'__SUITE_RC__'
 __SUITE_RC__
 export CYLC_CONF_PATH=
 cylc register "${SUITE_NAME}" "${SUITE_DIR}"
-cylc run --debug "${SUITE_NAME}" 2>'/dev/null'
+cylc run --debug "${SUITE_NAME}" 2>'/dev/null' \
+    || cat "${SUITE_DIR}/log/suite/err" >&2
 
 #-------------------------------------------------------------------------------
 # Sort by time_desc

--- a/t/rose-bush/08-suites-page.t
+++ b/t/rose-bush/08-suites-page.t
@@ -57,7 +57,8 @@ for SUFFIX in 'b' 'a' 'c'; do
     mkdir -p "${SUITE_DIR}"
     cp -p 'suite.rc' "${SUITE_DIR}/suite.rc"
     cylc register "${SUITE_NAME}" "${SUITE_DIR}"
-    cylc run --debug "${SUITE_NAME}" 2>'/dev/null'
+    cylc run --debug "${SUITE_NAME}" 2>'/dev/null' \
+        || cat "${SUITE_DIR}/log/suite/err" >&2
 done
 
 # Run another set of suites, for glob and paging tests
@@ -68,7 +69,8 @@ for SUFFIX in $(seq -w 1 10); do
     mkdir -p "${SUITE_DIR}"
     cp -p 'suite.rc' "${SUITE_DIR}/suite.rc"
     cylc register "${SUITE_NAME}" "${SUITE_DIR}"
-    cylc run --debug "${SUITE_NAME}" 2>'/dev/null'
+    cylc run --debug "${SUITE_NAME}" 2>'/dev/null' \
+        || cat "${SUITE_DIR}/log/suite/err" >&2
 done
 #-------------------------------------------------------------------------------
 # Batch 1, sort by time_desc

--- a/t/rose-bush/09-jobs-fuzzy-time.t
+++ b/t/rose-bush/09-jobs-fuzzy-time.t
@@ -54,7 +54,8 @@ SUITE_NAME="$(basename "${SUITE_DIR}")"
 cp -p 'suite.rc' "${SUITE_DIR}"
 export CYLC_CONF_PATH=
 cylc register "${SUITE_NAME}" "${SUITE_DIR}"
-cylc run --debug "${SUITE_NAME}" 2>'/dev/null'
+cylc run --debug "${SUITE_NAME}" 2>'/dev/null' \
+    || cat "${SUITE_DIR}/log/suite/err" >&2
 
 #-------------------------------------------------------------------------------
 TEST_KEY="${TEST_KEY_BASE}-200-curl-suites"
@@ -83,13 +84,13 @@ rose_ws_json_greps "${TEST_KEY}.out" "${TEST_KEY}.out" \
 #-------------------------------------------------------------------------------
 TEST_KEY="${TEST_KEY_BASE}-200-curl-jobs"
 run_pass "${TEST_KEY}" curl \
-    "${TEST_ROSE_WS_URL}/jobs/${USER}/${SUITE_NAME}?form=json"
+    "${TEST_ROSE_WS_URL}/taskjobs/${USER}/${SUITE_NAME}?form=json"
 rose_ws_json_greps "${TEST_KEY}.out" "${TEST_KEY}.out" \
     "[('no_fuzzy_time',), '0']"
 #-------------------------------------------------------------------------------
 TEST_KEY="${TEST_KEY_BASE}-200-curl-jobs-no-fuzzy-time"
 run_pass "${TEST_KEY}" curl \
-    "${TEST_ROSE_WS_URL}/jobs/${USER}/${SUITE_NAME}?form=json&no_fuzzy_time=1"
+    "${TEST_ROSE_WS_URL}/taskjobs/${USER}/${SUITE_NAME}?form=json&no_fuzzy_time=1"
 rose_ws_json_greps "${TEST_KEY}.out" "${TEST_KEY}.out" \
     "[('no_fuzzy_time',), '1']"
 #-------------------------------------------------------------------------------

--- a/t/rose-bush/10-jobs-task-status.t
+++ b/t/rose-bush/10-jobs-task-status.t
@@ -24,7 +24,7 @@ if ! python -c 'import cherrypy' 2>'/dev/null'; then
     skip_all '"cherrypy" not installed'
 fi
 
-tests 3
+tests 15
 
 ROSE_CONF_PATH= rose_ws_init 'rose' 'bush'
 if [[ -z "${TEST_ROSE_WS_PORT}" ]]; then
@@ -35,20 +35,34 @@ cat >'suite.rc' <<'__SUITE_RC__'
 #!Jinja2
 [cylc]
     UTC mode = True
-    abort if any task fails = True
+    [[events]]
+        abort on stalled = True
 [scheduling]
     initial cycle point = 2000
     final cycle point = 2000
     [[dependencies]]
         [[[P1Y]]]
-            graph = foo => bar
+            graph = foo & bar & baz
 [runtime]
     [[foo]]
         script = test "${CYLC_TASK_TRY_NUMBER}" -eq 3
-        retry delays = 3*P0Y
+        [[[job]]]
+            execution retry delays = 3*PT1S
     [[bar]]
         script = false
-        retry delays = 3*P0Y
+        [[[job]]]
+            execution retry delays = 3*PT1S
+    [[baz]]
+        env-script = """
+trap '' EXIT
+if ((${CYLC_TASK_SUBMIT_NUMBER} == 1)); then
+    exit
+fi
+"""
+        script = true
+        [[[job]]]
+            submission retry delays = 3*PT1S
+            submission polling intervals = 20*PT3S
 __SUITE_RC__
 
 #-------------------------------------------------------------------------------
@@ -60,30 +74,81 @@ cp -p 'suite.rc' "${SUITE_DIR}"
 export CYLC_CONF_PATH=
 cylc register "${SUITE_NAME}" "${SUITE_DIR}"
 cylc run --debug "${SUITE_NAME}" 2>'/dev/null'
-
+TASKJOBS_URL="${TEST_ROSE_WS_URL}/taskjobs/${USER}/${SUITE_NAME}?form=json"
 #-------------------------------------------------------------------------------
 TEST_KEY="${TEST_KEY_BASE}-200-curl-jobs"
-run_pass "${TEST_KEY}" curl \
-    "${TEST_ROSE_WS_URL}/jobs/${USER}/${SUITE_NAME}?form=json"
+run_pass "${TEST_KEY}" curl "${TASKJOBS_URL}"
 FOO1="{'cycle': '20000101T0000Z', 'name': 'foo', 'submit_num': 1}"
 FOO2="{'cycle': '20000101T0000Z', 'name': 'foo', 'submit_num': 2}"
 FOO3="{'cycle': '20000101T0000Z', 'name': 'foo', 'submit_num': 3}"
 BAR1="{'cycle': '20000101T0000Z', 'name': 'bar', 'submit_num': 1}"
 BAR2="{'cycle': '20000101T0000Z', 'name': 'bar', 'submit_num': 2}"
 BAR3="{'cycle': '20000101T0000Z', 'name': 'bar', 'submit_num': 3}"
+BAZ1="{'cycle': '20000101T0000Z', 'name': 'baz', 'submit_num': 1}"
+BAZ2="{'cycle': '20000101T0000Z', 'name': 'baz', 'submit_num': 2}"
 rose_ws_json_greps "${TEST_KEY}.out" "${TEST_KEY}.out" \
-    "[('entries', ${FOO1}, 'task_status',), 'success']" \
-    "[('entries', ${FOO1}, 'status',), 'fail(ERR)']" \
-    "[('entries', ${FOO2}, 'task_status',), 'success']" \
-    "[('entries', ${FOO2}, 'status',), 'fail(ERR)']" \
-    "[('entries', ${FOO3}, 'task_status',), 'success']" \
-    "[('entries', ${FOO3}, 'status',), 'success']" \
-    "[('entries', ${BAR1}, 'task_status',), 'fail']" \
-    "[('entries', ${BAR1}, 'status',), 'fail(ERR)']" \
-    "[('entries', ${BAR2}, 'task_status',), 'fail']" \
-    "[('entries', ${BAR2}, 'status',), 'fail(ERR)']" \
-    "[('entries', ${BAR3}, 'task_status',), 'fail']" \
-    "[('entries', ${BAR3}, 'status',), 'fail(ERR)']"
+    "[('of_n_entries',), 9]" \
+    "[('job_status',), None]" \
+    "[('entries', ${FOO1}, 'task_status',), 'succeeded']" \
+    "[('entries', ${FOO1}, 'run_status',), 1]" \
+    "[('entries', ${FOO1}, 'run_signal',), 'ERR']" \
+    "[('entries', ${FOO2}, 'task_status',), 'succeeded']" \
+    "[('entries', ${FOO2}, 'run_status',), 1]" \
+    "[('entries', ${FOO2}, 'run_signal',), 'ERR']" \
+    "[('entries', ${FOO3}, 'task_status',), 'succeeded']" \
+    "[('entries', ${FOO3}, 'run_status',), 0]" \
+    "[('entries', ${BAR1}, 'task_status',), 'failed']" \
+    "[('entries', ${BAR1}, 'run_status',), 1]" \
+    "[('entries', ${BAR1}, 'run_signal',), 'ERR']" \
+    "[('entries', ${BAR2}, 'task_status',), 'failed']" \
+    "[('entries', ${BAR2}, 'run_status',), 1]" \
+    "[('entries', ${BAR2}, 'run_signal',), 'ERR']" \
+    "[('entries', ${BAR3}, 'task_status',), 'failed']" \
+    "[('entries', ${BAR3}, 'run_status',), 1]" \
+    "[('entries', ${BAR3}, 'run_signal',), 'ERR']" \
+    "[('entries', ${BAZ1}, 'task_status',), 'succeeded']" \
+    "[('entries', ${BAZ1}, 'submit_status',), 1]" \
+    "[('entries', ${BAZ1}, 'run_status',), None]" \
+    "[('entries', ${BAZ1}, 'run_signal',), None]" \
+    "[('entries', ${BAZ2}, 'task_status',), 'succeeded']" \
+    "[('entries', ${BAZ2}, 'submit_status',), 0]" \
+    "[('entries', ${BAZ2}, 'run_status',), 0]" \
+    "[('entries', ${BAZ2}, 'run_signal',), None]"
+
+#-------------------------------------------------------------------------------
+TEST_KEY="${TEST_KEY_BASE}-200-curl-jobs-failed"
+run_pass "${TEST_KEY}" curl "${TASKJOBS_URL}&job_status=failed"
+rose_ws_json_greps "${TEST_KEY}.out" "${TEST_KEY}.out" \
+    "[('job_status',), 'failed']" \
+    "[('of_n_entries',), 6]"
+#-------------------------------------------------------------------------------
+TEST_KEY="${TEST_KEY_BASE}-200-curl-jobs-submission-failed-and-failed"
+run_pass "${TEST_KEY}" curl "${TASKJOBS_URL}&job_status=submission-failed,failed"
+rose_ws_json_greps "${TEST_KEY}.out" "${TEST_KEY}.out" \
+    "[('job_status',), 'submission-failed,failed']" \
+    "[('of_n_entries',), 7]"
+#-------------------------------------------------------------------------------
+TEST_KEY="${TEST_KEY_BASE}-200-curl-jobs-succeeded"
+run_pass "${TEST_KEY}" curl "${TASKJOBS_URL}&job_status=succeeded"
+rose_ws_json_greps "${TEST_KEY}.out" "${TEST_KEY}.out" \
+    "[('job_status',), 'succeeded']" \
+    "[('of_n_entries',), 2]"
+#-------------------------------------------------------------------------------
+TEST_KEY="${TEST_KEY_BASE}-200-curl-jobs-succeeded-failed"
+run_pass "${TEST_KEY}" curl "${TASKJOBS_URL}&job_status=succeeded,failed"
+rose_ws_json_greps "${TEST_KEY}.out" "${TEST_KEY}.out" \
+    "[('job_status',), 'succeeded,failed']" \
+    "[('of_n_entries',), 8]"
+#-------------------------------------------------------------------------------
+TEST_KEY="${TEST_KEY_BASE}-200-curl-task-succeeded"
+run_pass "${TEST_KEY}" curl "${TASKJOBS_URL}&task_status=succeeded"
+rose_ws_json_greps "${TEST_KEY}.out" "${TEST_KEY}.out" \
+    "[('of_n_entries',), 5]"
+#-------------------------------------------------------------------------------
+TEST_KEY="${TEST_KEY_BASE}-200-curl-task-succeeded-job-failed"
+run_pass "${TEST_KEY}" curl "${TASKJOBS_URL}&task_status=succeeded&job_status=failed"
+rose_ws_json_greps "${TEST_KEY}.out" "${TEST_KEY}.out" \
+    "[('of_n_entries',), 2]"
 #-------------------------------------------------------------------------------
 # Tidy up
 rose_ws_kill

--- a/t/rose-bush/11-view-unicode.t
+++ b/t/rose-bush/11-view-unicode.t
@@ -61,7 +61,8 @@ SUITE_NAME="$(basename "${SUITE_DIR}")"
 cp -pr 'bin' 'suite.rc' "${SUITE_DIR}"
 export CYLC_CONF_PATH=
 cylc register "${SUITE_NAME}" "${SUITE_DIR}"
-cylc run --debug "${SUITE_NAME}" 2>'/dev/null'
+cylc run --debug "${SUITE_NAME}" 2>'/dev/null' \
+    || cat "${SUITE_DIR}/log/suite/err" >&2
 #-------------------------------------------------------------------------------
 LOG_FILE='log/job/20000101T0000Z/echo-euro/01/job.txt'
 

--- a/t/rose-bush/12-cycle-counts.t
+++ b/t/rose-bush/12-cycle-counts.t
@@ -56,7 +56,8 @@ final cycle point = 20100101T0000Z
 __SUITE_RC__
 export CYLC_CONF_PATH=
 cylc register "${SUITE_NAME}" "${SUITE_DIR}"
-cylc run --debug "${SUITE_NAME}" 2>'/dev/null'
+cylc run --debug "${SUITE_NAME}" 2>'/dev/null' \
+    || cat "${SUITE_DIR}/log/suite/err" >&2
 
 #-------------------------------------------------------------------------------
 # Sort by time_desc

--- a/t/rose-suite-log/00-update-task.t
+++ b/t/rose-suite-log/00-update-task.t
@@ -29,7 +29,7 @@ if [[ $TEST_KEY_BASE == *-remote* ]]; then
     JOB_HOST=$(rose host-select -q $JOB_HOST)
 fi
 #-------------------------------------------------------------------------------
-tests 6
+tests 4
 #-------------------------------------------------------------------------------
 # Run the suite.
 export CYLC_CONF_PATH=
@@ -46,15 +46,6 @@ else
         --no-gcontrol --host=localhost -- --debug
 fi
 #-------------------------------------------------------------------------------
-TEST_KEY="$TEST_KEY_BASE-db-before"
-sqlite3 "$HOME/cylc-run/$NAME/log/rose-job-logs.db" \
-    'SELECT path,key FROM log_files ORDER BY path ASC;' >"$TEST_KEY.out"
-file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<'__OUT__'
-log/job/1/my_task_1/01/job|job
-log/job/1/my_task_1/01/job-activity.log|job-activity.log
-log/job/1/my_task_1/01/job.err|job.err
-log/job/1/my_task_1/01/job.out|job.out
-__OUT__
 TEST_KEY=$TEST_KEY_BASE-before-log.out
 if [[ -n ${JOB_HOST:-} ]]; then
     run_fail "$TEST_KEY-log.out" \
@@ -66,19 +57,6 @@ TEST_KEY=$TEST_KEY_BASE-command
 run_pass "$TEST_KEY" rose suite-log -n $NAME -U 'my_task_2' --debug
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
 file_test "$TEST_KEY-log.out" $SUITE_RUN_DIR/log/job/1/my_task_2/01/job.out
-TEST_KEY="$TEST_KEY_BASE-db-after"
-sqlite3 "$HOME/cylc-run/$NAME/log/rose-job-logs.db" \
-    'SELECT path,key FROM log_files ORDER BY path ASC;' >"$TEST_KEY.out"
-file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<'__OUT__'
-log/job/1/my_task_1/01/job|job
-log/job/1/my_task_1/01/job-activity.log|job-activity.log
-log/job/1/my_task_1/01/job.err|job.err
-log/job/1/my_task_1/01/job.out|job.out
-log/job/1/my_task_2/01/job|job
-log/job/1/my_task_2/01/job-activity.log|job-activity.log
-log/job/1/my_task_2/01/job.err|job.err
-log/job/1/my_task_2/01/job.out|job.out
-__OUT__
 #-------------------------------------------------------------------------------
 rose suite-clean -q -y $NAME
 exit 0

--- a/t/rose-suite-log/01-update-cycle.t
+++ b/t/rose-suite-log/01-update-cycle.t
@@ -31,7 +31,7 @@ if [[ $TEST_KEY_BASE == *-remote* ]]; then
     JOB_HOST=$(rose host-select -q $JOB_HOST)
 fi
 #-------------------------------------------------------------------------------
-tests 17
+tests 14
 #-------------------------------------------------------------------------------
 # Run the suite.
 export CYLC_CONF_PATH=
@@ -60,23 +60,6 @@ if [[ -n ${JOB_HOST:-} ]]; then
         test -f cylc-run/$NAME/log/job/$CYCLE/my_task_2/01/job.out
     ! test -f $SUITE_RUN_DIR/log/job/$CYCLE/my_task_2/01/job.out
 fi
-sqlite3 "$HOME/cylc-run/$NAME/log/rose-job-logs.db" \
-    'SELECT path,path_in_tar,key FROM log_files ORDER BY path,path_in_tar ASC;' \
-    >"$TEST_KEY-db-1.out"
-file_cmp "$TEST_KEY-db-1.out" "$TEST_KEY-db-1.out" <<'__OUT__'
-log/job/20130101T0000Z/my_task_1/01/job||job
-log/job/20130101T0000Z/my_task_1/01/job-activity.log||job-activity.log
-log/job/20130101T0000Z/my_task_1/01/job.err||job.err
-log/job/20130101T0000Z/my_task_1/01/job.out||job.out
-log/job/20130101T1200Z/my_task_1/01/job||job
-log/job/20130101T1200Z/my_task_1/01/job-activity.log||job-activity.log
-log/job/20130101T1200Z/my_task_1/01/job.err||job.err
-log/job/20130101T1200Z/my_task_1/01/job.out||job.out
-log/job/20130102T0000Z/my_task_1/01/job||job
-log/job/20130102T0000Z/my_task_1/01/job-activity.log||job-activity.log
-log/job/20130102T0000Z/my_task_1/01/job.err||job.err
-log/job/20130102T0000Z/my_task_1/01/job.out||job.out
-__OUT__
 # N_JOB_LOGS should be 4, my_task_1 script, err, out and my_task_2 script
 N_JOB_LOGS=$(wc -l "$TEST_KEY-list-job-logs-before.out" | cut -d' ' -f1)
 run_pass "$TEST_KEY-command" rose suite-log -n $NAME --archive $CYCLE --debug
@@ -96,27 +79,6 @@ run_pass "$TEST_KEY-after-log.out" \
 N_JOB_LOGS_ARCH=$(echo "$JOB_LOGS_ARCH" | wc -l | cut -d' ' -f1)
 run_pass "$TEST_KEY-n-arch" test "${N_JOB_LOGS}" -eq "${N_JOB_LOGS_ARCH}"
 file_cmp "$TEST_KEY-command.err" "$TEST_KEY-command.err" </dev/null
-sqlite3 "$HOME/cylc-run/$NAME/log/rose-job-logs.db" \
-    'SELECT path,path_in_tar,key FROM log_files ORDER BY path,path_in_tar ASC;' \
-    >"$TEST_KEY-db-2.out"
-file_cmp "$TEST_KEY-db-2.out" "$TEST_KEY-db-2.out" <<'__OUT__'
-log/job-20130101T0000Z.tar.gz|job/20130101T0000Z/my_task_1/01/job|job
-log/job-20130101T0000Z.tar.gz|job/20130101T0000Z/my_task_1/01/job-activity.log|job-activity.log
-log/job-20130101T0000Z.tar.gz|job/20130101T0000Z/my_task_1/01/job.err|job.err
-log/job-20130101T0000Z.tar.gz|job/20130101T0000Z/my_task_1/01/job.out|job.out
-log/job-20130101T0000Z.tar.gz|job/20130101T0000Z/my_task_2/01/job|job
-log/job-20130101T0000Z.tar.gz|job/20130101T0000Z/my_task_2/01/job-activity.log|job-activity.log
-log/job-20130101T0000Z.tar.gz|job/20130101T0000Z/my_task_2/01/job.err|job.err
-log/job-20130101T0000Z.tar.gz|job/20130101T0000Z/my_task_2/01/job.out|job.out
-log/job/20130101T1200Z/my_task_1/01/job||job
-log/job/20130101T1200Z/my_task_1/01/job-activity.log||job-activity.log
-log/job/20130101T1200Z/my_task_1/01/job.err||job.err
-log/job/20130101T1200Z/my_task_1/01/job.out||job.out
-log/job/20130102T0000Z/my_task_1/01/job||job
-log/job/20130102T0000Z/my_task_1/01/job-activity.log||job-activity.log
-log/job/20130102T0000Z/my_task_1/01/job.err||job.err
-log/job/20130102T0000Z/my_task_1/01/job.out||job.out
-__OUT__
 #-------------------------------------------------------------------------------
 # Test --update.
 for CYCLE in 20130101T1200Z 20130102T0000Z; do
@@ -126,35 +88,6 @@ for CYCLE in 20130101T1200Z 20130102T0000Z; do
     file_test "$TEST_KEY-after-log.out" \
         $SUITE_RUN_DIR/log/job/$CYCLE/my_task_2/01/job.out
 done
-sqlite3 "$HOME/cylc-run/$NAME/log/rose-job-logs.db" \
-    'SELECT path,path_in_tar,key FROM log_files ORDER BY path,path_in_tar ASC;' \
-    >"$TEST_KEY_BASE-db-final.out"
-file_cmp "$TEST_KEY_BASE-db-final.out" "$TEST_KEY_BASE-db-final.out" <<'__OUT__'
-log/job-20130101T0000Z.tar.gz|job/20130101T0000Z/my_task_1/01/job|job
-log/job-20130101T0000Z.tar.gz|job/20130101T0000Z/my_task_1/01/job-activity.log|job-activity.log
-log/job-20130101T0000Z.tar.gz|job/20130101T0000Z/my_task_1/01/job.err|job.err
-log/job-20130101T0000Z.tar.gz|job/20130101T0000Z/my_task_1/01/job.out|job.out
-log/job-20130101T0000Z.tar.gz|job/20130101T0000Z/my_task_2/01/job|job
-log/job-20130101T0000Z.tar.gz|job/20130101T0000Z/my_task_2/01/job-activity.log|job-activity.log
-log/job-20130101T0000Z.tar.gz|job/20130101T0000Z/my_task_2/01/job.err|job.err
-log/job-20130101T0000Z.tar.gz|job/20130101T0000Z/my_task_2/01/job.out|job.out
-log/job/20130101T1200Z/my_task_1/01/job||job
-log/job/20130101T1200Z/my_task_1/01/job-activity.log||job-activity.log
-log/job/20130101T1200Z/my_task_1/01/job.err||job.err
-log/job/20130101T1200Z/my_task_1/01/job.out||job.out
-log/job/20130101T1200Z/my_task_2/01/job||job
-log/job/20130101T1200Z/my_task_2/01/job-activity.log||job-activity.log
-log/job/20130101T1200Z/my_task_2/01/job.err||job.err
-log/job/20130101T1200Z/my_task_2/01/job.out||job.out
-log/job/20130102T0000Z/my_task_1/01/job||job
-log/job/20130102T0000Z/my_task_1/01/job-activity.log||job-activity.log
-log/job/20130102T0000Z/my_task_1/01/job.err||job.err
-log/job/20130102T0000Z/my_task_1/01/job.out||job.out
-log/job/20130102T0000Z/my_task_2/01/job||job
-log/job/20130102T0000Z/my_task_2/01/job-activity.log||job-activity.log
-log/job/20130102T0000Z/my_task_2/01/job.err||job.err
-log/job/20130102T0000Z/my_task_2/01/job.out||job.out
-__OUT__
 #-------------------------------------------------------------------------------
 rose suite-clean -q -y $NAME
 exit 0

--- a/t/rose-suite-log/02-update-force.t
+++ b/t/rose-suite-log/02-update-force.t
@@ -31,7 +31,7 @@ if [[ $TEST_KEY_BASE == *-remote* ]]; then
     JOB_HOST=$(rose host-select -q $JOB_HOST)
 fi
 #-------------------------------------------------------------------------------
-tests 17
+tests 15
 #-------------------------------------------------------------------------------
 # Run the suite.
 export ROSE_CONF_PATH=
@@ -56,10 +56,6 @@ for CYCLE in $CYCLES; do
     run_fail "$TEST_KEY" \
         test -f "$HOME/cylc-run/$NAME/log/rose-suite-log-$CYCLE.json"
 done
-TEST_KEY="$TEST_KEY_BASE-db-before"
-sqlite3 "$HOME/cylc-run/$NAME/log/rose-job-logs.db" \
-    'SELECT path,key FROM log_files ORDER BY path ASC;' >"$TEST_KEY.out"
-file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
 TEST_KEY="$TEST_KEY_BASE-command"
 run_pass "$TEST_KEY" rose suite-log -n $NAME -f --debug
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
@@ -70,35 +66,6 @@ for CYCLE in $CYCLES; do
     file_test "$TEST_KEY-after-log-2.out" \
         $SUITE_RUN_DIR/log/job/$CYCLE/my_task_2/01/job.out
 done
-TEST_KEY="$TEST_KEY_BASE-db-after"
-sqlite3 "$HOME/cylc-run/$NAME/log/rose-job-logs.db" \
-    'SELECT path,key FROM log_files ORDER BY path ASC;' >"$TEST_KEY.out"
-file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<'__OUT__'
-log/job/20130101T0000Z/my_task_1/01/job|job
-log/job/20130101T0000Z/my_task_1/01/job-activity.log|job-activity.log
-log/job/20130101T0000Z/my_task_1/01/job.err|job.err
-log/job/20130101T0000Z/my_task_1/01/job.out|job.out
-log/job/20130101T0000Z/my_task_2/01/job|job
-log/job/20130101T0000Z/my_task_2/01/job-activity.log|job-activity.log
-log/job/20130101T0000Z/my_task_2/01/job.err|job.err
-log/job/20130101T0000Z/my_task_2/01/job.out|job.out
-log/job/20130101T1200Z/my_task_1/01/job|job
-log/job/20130101T1200Z/my_task_1/01/job-activity.log|job-activity.log
-log/job/20130101T1200Z/my_task_1/01/job.err|job.err
-log/job/20130101T1200Z/my_task_1/01/job.out|job.out
-log/job/20130101T1200Z/my_task_2/01/job|job
-log/job/20130101T1200Z/my_task_2/01/job-activity.log|job-activity.log
-log/job/20130101T1200Z/my_task_2/01/job.err|job.err
-log/job/20130101T1200Z/my_task_2/01/job.out|job.out
-log/job/20130102T0000Z/my_task_1/01/job|job
-log/job/20130102T0000Z/my_task_1/01/job-activity.log|job-activity.log
-log/job/20130102T0000Z/my_task_1/01/job.err|job.err
-log/job/20130102T0000Z/my_task_1/01/job.out|job.out
-log/job/20130102T0000Z/my_task_2/01/job|job
-log/job/20130102T0000Z/my_task_2/01/job-activity.log|job-activity.log
-log/job/20130102T0000Z/my_task_2/01/job.err|job.err
-log/job/20130102T0000Z/my_task_2/01/job.out|job.out
-__OUT__
 #-------------------------------------------------------------------------------
 # Test --prune-remote.
 TEST_KEY="$TEST_KEY_BASE-prune-remote"

--- a/t/rose-suite-log/06-archive-star.t
+++ b/t/rose-suite-log/06-archive-star.t
@@ -29,7 +29,7 @@ if [[ $TEST_KEY_BASE == *-remote* ]]; then
     JOB_HOST=$(rose host-select -q $JOB_HOST)
 fi
 #-------------------------------------------------------------------------------
-tests 14
+tests 12
 #-------------------------------------------------------------------------------
 # Run the suite.
 export ROSE_CONF_PATH=
@@ -60,23 +60,6 @@ if [[ -n ${JOB_HOST:-} ]]; then
 fi
 set +e
 
-sqlite3 "$HOME/cylc-run/$NAME/log/rose-job-logs.db" \
-    'SELECT path,path_in_tar,key FROM log_files ORDER BY path,path_in_tar ASC;' \
-    >"$TEST_KEY-db-1.out"
-file_cmp "$TEST_KEY-db-1.out" "$TEST_KEY-db-1.out" <<'__OUT__'
-log/job/20130101T0000Z/my_task_1/01/job||job
-log/job/20130101T0000Z/my_task_1/01/job-activity.log||job-activity.log
-log/job/20130101T0000Z/my_task_1/01/job.err||job.err
-log/job/20130101T0000Z/my_task_1/01/job.out||job.out
-log/job/20130101T1200Z/my_task_1/01/job||job
-log/job/20130101T1200Z/my_task_1/01/job-activity.log||job-activity.log
-log/job/20130101T1200Z/my_task_1/01/job.err||job.err
-log/job/20130101T1200Z/my_task_1/01/job.out||job.out
-log/job/20130102T0000Z/my_task_1/01/job||job
-log/job/20130102T0000Z/my_task_1/01/job-activity.log||job-activity.log
-log/job/20130102T0000Z/my_task_1/01/job.err||job.err
-log/job/20130102T0000Z/my_task_1/01/job.out||job.out
-__OUT__
 N_JOB_LOGS=$(wc -l "$TEST_KEY-list-job-logs-before.out" | cut -d' ' -f1)
 run_pass "$TEST_KEY-command" rose suite-log -n $NAME --archive '*' --debug
 run_fail "$TEST_KEY-list-job-logs-after" ls $SUITE_RUN_DIR/log/job/*
@@ -109,35 +92,6 @@ N_JOB_LOGS_ARCH=$(echo "$ALL_JOB_LOGS_ARCH" | wc -l | cut -d' ' -f1)
 run_pass "$TEST_KEY-n-arch" test "${N_JOB_LOGS}" -eq "${N_JOB_LOGS_ARCH}"
 
 file_cmp "$TEST_KEY-command.err" "$TEST_KEY-command.err" </dev/null
-sqlite3 "$HOME/cylc-run/$NAME/log/rose-job-logs.db" \
-    'SELECT path,path_in_tar,key FROM log_files ORDER BY path,path_in_tar ASC;' \
-    >"$TEST_KEY-db-2.out"
-file_cmp "$TEST_KEY-db-2.out" "$TEST_KEY-db-2.out" <<'__OUT__'
-log/job-20130101T0000Z.tar.gz|job/20130101T0000Z/my_task_1/01/job|job
-log/job-20130101T0000Z.tar.gz|job/20130101T0000Z/my_task_1/01/job-activity.log|job-activity.log
-log/job-20130101T0000Z.tar.gz|job/20130101T0000Z/my_task_1/01/job.err|job.err
-log/job-20130101T0000Z.tar.gz|job/20130101T0000Z/my_task_1/01/job.out|job.out
-log/job-20130101T0000Z.tar.gz|job/20130101T0000Z/my_task_2/01/job|job
-log/job-20130101T0000Z.tar.gz|job/20130101T0000Z/my_task_2/01/job-activity.log|job-activity.log
-log/job-20130101T0000Z.tar.gz|job/20130101T0000Z/my_task_2/01/job.err|job.err
-log/job-20130101T0000Z.tar.gz|job/20130101T0000Z/my_task_2/01/job.out|job.out
-log/job-20130101T1200Z.tar.gz|job/20130101T1200Z/my_task_1/01/job|job
-log/job-20130101T1200Z.tar.gz|job/20130101T1200Z/my_task_1/01/job-activity.log|job-activity.log
-log/job-20130101T1200Z.tar.gz|job/20130101T1200Z/my_task_1/01/job.err|job.err
-log/job-20130101T1200Z.tar.gz|job/20130101T1200Z/my_task_1/01/job.out|job.out
-log/job-20130101T1200Z.tar.gz|job/20130101T1200Z/my_task_2/01/job|job
-log/job-20130101T1200Z.tar.gz|job/20130101T1200Z/my_task_2/01/job-activity.log|job-activity.log
-log/job-20130101T1200Z.tar.gz|job/20130101T1200Z/my_task_2/01/job.err|job.err
-log/job-20130101T1200Z.tar.gz|job/20130101T1200Z/my_task_2/01/job.out|job.out
-log/job-20130102T0000Z.tar.gz|job/20130102T0000Z/my_task_1/01/job|job
-log/job-20130102T0000Z.tar.gz|job/20130102T0000Z/my_task_1/01/job-activity.log|job-activity.log
-log/job-20130102T0000Z.tar.gz|job/20130102T0000Z/my_task_1/01/job.err|job.err
-log/job-20130102T0000Z.tar.gz|job/20130102T0000Z/my_task_1/01/job.out|job.out
-log/job-20130102T0000Z.tar.gz|job/20130102T0000Z/my_task_2/01/job|job
-log/job-20130102T0000Z.tar.gz|job/20130102T0000Z/my_task_2/01/job-activity.log|job-activity.log
-log/job-20130102T0000Z.tar.gz|job/20130102T0000Z/my_task_2/01/job.err|job.err
-log/job-20130102T0000Z.tar.gz|job/20130102T0000Z/my_task_2/01/job.out|job.out
-__OUT__
 #-------------------------------------------------------------------------------
 rose suite-clean -q -y $NAME
 exit 0


### PR DESCRIPTION
Cycles list now displays number of tasks and jobs.

Cycles list now provides download links to those cycles with a `log/job-CYCLE.tar.gz`.

Jobs list can now be filtered by job status combinations and individual
cylc task statuses.

Job list `cycles` filter can now use syntax such as `<CYCLE` (currently `before CYCLE`), `>CYCLE` (currently `after CYCLE`).

Improve display for screens with smaller width.

Rose Bush related logic from `rose.suite_engine_procs.cylc` is moved to
`rose.bush_dao`.
- 1st step towards decoupling Rose Bush from the rest of Rose. (cylc/cylc#1052)
- Remove rose job logs DB logic.

Close #918. Close #1873.
