### PR TITLE
rose edit: allow removal of empty elements in compulsory arrays

### DIFF
--- a/lib/python/rose/config_editor/valuewidget/array/entry.py
+++ b/lib/python/rose/config_editor/valuewidget/array/entry.py
@@ -369,10 +369,7 @@ class EntryArrayValueWidget(gtk.HBox):
             text = self.entries[-1].get_text()
             entry = self.entries.pop()
         self.populate_table()
-        if (self.metadata.get(rose.META_PROP_COMPULSORY) !=
-                rose.META_PROP_VALUE_TRUE or text):
-            # Optional, or compulsory but not blank.
-            self.setter(entry)
+        self.setter(entry)
 
     def setter(self, widget):
         """Reconstruct the new variable value from the entry array."""


### PR DESCRIPTION
Closes #1851 

The EntryArrayValueWidget didn't update when a blank array element was removed. Removing the check doesn't seem to introduce any problems?

@matthewrmshin @arjclark Please Review