### PR TITLE
rose.ws: ad hoc server: allow service name in URL

### DIFF
--- a/bin/rose-bush
+++ b/bin/rose-bush
@@ -23,6 +23,7 @@
 # SYNOPSIS
 #     rose bush start [PORT] # start ad-hoc web service server (on PORT)
 #     rose bush stop         # stop ad-hoc web service server
+#     rose bush stop -y      # stop ad-hoc web service server w/o prompting
 #     rose bush              # print status of ad-hoc web service server
 #
 # DESCRIPTION
@@ -32,5 +33,12 @@
 #
 #     Rose Bush is a web service for browsing users' Rose suite logs via an
 #     HTTP interface.
+#
+# OPTIONS
+#     --non-interactive, --yes, -y
+#         (For stop only.) Switch off interactive prompting (=answer yes to
+#         everything)
+#     --service-root, -R
+#         (For start only.) Include web service name under root of URL.
 #-------------------------------------------------------------------------------
 exec python -m rose.bush "$@"

--- a/bin/rosie-disco
+++ b/bin/rosie-disco
@@ -21,13 +21,21 @@
 #     rosie disco
 #
 # SYNOPSIS
-#     rosie disco
 #     rosie disco start [PORT] # start ad-hoc web service server (on PORT)
 #     rosie disco stop         # stop ad-hoc web service server
+#     rosie disco stop -y      # stop ad-hoc web service server w/o prompting
+#     rosie disco              # print status of ad-hoc web service server
 #
 # DESCRIPTION
 #     Start/stop ad-hoc Rosie suite discovery web service server.
 #
 #     For "rosie disco start", if PORT is not specified, use port 8080.
+#
+# OPTIONS
+#     --non-interactive, --yes, -y
+#         (For stop only.) Switch off interactive prompting (=answer yes to
+#         everything)
+#     --service-root, -R
+#         (For start only.) Include web service name under root of URL.
 #-------------------------------------------------------------------------------
 exec python -m rosie.ws "$@"

--- a/doc/rose-command.html
+++ b/doc/rose-command.html
@@ -593,6 +593,10 @@ rosie UTIL [OPTS] [ARG ...]
 
               <dd>Stop ad-hoc web service server</dd>
 
+              <dt><kbd>rose bush stop -y</kbd></dt>
+
+              <dd>Stop ad-hoc web service server without prompting</dd>
+
               <dt><kbd>rose bush</kbd></dt>
 
               <dd>Print status of ad-hoc web service server</dd>
@@ -607,6 +611,20 @@ rosie UTIL [OPTS] [ARG ...]
 
             <p>Rose Bush is a web service for browsing users' Rose
             suite logs via an HTTP interface.</p>
+
+            <h3>OPTIONS</h3>
+
+            <dl>
+              <dt><kbd>--non-interactive, --yes, -y</kbd></dt>
+
+              <dd>(For stop only.) Switch off interactive prompting (=answer yes
+              to everything).</dd>
+
+              <dt><kbd>--service-root, -R</kbd></dt>
+
+              <dd>(For start only.) Include web service name under root of
+              URL.</dd>
+            </dl>
 
             <h2 id="rose-config">rose config</h2>
 
@@ -3434,6 +3452,10 @@ rose test-battery -v t/rose-app-run/07-opt.t
 
               <dd>Stop ad-hoc web service server</dd>
 
+              <dt><kbd>rosie disco stop -y</kbd></dt>
+
+              <dd>Stop ad-hoc web service server without prompting</dd>
+
               <dt><kbd>rosie disco</kbd></dt>
 
               <dd>Print status of ad-hoc web service server</dd>
@@ -3446,6 +3468,20 @@ rose test-battery -v t/rose-app-run/07-opt.t
 
             <p>For <code>rosie disco start</code>, if
             <var>PORT</var> is not specified, use port 8080.</p>
+
+            <h3>OPTIONS</h3>
+
+            <dl>
+              <dt><kbd>--non-interactive, --yes, -y</kbd></dt>
+
+              <dd>(For stop only.) Switch off interactive prompting (=answer yes
+              to everything).</dd>
+
+              <dt><kbd>--service-root, -R</kbd></dt>
+
+              <dd>(For start only.) Include web service name under root of
+              URL.</dd>
+            </dl>
 
             <h2 id="rosie-go">rosie go</h2>
 

--- a/lib/python/rose/opt_parse.py
+++ b/lib/python/rose/opt_parse.py
@@ -556,6 +556,12 @@ class RoseOptionParser(OptionParser):
              "const": "search",
              "dest": "lookup_mode",
              "help": "Shorthand for --lookup-mode=search."}],
+        "service_root_mode": [
+            ["--service-root", "-R"],
+            {"action": "store_true",
+             "default": False,
+             "dest": "service_root_mode",
+             "help": "Include web service name under root of URL."}],
         "shutdown": [
             ["--shutdown"],
             {"action": "store_true",

--- a/t/lib/bash/test_header
+++ b/t/lib/bash/test_header
@@ -350,7 +350,7 @@ rose_ws_init() {
     done
 
     TEST_KEY="${TEST_KEY_BASE}-${NS}-${UTIL}"
-    "${NS}" "${UTIL}" 'start' "${PORT}" \
+    "${NS}" "${UTIL}" '-R' 'start' "${PORT}" \
         0<'/dev/null' 1>"${NS}-${UTIL}.out" 2>"${NS}-${UTIL}.err" &
     TEST_ROSE_WS_PID="$!"
     T_INIT="$(date '+%s')"
@@ -360,7 +360,7 @@ rose_ws_init() {
     TEST_ROSE_WS_PORT="${PORT}"
     if port_is_busy "${TEST_ROSE_WS_PORT}"; then
         pass "${TEST_KEY}"
-        TEST_ROSE_WS_URL="http://${HOSTNAME}:${TEST_ROSE_WS_PORT}/"
+        TEST_ROSE_WS_URL="http://${HOSTNAME}:${TEST_ROSE_WS_PORT}/${NS}-${UTIL}/"
     else
         fail "${TEST_KEY}"
         rose_ws_kill


### PR DESCRIPTION
With the new `--service-root` option, the URL of the ad hoc web service
will become e.g. `http://localhost:8080/rose-bush/`. This allows the
ad hoc server to be more similar to their WSGI counterparts.