### PR TITLE
rose macro: added suite-only option

### DIFF
--- a/bin/rose-macro
+++ b/bin/rose-macro
@@ -48,6 +48,8 @@
 #         there is at least one transformer in the argument list.
 #     --quiet, -q
 #         Reduce verbosity.
+#     --suite-only
+#         Run only for suite level macros.
 #     --validate, -V
 #         Prepend all validators to the argument list.
 #

--- a/doc/rose-command.html
+++ b/doc/rose-command.html
@@ -1663,6 +1663,10 @@ rose date --as-total=s PT1H
 
               <dd>Reduce verbosity.</dd>
 
+              <dt><kbd>--suite-only</kbd></dt>
+
+              <dd>Run only for suite level macros.</dd>
+
               <dt><kbd>--validate, -V</kbd></dt>
 
               <dd>Prepend all validators to the argument list.</dd>

--- a/lib/python/rose/opt_parse.py
+++ b/lib/python/rose/opt_parse.py
@@ -586,6 +586,12 @@ class RoseOptionParser(OptionParser):
             ["--suffix-delim"],
             {"metavar": "DELIMITER",
              "help": "Specify the suffix delimiter."}],
+        "suite_only": [
+            ["--suite-only"],
+            {"action": "store_true",
+             "dest": "suite_only",
+             "default": False,
+             "help": "Run only for suite level macros."}],
         "task": [
             ["--task", "-t"],
             {"action": "append",

--- a/t/rose-macro/00-null.t
+++ b/t/rose-macro/00-null.t
@@ -23,7 +23,7 @@
 init </dev/null
 rm config/rose-app.conf
 #-------------------------------------------------------------------------------
-tests 38
+tests 40
 #-------------------------------------------------------------------------------
 # Normal mode.
 TEST_KEY=$TEST_KEY_BASE-base
@@ -221,6 +221,18 @@ file_cmp "$TEST_KEY.err" "$TEST_KEY.err" <<'__ERR__'
     env=SUITE=sweet
         Not an integer: 'sweet'
 __ERR__
+
+# run with --suite-only option
+TEST_KEY=$TEST_KEY_BASE-suite-only
+run_pass "$TEST_KEY" rose macro -C $TEST_DIR/$TEST_SUITE/app --suite-only
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<'__OUT__'
+[INFO] suite: test-suite
+[V] rose.macros.DefaultValidators
+    # Runs all the default checks, such as compulsory checking.
+[T] rose.macros.DefaultTransforms
+    # Runs all the default fixers, such as trigger fixing.
+__OUT__
+
 rm -r $TEST_DIR/$TEST_SUITE
 #-------------------------------------------------------------------------------
 exit


### PR DESCRIPTION
Closes #1953 

Added `--suite-only` option to rose macro for running suite level macros only.

@arjclark Please review
@matthewrmshin Please review