### PR TITLE
t: rose-suite-run-08: fix duration syntax

### DIFF
--- a/t/rose-suite-run/08-pgrep/suite.rc
+++ b/t/rose-suite-run/08-pgrep/suite.rc
@@ -2,8 +2,8 @@
 [cylc]
     UTC mode=True
     [[events]]
-        timeout handler=rose suite-hook --shutdown
-        timeout=2
+        abort on timeout=True
+        timeout=PT2M
 [scheduling]
     [[dependencies]]
         graph=my_task_1


### PR DESCRIPTION
Fix test failure due to old syntax being removed by cylc/cylc#2063.

@arjclark @oliver-sanders could one of you please review?