### PR TITLE
rose macro: don't run transform macros in validate mode.

### DIFF
--- a/lib/python/rose/macro.py
+++ b/lib/python/rose/macro.py
@@ -888,25 +888,26 @@ def run_macros(config_map, meta_config, config_name, macro_names,
         include_system=True,
         no_warn=no_warn
     )
-    # Add all validator macros to the run list if specified.
+
+    # Add all macros to the run list as specified.
+    methods = []
     if opt_validate_all:
+        methods.append(VALIDATE_METHOD)
+    if opt_fix:
+        methods.append(TRANSFORM_METHOD)
+    macros_by_type = {}
+    for macro_method in methods:
+        macros_by_type[macro_method] = []
         for module_name, class_name, method, help in macro_tuples:
-            if method == VALIDATE_METHOD:
+            if method == macro_method:
                 macro_name = ".".join([module_name, class_name])
-                macro_names.insert(0, macro_name)
-        if not macro_names:
+                macros_by_type[macro_method].append(macro_name)
+        if not macros_by_type[macro_method]:
             return True
-    elif opt_fix:
-        for module_name, class_name, method, help in macro_tuples:
-            if module_name != rose.macros.__name__:
-                continue
-            if method == TRANSFORM_METHOD:
-                macro_name = ".".join([module_name, class_name])
-                macro_names.insert(0, macro_name)
-        if not macro_names:
-            return True
+
     # List all macros if none are given.
-    if not macro_names:
+    if not macro_names and not [macros_by_type[method] for method in
+                                macros_by_type]:
         for module_name, class_name, method, help in macro_tuples:
             macro_name = ".".join([module_name, class_name])
             macro_id = MACRO_OUTPUT_ID.format(method.upper()[0], macro_name)
@@ -917,7 +918,6 @@ def run_macros(config_map, meta_config, config_name, macro_names,
         return True
 
     # Categorise macros given as arguments.
-    macros_by_type = {}
     macros_not_found = [m for m in macro_names]
     for module_name, class_name, method, help in macro_tuples:
         this_macro_name = ".".join([module_name, class_name])

--- a/t/rose-macro/00-null.t
+++ b/t/rose-macro/00-null.t
@@ -23,7 +23,7 @@
 init </dev/null
 rm config/rose-app.conf
 #-------------------------------------------------------------------------------
-tests 40
+tests 33
 #-------------------------------------------------------------------------------
 # Normal mode.
 TEST_KEY=$TEST_KEY_BASE-base
@@ -158,81 +158,5 @@ run_pass "$TEST_KEY" rose macro -V -C ../config
 file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
 teardown
-#-------------------------------------------------------------------------------
-# run from suite directory
-TEST_KEY=$TEST_KEY_BASE-suite
-TEST_SUITE=test-suite
-mkdir -p $TEST_DIR/$TEST_SUITE/meta
-cat >$TEST_DIR/$TEST_SUITE/rose-suite.conf <<'__SUITE_CONF__'
-[env]
-SUITE=sweet
-__SUITE_CONF__
-cat >$TEST_DIR/$TEST_SUITE/meta/rose-meta.conf <<'__META_CONF__'
-[env=SUITE]
-type=integer
-__META_CONF__
-run_fail "$TEST_KEY" rose macro -V -C $TEST_DIR/$TEST_SUITE
-#echo `rose macro -V -C $TEST_DIR/$TEST_SUITE`
-file_cmp "$TEST_KEY.err" "$TEST_KEY.err" <<'__ERR__'
-[V] rose.macros.DefaultValidators: issues: 1
-    env=SUITE=sweet
-        Not an integer: 'sweet'
-__ERR__
-
-# run from suite/app directory
-TEST_KEY=$TEST_KEY_BASE-suite-app-dir
-mkdir -p $TEST_DIR/$TEST_SUITE/app/foo/meta/lib/python/macros
-cat >$TEST_DIR/$TEST_SUITE/app/foo/rose-app.conf <<'__APP_CONF__'
-[env]
-FOO=baz
-__APP_CONF__
-cat >$TEST_DIR/$TEST_SUITE/app/foo/meta/rose-meta.conf <<'__META_CONF__'
-[env=FOO]
-macro=foo.FooChecker
-__META_CONF__
-touch $TEST_DIR/$TEST_SUITE/app/foo/meta/lib/python/macros/__init__.py
-cat >$TEST_DIR/$TEST_SUITE/app/foo/meta/lib/python/macros/foo.py <<'__MACRO__'
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
-import rose.macro
-
-
-class FooChecker(rose.macro.MacroBase):
-    """Checks weather suite is sweet enough."""
-
-    def validate(self, config, meta_config=None):
-        node = config.get(['env', 'FOO'])
-        if node is not None or not node.is_ignored():
-            if node.value not in ['foo']:
-                self.add_report('env', 'FOO', node.value, 'Not foo enough')
-        return self.reports
-__MACRO__
-run_fail "$TEST_KEY" rose macro -V -C $TEST_DIR/$TEST_SUITE/app
-file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<'__OUT__'
-[INFO] app: foo
-[INFO] suite: test-suite
-__OUT__
-file_cmp "$TEST_KEY.err" "$TEST_KEY.err" <<'__ERR__'
-[V] foo.FooChecker: issues: 1
-    env=FOO=baz
-        Not foo enough
-[V] rose.macros.DefaultValidators: issues: 1
-    env=SUITE=sweet
-        Not an integer: 'sweet'
-__ERR__
-
-# run with --suite-only option
-TEST_KEY=$TEST_KEY_BASE-suite-only
-run_pass "$TEST_KEY" rose macro -C $TEST_DIR/$TEST_SUITE/app --suite-only
-file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<'__OUT__'
-[INFO] suite: test-suite
-[V] rose.macros.DefaultValidators
-    # Runs all the default checks, such as compulsory checking.
-[T] rose.macros.DefaultTransforms
-    # Runs all the default fixers, such as trigger fixing.
-__OUT__
-
-rm -r $TEST_DIR/$TEST_SUITE
 #-------------------------------------------------------------------------------
 exit

--- a/t/rose-macro/25-suite-level.t
+++ b/t/rose-macro/25-suite-level.t
@@ -1,0 +1,109 @@
+#!/bin/bash
+#-------------------------------------------------------------------------------
+# (C) British Crown Copyright 2012-6 Met Office.
+#
+# This file is part of Rose, a framework for meteorological suites.
+#
+# Rose is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Rose is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Rose. If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test "rose macro" in the absence of a rose configuration.
+#-------------------------------------------------------------------------------
+. $(dirname $0)/test_header
+init </dev/null
+rm config/rose-app.conf
+#-------------------------------------------------------------------------------
+tests 7
+#-------------------------------------------------------------------------------
+# run from suite directory
+TEST_KEY=$TEST_KEY_BASE-suite
+TEST_SUITE=test-suite
+mkdir -p $TEST_DIR/$TEST_SUITE/meta
+cat >$TEST_DIR/$TEST_SUITE/rose-suite.conf <<'__SUITE_CONF__'
+[env]
+SUITE=sweet
+__SUITE_CONF__
+cat >$TEST_DIR/$TEST_SUITE/meta/rose-meta.conf <<'__META_CONF__'
+[env=SUITE]
+type=integer
+__META_CONF__
+run_fail "$TEST_KEY" rose macro -V -C $TEST_DIR/$TEST_SUITE
+#echo `rose macro -V -C $TEST_DIR/$TEST_SUITE`
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" <<'__ERR__'
+[V] rose.macros.DefaultValidators: issues: 1
+    env=SUITE=sweet
+        Not an integer: 'sweet'
+__ERR__
+#-------------------------------------------------------------------------------
+# run from suite/app directory
+TEST_KEY=$TEST_KEY_BASE-suite-app-dir
+mkdir -p $TEST_DIR/$TEST_SUITE/app/foo/meta/lib/python/macros
+cat >$TEST_DIR/$TEST_SUITE/app/foo/rose-app.conf <<'__APP_CONF__'
+[env]
+FOO=baz
+__APP_CONF__
+cat >$TEST_DIR/$TEST_SUITE/app/foo/meta/rose-meta.conf <<'__META_CONF__'
+[env=FOO]
+macro=foo.FooChecker
+__META_CONF__
+touch $TEST_DIR/$TEST_SUITE/app/foo/meta/lib/python/macros/__init__.py
+cat >$TEST_DIR/$TEST_SUITE/app/foo/meta/lib/python/macros/foo.py <<'__MACRO__'
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import rose.macro
+
+
+class FooChecker(rose.macro.MacroBase):
+    """Checks weather suite is sweet enough."""
+
+    def validate(self, config, meta_config=None):
+        node = config.get(['env', 'FOO'])
+        if node is not None or not node.is_ignored():
+            if node.value not in ['foo']:
+                self.add_report('env', 'FOO', node.value, 'Not foo enough')
+        return self.reports
+
+    def transform(self, config, meta_config=None):
+        # This is here to ensure transform macros are not run with the -V
+        # option.
+        return config, self.reports
+__MACRO__
+run_fail "$TEST_KEY" rose macro -V -C $TEST_DIR/$TEST_SUITE/app
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<'__OUT__'
+[INFO] app: foo
+[INFO] suite: test-suite
+__OUT__
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" <<'__ERR__'
+[V] foo.FooChecker: issues: 1
+    env=FOO=baz
+        Not foo enough
+[V] rose.macros.DefaultValidators: issues: 1
+    env=SUITE=sweet
+        Not an integer: 'sweet'
+__ERR__
+#-------------------------------------------------------------------------------
+# run with --suite-only option
+TEST_KEY=$TEST_KEY_BASE-suite-only
+run_pass "$TEST_KEY" rose macro -C $TEST_DIR/$TEST_SUITE/app --suite-only
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<'__OUT__'
+[INFO] suite: test-suite
+[V] rose.macros.DefaultValidators
+    # Runs all the default checks, such as compulsory checking.
+[T] rose.macros.DefaultTransforms
+    # Runs all the default fixers, such as trigger fixing.
+__OUT__
+#-------------------------------------------------------------------------------
+
+rm -r $TEST_DIR/$TEST_SUITE
+exit


### PR DESCRIPTION
Closes #1923 

If a transform and a validate method were defined in the same class then the transform macro would be run by `rose macro -V`.

@arjclark Please review
@matthewrmshin Please review