### PR TITLE
Change rose edit default to show fixed variables.

### DIFF
--- a/lib/python/rose/config_editor/__init__.py
+++ b/lib/python/rose/config_editor/__init__.py
@@ -374,7 +374,7 @@ SHOULD_SHOW_FLAG_OPTIONAL_VARS = False
 # Control showing all comment text.
 SHOULD_SHOW_ALL_COMMENTS = False
 # Control showing fixed variables on a page.
-SHOULD_SHOW_FIXED_VARS = False
+SHOULD_SHOW_FIXED_VARS = True
 # Control showing ! or !! ignored pages.
 SHOULD_SHOW_IGNORED_PAGES = False
 # Control showing ! or !! ignored variables on a page.


### PR DESCRIPTION
Closes #1648 

Sets the view default to show fixed variables. Haven't removed the functionality completely as it can still be useful to hide them.

@matthewrmshin, @oliver-sanders - please review