### PR TITLE
rose_prune: fix bad fail message on non-suite host

### DIFF
--- a/lib/python/rose/suite_engine_procs/cylc.py
+++ b/lib/python/rose/suite_engine_procs/cylc.py
@@ -1595,7 +1595,7 @@ class CylcProcessor(SuiteEngineProcessor):
         cursor = self._db_exec(
             db_name, user_name, suite_name,
             "SELECT name FROM sqlite_master WHERE name==?", [table_name])
-        return cursor.fetchone() is not None
+        return (cursor and cursor.fetchone() is not None)
 
     def _db_init(self, db_name, user_name, suite_name):
         """Initialise a named database connection."""


### PR DESCRIPTION
rose_prune attempts to connect to the cylc suite run time database to
get a list of job hosts. If rose_prune was being invoked on non-suite
host, it would return a rather cryptic fail message. This change should
fix the issue.