### PR TITLE
rose edit: fixed integer widget updating.

### DIFF
--- a/lib/python/rose/config_editor/valuewidget/intspin.py
+++ b/lib/python/rose/config_editor/valuewidget/intspin.py
@@ -58,7 +58,7 @@ class IntSpinButtonValueWidget(gtk.HBox):
 
         if acceptable:
             entry = self.make_spinner(int_value)
-            signal = 'value-changed'
+            signal = 'changed'
         else:
             entry = gtk.Entry()
             entry.set_text(self.value)


### PR DESCRIPTION
Closes #1540 

Switched from using gtk.SpinButton `value-changed` signal to the more generic gtk.Editable `changed` signal.

@matthewrmshin Please review / assign as needed