### PR TITLE
Provide ROSE_BUNCH_LOG_PREFIX to bunch instances.

### DIFF
--- a/doc/rose-variables.html
+++ b/doc/rose-variables.html
@@ -109,6 +109,24 @@
               task-run</a></li>
             </ul>
 
+            <h2 id="ROSE_BUNCH_LOG_PREFIX">
+            <var>ROSE_BUNCH_LOG_PREFIX</var></h2>
+
+            <h3>Description</h3>
+
+            <p>Environment variable provided to rose bunch instances at runtime
+            to identify the log prefix that will be used for output e.g. for a
+            bunch instance named <var>foo</var> then
+            <var>ROSE_BUNCH_LOG_PREFIX=foo</var>.</p>
+
+            <h3>Provided At Runtime By</h3>
+
+            <ul>
+              <li>
+              <a href="rose-rug-task-run.html#rose-task-run.util.rose_bunch">
+              rose bunch</a></li>
+            </ul>
+
             <h2 id="ROSE_CONF_PATH"><var>ROSE_CONF_PATH</var></h2>
 
             <h3>Description</h3>

--- a/lib/python/rose/apps/rose_bunch.py
+++ b/lib/python/rose/apps/rose_bunch.py
@@ -269,6 +269,9 @@ class RoseBunchApp(BuiltinApp):
                 cmd = command.get_command()
                 cmd_stdout = log_format % command.get_out_file()
                 cmd_stderr = log_format % command.get_err_file()
+                prefix = command.get_log_prefix()
+                bunch_environ = os.environ
+                bunch_environ['ROSE_BUNCH_LOG_PREFIX'] = prefix
 
                 if self.dao:
                     if self.dao.check_has_succeeded(key):
@@ -284,7 +287,8 @@ class RoseBunchApp(BuiltinApp):
                     app_runner.popen.run_bg(cmd,
                                             shell=True,
                                             stdout=open(cmd_stdout, 'w'),
-                                            stderr=open(cmd_stderr, 'w'))
+                                            stderr=open(cmd_stderr, 'w'),
+                                            env=bunch_environ)
             sleep(self.SLEEP_DURATION)
 
         if abort and commands:
@@ -316,7 +320,7 @@ class RoseBunchCmd(object):
     def __init__(self, name, command, index):
         self.command_format = command
         self.argsdict = {}
-        self.name = name
+        self.name = str(name)
         self.index = index
 
     def get_command(self):
@@ -333,6 +337,11 @@ class RoseBunchCmd(object):
         """Return error file name"""
 
         return self.OUTPUT_TEMPLATE % (self.name, "err")
+
+    def get_log_prefix(self):
+        """Return log prefix"""
+
+        return self.name
 
 
 class RoseBunchDAO(object):

--- a/t/rose-task-run/31-app-bunch.t
+++ b/t/rose-task-run/31-app-bunch.t
@@ -21,7 +21,7 @@
 #-------------------------------------------------------------------------------
 . $(dirname $0)/test_header
 #-------------------------------------------------------------------------------
-tests 47
+tests 51
 #-------------------------------------------------------------------------------
 # Run the suite, and wait for it to complete
 export ROSE_CONF_PATH=
@@ -149,6 +149,18 @@ FILE_DIR=$LOG_DIR/$APP/01/
 for KEY in $(seq 0 2); do
     file_grep $TEST_KEY_PREFIX-cmd_eval_ran-$KEY \
         "a comment" $FILE_DIR/bunch.$KEY.out
+done
+#-------------------------------------------------------------------------------
+#-------------------------------------------------------------------------------
+# Testing ROSE_BUNCH_LOG_PREFIX is correctly set
+#-------------------------------------------------------------------------------
+APP=bunch_print_envar
+#-------------------------------------------------------------------------------
+TEST_KEY_PREFIX=log_prefix
+FILE_DIR=$LOG_DIR/$APP/01/
+for KEY in $(seq 0 3); do
+    file_grep $TEST_KEY_PREFIX-ok-$KEY \
+        "ROSE_BUNCH_LOG_PREFIX: $KEY" $FILE_DIR/bunch.$KEY.out
 done
 #-------------------------------------------------------------------------------
 rose suite-clean -q -y $NAME

--- a/t/rose-task-run/31-app-bunch/app/bunch_print_envar/rose-app.conf
+++ b/t/rose-task-run/31-app-bunch/app/bunch_print_envar/rose-app.conf
@@ -1,0 +1,10 @@
+mode=rose_bunch
+meta=rose_bunch
+
+[bunch-args]
+arg1=1 2 3 4
+
+[bunch]
+command-format=echo ROSE_BUNCH_LOG_PREFIX: \$ROSE_BUNCH_LOG_PREFIX
+pool-size=1
+command-instances = 4

--- a/t/rose-task-run/31-app-bunch/suite.rc
+++ b/t/rose-task-run/31-app-bunch/suite.rc
@@ -39,6 +39,8 @@
             FAIL_MODE=continue
             INCREMENTAL=true
             POOL_SIZE=1
-            
+    [[bunch_print_envar]]
+        inherit = BUNCH_TASKS
+
     [[dummy]]
         script = true


### PR DESCRIPTION
Provides a `ROSE_BUNCH_LOG_PREFIX` environment variable to rose bunch instances.

Addresses #1919 part of #1954 

@matthewrmshin please review 1 - up to you if you want a review 2.