### PR TITLE
rose macro: fix macro optional_config_name kwarg.

### DIFF
--- a/lib/python/rose/macro.py
+++ b/lib/python/rose/macro.py
@@ -718,21 +718,26 @@ def validate_config(app_config, meta_config, run_macro_list, modules,
                     else:
                         break
                 if optionals:
-                    res = {}
-                    if "optional_config_name" in optionals:
-                        res["optional_config_name"] = optional_config_name
-                    for key in set(optionals) & set(optional_values):
-                        res[key] = optional_values[key]
-                    res.update(get_user_values(optionals, res.keys()))
-                    optional_values.update(res)
-                    if "optional_config_name" in optional_values:
-                        del optional_values["optional_config_name"]
+                    update_optional_values(res, optionals, optional_values,
+                                           optional_config_name)
             problem_list = macro_meth(app_config, meta_config, **res)
             if not isinstance(problem_list, list):
                 raise ValueError(ERROR_RETURN_VALUE.format(macro_name))
             if problem_list:
                 macro_problem_map.update({macro_name: problem_list})
     return macro_problem_map
+
+
+def update_optional_values(res, optionals, optional_values,
+                           optional_config_name):
+    """Copy any relevant parameters into the 'res' dict."""
+    if "optional_config_name" in optionals:
+        res["optional_config_name"] = optional_config_name
+        del optionals["optional_config_name"]
+    for key in set(optionals) & set(optional_values):
+        res[key] = optional_values[key]
+    res.update(get_user_values(optionals, res.keys()))
+    optional_values.update(res)
 
 
 def transform_config(config, meta_config, transformer_macro, modules,
@@ -765,16 +770,8 @@ def transform_config(config, meta_config, transformer_macro, modules,
                 else:
                     break
             if optionals:
-                res = {}
-                if "optional_config_name" in optionals:
-                    res["optional_config_name"] = optional_config_name
-                for key in optionals:
-                    if key in optional_values:
-                        res[key] = optional_values[key]
-                res.update(get_user_values(optionals, res.keys()))
-                optional_values.update(res)
-                if "optional_config_name" in optional_values:
-                    del optional_values["optional_config_name"]
+                update_optional_values(res, optionals, optional_values,
+                                       optional_config_name)
         return macro_method(config, meta_config, **res)
     return config, []
 

--- a/t/rose-macro/24-optional-config-name.t
+++ b/t/rose-macro/24-optional-config-name.t
@@ -21,9 +21,10 @@
 #-------------------------------------------------------------------------------
 . $(dirname $0)/test_header
 #-------------------------------------------------------------------------------
-tests 2
+tests 4
 #-------------------------------------------------------------------------------
-# Test that only relevant prompts are provided
+# Test that optional_config_name is not prompted for and that a custom
+# parameter is only prompted for once.
 init <<'__CONFIG__'
 [env]
 ANSWER=42
@@ -45,7 +46,11 @@ TEST_KEY="$TEST_KEY_BASE"
 rose macro --config='../config' -V <<<'' >>'temp'
 grep_count_ok "$TEST_KEY"-1 'Value for answer (default 42)' 'temp' 1
 grep_count_ok "$TEST_KEY"-2 'Value for optional_config_name' 'temp' 0
-
+#-------------------------------------------------------------------------------
+# Test that the optional_config_name keyword is being set correctly.
+TEST_KEY="$TEST_KEY_BASE-optional_config_name"
+file_grep "$TEST_KEY"-3 'optional_config_name None 42' 'temp'
+file_grep "$TEST_KEY"-3 'optional_config_name baseeight 52' 'temp'
 rm temp
 teardown
 #-------------------------------------------------------------------------------

--- a/t/rose-macro/lib/custom_macro_prompt.py
+++ b/t/rose-macro/lib/custom_macro_prompt.py
@@ -8,4 +8,6 @@ class Test(rose.macro.MacroBase):
 
     def validate(self, config, meta_config=None, answer=42,
                  optional_config_name=None):
+        print 'optional_config_name', optional_config_name, \
+               config['env']['ANSWER'].get_value()
         return self.reports


### PR DESCRIPTION
Fix for functionality introduced in #1915 (and broken since).
- Fixes problem where the `optional_config_name` variable was always `None`.
- Added test.

@arjclark @matthewrmshin Please Review.