### PR TITLE
rose edit: better behaviour for enviroment variables in values metadata.

### DIFF
--- a/lib/python/rose/config_editor/valuewidget/__init__.py
+++ b/lib/python/rose/config_editor/valuewidget/__init__.py
@@ -65,8 +65,6 @@ class ValueWidgetHook(object):
 
 def chooser(value, metadata, error):
     """Select an appropriate widget class based on the arguments."""
-    if rose.env.contains_env_var(value):
-        return text.RawValueWidget
     m_type = metadata.get(rose.META_PROP_TYPE)
     m_values = metadata.get(rose.META_PROP_VALUES)
     m_length = metadata.get(rose.META_PROP_LENGTH)


### PR DESCRIPTION
Closes #1512 

Changes the behaviour of environment variables when used with values metadata e.g:

```
[env=SOMETHING]
values=bar, baz, $SUITE_SOMETHING
```
Old behaviour:
 - If an environment variable value is selected then display a textbox (only works if the value is selected before the panel is rendered)
 - Else show a radio/combobox

New behaviour:
- Always display such settings as a radio/combobox (do not try to change to a textbox)

@arjclark @matthewrmshin Please Review.
@matthewrmshin On next release for the moment, bump milestone accordingly.