### PR TITLE
rose bush pager: fix lost task/job status filters

### DIFF
--- a/lib/html/template/rose-bush/pager.html
+++ b/lib/html/template/rose-bush/pager.html
@@ -37,11 +37,17 @@
             {% if order -%}
               <input type="hidden" name="order" value="{{order}}" />
             {% endif -%}
-            {% for status in ["active", "success", "fail"] -%}
-              {% if no_statuses and status in no_statuses -%}
-                <input type="hidden" name="no_status" value="{{status}}" />
+            {% for key, value in task_statuses -%}
+              {% if value == "1" -%}
+              <input type="hidden" name="task_status" value="{{key}}" />
               {% endif -%}
             {% endfor -%}
+            {% if all_task_statuses -%}
+              <input type="hidden" name="task_status" value="" />
+            {% endif -%}
+            {% if job_status -%}
+              <input type="hidden" name="job_status" value="{{job_status}}" />
+            {% endif -%}
             <ul class="list-inline">
               <li class="previous">
                 <button id="page-prev" title="previous"


### PR DESCRIPTION
Pager template should no longer lose task/job status filters.

Reported by @scwhitehouse. @arjclark @oliver-sanders please review.