### PR TITLE
rose macro: add reporter macros

### DIFF
--- a/doc/etc/rose-rug-advanced-tutorials-macro/planet.py.report.html
+++ b/doc/etc/rose-rug-advanced-tutorials-macro/planet.py.report.html
@@ -93,11 +93,12 @@ class PlanetReporter(rose.macro.MacroBase):
         else:
             print (
                 '{planet} is currently passing through {constellation}.\n'
-                'You should {tosh} today.'
+                'You should {generic_message} today.'
             ).format(
                 planet = planet,
                 constellation = constellation,
-                tosh = random.choice(self.GENERIC_HOROSCOPE_STATEMENTS)
+                generic_message = random.choice(
+                  self.GENERIC_HOROSCOPE_STATEMENTS)
             )
 
     def get_planet_info(self, planet_name):

--- a/doc/etc/rose-rug-advanced-tutorials-macro/planet.py.report.html
+++ b/doc/etc/rose-rug-advanced-tutorials-macro/planet.py.report.html
@@ -1,0 +1,125 @@
+<!DOCTYPE html>
+<html>
+<head>
+
+  <title>Rose User Guide - Advanced Tutorials: Custom Macro
+  planet.py</title>
+  <meta name="author" content="Rose Team, Met Office, UK" />
+  <meta http-equiv="Content-Type" content=
+  "text/html; charset=us-ascii" />
+  <link rel="icon" href="../../img/rose-icon.png" type=
+  "image/png" />
+  <link rel="shortcut icon" href="../../img/rose-icon.png" type=
+  "image/png" />
+  <link rel="stylesheet" type="text/css" href=
+  "../../css/bootstrap.min.css" />
+  <link rel="stylesheet" type="text/css" href=
+  "../../css/rose-doc.css" />
+  <link rel="stylesheet" type="text/css" href=
+  "../../google-code-prettify/prettify.css" />
+  <script type="text/javascript" src="../../js/jquery.min.js">
+</script>
+  <script type="text/javascript" src="../../js/run_prettify.js">
+</script>
+  <script type="text/javascript" src=
+  "../../js/prettify-rose-conf.js">
+</script>
+  <script type="text/javascript" src=
+  "../../js/prettify-cylc-suite-rc.js">
+</script>
+  <script type="text/javascript" src="../../js/bootstrap.min.js">
+</script>
+  <script type="text/javascript" src="../../js/rose-doc.js">
+</script>
+  <script type="text/javascript" src="../../js/rose-version.js">
+</script>
+</head>
+
+<body>
+  <nav class="navbar navbar-default">
+    <div class="container-fluid">
+      <div class="navbar-header">
+        <a class="navbar-brand" href="."><span class="logo">Rose
+        Documentation</span></a>
+      </div>
+      <!-- Collect the nav links, forms, and other content for toggling -->
+
+      <div class="collapse navbar-collapse" id=
+      "bs-example-navbar-collapse-1">
+        <ul class="nav navbar-nav navbar-right">
+          <li><span class="navbar-text"><span class=
+          "compliance">&#169; British Crown Copyright 2012-6
+          <a href="http://www.metoffice.gov.uk">Met Office</a>. See
+          <a href="rose-terms-of-use.html">Terms of Use</a>.<br />
+          This document is released under the <a href=
+          "http://www.nationalarchives.gov.uk/doc/open-government-licence/"
+          rel="license">Open Government
+          Licence</a>.</span></span></li>
+
+          <li><span id="rose-version" class=
+          "navbar-text"></span></li>
+        </ul>
+      </div><!-- /.navbar-collapse -->
+    </div><!-- /.container-fluid -->
+  </nav>
+
+  <div class="container">
+    <div class="row">
+      <div class="col-md-12">
+        <div class="panel panel-default">
+          <div class="panel-body">
+            <h2>planet.py</h2>
+            <pre class="prettyprint">
+class PlanetReporter(rose.macro.MacroBase):
+
+    """Creates a report on the value of env=WORLD."""
+
+    GENERIC_HOROSCOPE_STATEMENTS = [
+        'be cautious', 'remain indoors', 'expect the unexpected',
+        'not walk under ladders', 'seek new opportunities']
+
+    def report(self, config, meta_config=None):
+        world_node = config.get(["env", "WORLD"])
+        if world_node is None or world_node.is_ignored():
+            return
+        planet = world_node.value
+        if planet.lower() == 'earth':
+            print 'Please choose a planet other than Earth.'
+            return
+        constellation = self.get_planet_info(planet)
+        if not constellation:
+            print 'Could not find horoscope entry for {0}'.format(planet)
+            return
+        else:
+            print (
+                '{planet} is currently passing through {constellation}.\n'
+                'You should {tosh} today.'
+            ).format(
+                planet = planet,
+                constellation = constellation,
+                tosh = random.choice(self.GENERIC_HOROSCOPE_STATEMENTS)
+            )
+
+    def get_planet_info(self, planet_name):
+        cmd_strings = ["curl", "-s",
+                       "http://www.heavens-above.com/planetsummary.aspx"]
+        p = subprocess.Popen(cmd_strings, stdout=subprocess.PIPE)
+        text = p.communicate()[0]
+        planets = re.findall("(\w+)&lt;/td&gt;",
+                             re.sub('(?s)^.*(tablehead.*?ascension).*$',
+                                    r"\1", text))
+        constellations = re.findall("(\w+)&lt;/a&gt;",
+                               re.sub('(?s)^.*(Constellation.*?Meridian).*$',
+                                      r"\1", text))
+        for planet, constellation in zip(planets, constellations):
+            if planet.lower() == planet_name.lower():
+                return constellation
+        return None
+</pre>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/doc/rose-api.html
+++ b/doc/rose-api.html
@@ -775,7 +775,7 @@ widget[rose-config-edit:sub-ns] = modulename.ClassName arg1 arg2 arg3 ...
             <h2 id="macro">Rose Macros</h2>
 
             <p>Rose macros manipulate or check configurations,
-            often based on their metadata. There are three types of
+            often based on their metadata. There are four types of
             macros:</p>
 
             <ul>
@@ -787,6 +787,9 @@ widget[rose-config-edit:sub-ns] = modulename.ClassName arg1 arg2 arg3 ...
 
               <li>Upgraders - these are special transformer macros
               for upgrading and downgrading configurations.</li>
+
+              <li>Reporters - output information about a
+              configuration.</li>
             </ul>
 
             <p>There are built-in rose macros that handle standard
@@ -952,6 +955,18 @@ class SomeTransformer(rose.macro.MacroBase):
             always the configuration's directory. This makes it
             easy to access non-<samp>rose-app.conf</samp> files
             (e.g. in the <samp>file/</samp> subdirectory).</p>
+
+            <p>There are also reporter macros which can be used
+            where you need to output some information about a
+            configuration. A reporter macro takes the same form
+            as validator and transform macros but does not require
+            a return value.</p>
+
+            <pre class="prettyprint">
+    def report(self, config, meta_config=None):
+        with open('report/file', 'r') as report_file:
+            report_file.write(str(config.get(["namelist:snowflakes"])))
+</pre>
 
             <p>Macros also support the use of keyword arguments,
             giving you the ability to have the user specify some

--- a/doc/rose-rug-advanced-tutorials-macro.html
+++ b/doc/rose-rug-advanced-tutorials-macro.html
@@ -589,6 +589,21 @@ macro=planet.PlanetChecker, planet.PlanetChanger
             </div>
 
             <div class="slide">
+              <h2 id="reporter-macros">Reporter Macros</h2>
+              <p>There are also reporter macros which can be used
+              where you need to output some information about a
+              configuration. A reporter macro takes the same form
+              as validator and transform macros but does not require
+              a return value.</p>
+
+              <pre class="prettyprint">
+    def report(self, config, meta_config=None):
+        with open('report/file', 'r') as report_file:
+            report_file.write(str(config.get(["namelist:snowflakes"])))
+</pre>
+            </div>
+
+            <div class="slide">
               <h2>Further Reading</h2>
 
               <p>For more information, see the <a href=

--- a/doc/rose-rug-advanced-tutorials-macro.html
+++ b/doc/rose-rug-advanced-tutorials-macro.html
@@ -508,6 +508,32 @@ rose edit
             </div>
 
             <div class="slide">
+              <h2>Reporter macro</h2>
+              <p>Along with validator and transformer macros there are also
+              reporter macros. These are used when you want to output
+              information about a configuration but do not want to make any
+              changes to it.</p>
+              <p>Next we will write a reporter macro which produces a
+              horoscope entry based on the value of <var>env=WORLD</var>.</p>
+            </div>
+
+            <div class="slide">
+              <h3 class="alwayshidden">Running the reporter macro</h3>
+              <p>Open <code>planet.py</code> and paste in this <a
+                href="etc/rose-rug-advanced-tutorials-macro/planet.py.report.html">text</a>.</p>
+              <p>You will need to add the following line with the other imports
+              at the top of the file.</p>
+              <pre class="prettyprint">
+import random
+</pre>
+
+              <p>Next run this macro from the command line by invoking:</p>
+
+              <pre class="shell">
+rose macro planet.PlanetReporter</pre>
+            </div>
+
+            <div class="slide">
               <h2 id="macro-args">Macro Arguments</h2>
 
               <p>From time to time, we may want to change some
@@ -586,21 +612,6 @@ macro=planet.PlanetChecker, planet.PlanetChanger
               <var>env</var> page should now contain a dropdown
               menu at the top of the page for launching the two
               macros.</p>
-            </div>
-
-            <div class="slide">
-              <h2 id="reporter-macros">Reporter Macros</h2>
-              <p>There are also reporter macros which can be used
-              where you need to output some information about a
-              configuration. A reporter macro takes the same form
-              as validator and transform macros but does not require
-              a return value.</p>
-
-              <pre class="prettyprint">
-    def report(self, config, meta_config=None):
-        with open('report/file', 'r') as report_file:
-            report_file.write(str(config.get(["namelist:snowflakes"])))
-</pre>
             </div>
 
             <div class="slide">

--- a/t/rose-macro/00-null.t
+++ b/t/rose-macro/00-null.t
@@ -23,7 +23,7 @@
 init </dev/null
 rm config/rose-app.conf
 #-------------------------------------------------------------------------------
-tests 33
+tests 36
 #-------------------------------------------------------------------------------
 # Normal mode.
 TEST_KEY=$TEST_KEY_BASE-base
@@ -155,6 +155,28 @@ init </dev/null
 TEST_KEY=$TEST_KEY_BASE-default-metadata
 setup
 run_pass "$TEST_KEY" rose macro -V -C ../config
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+teardown
+#-------------------------------------------------------------------------------
+# Check reporter macros run ok.
+init </dev/null
+init_meta <<'__META_CONFIG__'
+[env=ANSWER]
+macro=report.Test
+__META_CONFIG__
+init_macro report.py <<'__MACRO__'
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+import rose.macro
+class Test(rose.macro.MacroBase):
+    """Test reporter macro."""
+    def report(self, config, meta_config=None):
+        return True
+__MACRO__
+setup
+TEST_KEY=$TEST_KEY_BASE-validator-macro
+run_pass "$TEST_KEY" rose macro report.Test -C ../config
 file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
 teardown


### PR DESCRIPTION
Closes #1687 

Adds a new type of macro for reporting on application configurations, the main purpose of this is so that these macros don't get run by `rose macro -V`.

@matthewrmshin @arjclark Please Review