### PR TITLE
rose docs: broken link detection

### DIFF
--- a/doc/etc/rose-rug-advanced-tutorials-fail-if/meta/rose-meta.conf.html
+++ b/doc/etc/rose-rug-advanced-tutorials-fail-if/meta/rose-meta.conf.html
@@ -51,7 +51,7 @@
           <li><span class="navbar-text"><span class=
           "compliance">&#169; British Crown Copyright 2012-6
           <a href="http://www.metoffice.gov.uk">Met Office</a>. See
-          <a href="rose-terms-of-use.html">Terms of Use</a>.<br />
+          <a href="../../../rose-terms-of-use.html">Terms of Use</a>.<br />
           This document is released under the <a href=
           "http://www.nationalarchives.gov.uk/doc/open-government-licence/"
           rel="license">Open Government

--- a/doc/etc/rose-rug-advanced-tutorials-jinja2/rose-app.conf.html
+++ b/doc/etc/rose-rug-advanced-tutorials-jinja2/rose-app.conf.html
@@ -50,7 +50,7 @@
           <li><span class="navbar-text"><span class=
           "compliance">&#169; British Crown Copyright 2012-6
           <a href="http://www.metoffice.gov.uk">Met Office</a>. See
-          <a href="rose-terms-of-use.html">Terms of Use</a>.<br />
+          <a href="../../rose-terms-of-use.html">Terms of Use</a>.<br />
           This document is released under the <a href=
           "http://www.nationalarchives.gov.uk/doc/open-government-licence/"
           rel="license">Open Government

--- a/doc/etc/rose-rug-advanced-tutorials-jinja2/suite.rc.standalone.html
+++ b/doc/etc/rose-rug-advanced-tutorials-jinja2/suite.rc.standalone.html
@@ -25,7 +25,7 @@
   "../../js/prettify-rose-conf.js">
 </script>
   <script type="text/javascript" src=
-  "../../prettify-cylc-suite-rc.js">
+  "../../js/prettify-cylc-suite-rc.js">
 </script>
   <script type="text/javascript" src="../../js/bootstrap.min.js">
 </script>
@@ -50,7 +50,7 @@
           <li><span class="navbar-text"><span class=
           "compliance">&#169; British Crown Copyright 2012-6
           <a href="http://www.metoffice.gov.uk">Met Office</a>. See
-          <a href="rose-terms-of-use.html">Terms of Use</a>.<br />
+          <a href="../../rose-terms-of-use.html">Terms of Use</a>.<br />
           This document is released under the <a href=
           "http://www.nationalarchives.gov.uk/doc/open-government-licence/"
           rel="license">Open Government

--- a/doc/etc/rose-rug-advanced-tutorials-jinja2/suite.rc.start.html
+++ b/doc/etc/rose-rug-advanced-tutorials-jinja2/suite.rc.start.html
@@ -25,7 +25,7 @@
   "../../js/prettify-rose-conf.js">
 </script>
   <script type="text/javascript" src=
-  "../../prettify-cylc-suite-rc.js">
+  "../../js/prettify-cylc-suite-rc.js">
 </script>
   <script type="text/javascript" src="../../js/bootstrap.min.js">
 </script>
@@ -50,7 +50,7 @@
           <li><span class="navbar-text"><span class=
           "compliance">&#169; British Crown Copyright 2012-6
           <a href="http://www.metoffice.gov.uk">Met Office</a>. See
-          <a href="rose-terms-of-use.html">Terms of Use</a>.<br />
+          <a href="../../rose-terms-of-use.html">Terms of Use</a>.<br />
           This document is released under the <a href=
           "http://www.nationalarchives.gov.uk/doc/open-government-licence/"
           rel="license">Open Government

--- a/doc/etc/rose-rug-advanced-tutorials-macro/planet.py.report.html
+++ b/doc/etc/rose-rug-advanced-tutorials-macro/planet.py.report.html
@@ -50,7 +50,7 @@
           <li><span class="navbar-text"><span class=
           "compliance">&#169; British Crown Copyright 2012-6
           <a href="http://www.metoffice.gov.uk">Met Office</a>. See
-          <a href="rose-terms-of-use.html">Terms of Use</a>.<br />
+          <a href="../../rose-terms-of-use.html">Terms of Use</a>.<br />
           This document is released under the <a href=
           "http://www.nationalarchives.gov.uk/doc/open-government-licence/"
           rel="license">Open Government

--- a/doc/etc/rose-rug-advanced-tutorials-macro/planet.py.report.html
+++ b/doc/etc/rose-rug-advanced-tutorials-macro/planet.py.report.html
@@ -107,7 +107,7 @@ class PlanetReporter(rose.macro.MacroBase):
         p = subprocess.Popen(cmd_strings, stdout=subprocess.PIPE)
         text = p.communicate()[0]
         planets = re.findall("(\w+)&lt;/td&gt;",
-                             re.sub('(?s)^.*(tablehead.*?ascension).*$',
+                             re.sub(r'(?s)^.*(&lt;thead.*?ascension).*$',
                                     r"\1", text))
         constellations = re.findall("(\w+)&lt;/a&gt;",
                                re.sub('(?s)^.*(Constellation.*?Meridian).*$',

--- a/doc/etc/rose-rug-advanced-tutorials-macro/planet.py.start.html
+++ b/doc/etc/rose-rug-advanced-tutorials-macro/planet.py.start.html
@@ -50,7 +50,7 @@
           <li><span class="navbar-text"><span class=
           "compliance">&#169; British Crown Copyright 2012-6
           <a href="http://www.metoffice.gov.uk">Met Office</a>. See
-          <a href="rose-terms-of-use.html">Terms of Use</a>.<br />
+          <a href="../../rose-terms-of-use.html">Terms of Use</a>.<br />
           This document is released under the <a href=
           "http://www.nationalarchives.gov.uk/doc/open-government-licence/"
           rel="license">Open Government

--- a/doc/etc/rose-rug-advanced-tutorials-macro/planet.py.transform-kwargs.html
+++ b/doc/etc/rose-rug-advanced-tutorials-macro/planet.py.transform-kwargs.html
@@ -50,7 +50,7 @@
           <li><span class="navbar-text"><span class=
           "compliance">&#169; British Crown Copyright 2012-6
           <a href="http://www.metoffice.gov.uk">Met Office</a>. See
-          <a href="rose-terms-of-use.html">Terms of Use</a>.<br />
+          <a href="../../rose-terms-of-use.html">Terms of Use</a>.<br />
           This document is released under the <a href=
           "http://www.nationalarchives.gov.uk/doc/open-government-licence/"
           rel="license">Open Government

--- a/doc/etc/rose-rug-advanced-tutorials-macro/planet.py.transform-start.html
+++ b/doc/etc/rose-rug-advanced-tutorials-macro/planet.py.transform-start.html
@@ -50,7 +50,7 @@
           <li><span class="navbar-text"><span class=
           "compliance">&#169; British Crown Copyright 2012-6
           <a href="http://www.metoffice.gov.uk">Met Office</a>. See
-          <a href="rose-terms-of-use.html">Terms of Use</a>.<br />
+          <a href="../../rose-terms-of-use.html">Terms of Use</a>.<br />
           This document is released under the <a href=
           "http://www.nationalarchives.gov.uk/doc/open-government-licence/"
           rel="license">Open Government

--- a/doc/etc/rose-rug-advanced-tutorials-macro/planet.py.transform.html
+++ b/doc/etc/rose-rug-advanced-tutorials-macro/planet.py.transform.html
@@ -50,7 +50,7 @@
           <li><span class="navbar-text"><span class=
           "compliance">&#169; British Crown Copyright 2012-6
           <a href="http://www.metoffice.gov.uk">Met Office</a>. See
-          <a href="rose-terms-of-use.html">Terms of Use</a>.<br />
+          <a href="../../rose-terms-of-use.html">Terms of Use</a>.<br />
           This document is released under the <a href=
           "http://www.nationalarchives.gov.uk/doc/open-government-licence/"
           rel="license">Open Government

--- a/doc/etc/rose-rug-advanced-tutorials-macro/planet.py.validate.html
+++ b/doc/etc/rose-rug-advanced-tutorials-macro/planet.py.validate.html
@@ -104,7 +104,7 @@ class PlanetChecker(rose.macro.MacroBase):
         p = subprocess.Popen(cmd_strings, stdout=subprocess.PIPE)
         text = p.communicate()[0]
         planets = re.findall("(\w+)&lt;/td&gt;",
-                             re.sub('(?s)^.*(tablehead.*?ascension).*$',
+                             re.sub(r'(?s)^.*(&lt;thead.*?ascension).*$',
                                     r"\1", text))
         distances = re.findall("([\d.]+)&lt;/td&gt;",
                                re.sub('(?s)^.*(Range.*?Brightness).*$',

--- a/doc/etc/rose-rug-advanced-tutorials-macro/planet.py.validate.html
+++ b/doc/etc/rose-rug-advanced-tutorials-macro/planet.py.validate.html
@@ -50,7 +50,7 @@
           <li><span class="navbar-text"><span class=
           "compliance">&#169; British Crown Copyright 2012-6
           <a href="http://www.metoffice.gov.uk">Met Office</a>. See
-          <a href="rose-terms-of-use.html">Terms of Use</a>.<br />
+          <a href="../../rose-terms-of-use.html">Terms of Use</a>.<br />
           This document is released under the <a href=
           "http://www.nationalarchives.gov.uk/doc/open-government-licence/"
           rel="license">Open Government

--- a/doc/etc/rose-rug-advanced-tutorials-multi-inherit/output.html
+++ b/doc/etc/rose-rug-advanced-tutorials-multi-inherit/output.html
@@ -25,7 +25,7 @@
   "../../js/prettify-rose-conf.js">
 </script>
   <script type="text/javascript" src=
-  "../../prettify-cylc-suite-rc.js">
+  "../../js/prettify-cylc-suite-rc.js">
 </script>
   <script type="text/javascript" src="../../js/bootstrap.min.js">
 </script>
@@ -50,7 +50,7 @@
           <li><span class="navbar-text"><span class=
           "compliance">&#169; British Crown Copyright 2012-6
           <a href="http://www.metoffice.gov.uk">Met Office</a>. See
-          <a href="rose-terms-of-use.html">Terms of Use</a>.<br />
+          <a href="../../rose-terms-of-use.html">Terms of Use</a>.<br />
           This document is released under the <a href=
           "http://www.nationalarchives.gov.uk/doc/open-government-licence/"
           rel="license">Open Government

--- a/doc/etc/rose-rug-advanced-tutorials-multi-inherit/race.html
+++ b/doc/etc/rose-rug-advanced-tutorials-multi-inherit/race.html
@@ -25,7 +25,7 @@
   "../../js/prettify-rose-conf.js">
 </script>
   <script type="text/javascript" src=
-  "../../prettify-cylc-suite-rc.js">
+  "../../js/prettify-cylc-suite-rc.js">
 </script>
   <script type="text/javascript" src="../../js/bootstrap.min.js">
 </script>
@@ -50,7 +50,7 @@
           <li><span class="navbar-text"><span class=
           "compliance">&#169; British Crown Copyright 2012-6
           <a href="http://www.metoffice.gov.uk">Met Office</a>. See
-          <a href="rose-terms-of-use.html">Terms of Use</a>.<br />
+          <a href="../../rose-terms-of-use.html">Terms of Use</a>.<br />
           This document is released under the <a href=
           "http://www.nationalarchives.gov.uk/doc/open-government-licence/"
           rel="license">Open Government

--- a/doc/etc/rose-rug-advanced-tutorials-multi-inherit/suite.rc.html
+++ b/doc/etc/rose-rug-advanced-tutorials-multi-inherit/suite.rc.html
@@ -25,7 +25,7 @@
   "../../js/prettify-rose-conf.js">
 </script>
   <script type="text/javascript" src=
-  "../../prettify-cylc-suite-rc.js">
+  "../../js/prettify-cylc-suite-rc.js">
 </script>
   <script type="text/javascript" src="../../js/bootstrap.min.js">
 </script>
@@ -50,7 +50,7 @@
           <li><span class="navbar-text"><span class=
           "compliance">&#169; British Crown Copyright 2012-6
           <a href="http://www.metoffice.gov.uk">Met Office</a>. See
-          <a href="rose-terms-of-use.html">Terms of Use</a>.<br />
+          <a href="../../rose-terms-of-use.html">Terms of Use</a>.<br />
           This document is released under the <a href=
           "http://www.nationalarchives.gov.uk/doc/open-government-licence/"
           rel="license">Open Government

--- a/doc/etc/rose-rug-advanced-tutorials-rose-bunch/src/land.html
+++ b/doc/etc/rose-rug-advanced-tutorials-rose-bunch/src/land.html
@@ -51,7 +51,7 @@
           <li><span class="navbar-text"><span class=
           "compliance">&#169; British Crown Copyright 2012-6
           <a href="http://www.metoffice.gov.uk">Met Office</a>. See
-          <a href="rose-terms-of-use.html">Terms of Use</a>.<br />
+          <a href="../../../rose-terms-of-use.html">Terms of Use</a>.<br />
           This document is released under the <a href=
           "http://www.nationalarchives.gov.uk/doc/open-government-licence/"
           rel="license">Open Government

--- a/doc/etc/rose-rug-advanced-tutorials-rose-stem/src/kgo.txt.html
+++ b/doc/etc/rose-rug-advanced-tutorials-rose-stem/src/kgo.txt.html
@@ -50,7 +50,7 @@
           <li><span class="navbar-text"><span class=
           "compliance">&#169; British Crown Copyright 2012-6
           <a href="http://www.metoffice.gov.uk">Met Office</a>. See
-          <a href="rose-terms-of-use.html">Terms of Use</a>.<br />
+          <a href="../../../rose-terms-of-use.html">Terms of Use</a>.<br />
           This document is released under the <a href=
           "http://www.nationalarchives.gov.uk/doc/open-government-licence/"
           rel="license">Open Government

--- a/doc/etc/rose-rug-advanced-tutorials-rose-stem/src/spaceship_command.f90.html
+++ b/doc/etc/rose-rug-advanced-tutorials-rose-stem/src/spaceship_command.f90.html
@@ -51,7 +51,7 @@
           <li><span class="navbar-text"><span class=
           "compliance">&#169; British Crown Copyright 2012-6
           <a href="http://www.metoffice.gov.uk">Met Office</a>. See
-          <a href="rose-terms-of-use.html">Terms of Use</a>.<br />
+          <a href="../../../rose-terms-of-use.html">Terms of Use</a>.<br />
           This document is released under the <a href=
           "http://www.nationalarchives.gov.uk/doc/open-government-licence/"
           rel="license">Open Government

--- a/doc/etc/rose-rug-advanced-tutorials-rose-stem/src/suite.rc.html
+++ b/doc/etc/rose-rug-advanced-tutorials-rose-stem/src/suite.rc.html
@@ -50,7 +50,7 @@
           <li><span class="navbar-text"><span class=
           "compliance">&#169; British Crown Copyright 2012-6
           <a href="http://www.metoffice.gov.uk">Met Office</a>. See
-          <a href="rose-terms-of-use.html">Terms of Use</a>.<br />
+          <a href="../../../rose-terms-of-use.html">Terms of Use</a>.<br />
           This document is released under the <a href=
           "http://www.nationalarchives.gov.uk/doc/open-government-licence/"
           rel="license">Open Government

--- a/doc/etc/rose-rug-advanced-tutorials-suite-date-time/suite.rc.html
+++ b/doc/etc/rose-rug-advanced-tutorials-suite-date-time/suite.rc.html
@@ -25,7 +25,7 @@
   "../../js/prettify-rose-conf.js">
 </script>
   <script type="text/javascript" src=
-  "../../prettify-cylc-suite-rc.js">
+  "../../js/prettify-cylc-suite-rc.js">
 </script>
   <script type="text/javascript" src="../../js/bootstrap.min.js">
 </script>
@@ -50,7 +50,7 @@
           <li><span class="navbar-text"><span class=
           "compliance">&#169; British Crown Copyright 2012-6
           <a href="http://www.metoffice.gov.uk">Met Office</a>. See
-          <a href="rose-terms-of-use.html">Terms of Use</a>.<br />
+          <a href="../../rose-terms-of-use.html">Terms of Use</a>.<br />
           This document is released under the <a href=
           "http://www.nationalarchives.gov.uk/doc/open-government-licence/"
           rel="license">Open Government

--- a/doc/etc/rose-rug-advanced-tutorials-trigger/meta/rose-meta.conf.html
+++ b/doc/etc/rose-rug-advanced-tutorials-trigger/meta/rose-meta.conf.html
@@ -48,7 +48,7 @@
           <li><span class="navbar-text"><span class=
           "compliance">&#169; British Crown Copyright 2012-6
           <a href="http://www.metoffice.gov.uk">Met Office</a>. See
-          <a href="rose-terms-of-use.html">Terms of Use</a>.<br />
+          <a href="../../../rose-terms-of-use.html">Terms of Use</a>.<br />
           This document is released under the <a href=
           "http://www.nationalarchives.gov.uk/doc/open-government-licence/"
           rel="license">Open Government

--- a/doc/etc/rose-rug-advanced-tutorials-trigger/rose-app.conf.html
+++ b/doc/etc/rose-rug-advanced-tutorials-trigger/rose-app.conf.html
@@ -49,7 +49,7 @@
           <li><span class="navbar-text"><span class=
           "compliance">&#169; British Crown Copyright 2012-6
           <a href="http://www.metoffice.gov.uk">Met Office</a>. See
-          <a href="rose-terms-of-use.html">Terms of Use</a>.<br>
+          <a href="../../rose-terms-of-use.html">Terms of Use</a>.<br>
           This document is released under the <a href=
           "http://www.nationalarchives.gov.uk/doc/open-government-licence/"
           rel="license">Open Government

--- a/doc/etc/rose-rug-advanced-tutorials-upgrade-dev/rose-meta.conf.html
+++ b/doc/etc/rose-rug-advanced-tutorials-upgrade-dev/rose-meta.conf.html
@@ -52,7 +52,7 @@
           <li><span class="navbar-text"><span class=
           "compliance">&#169; British Crown Copyright 2012-6
           <a href="http://www.metoffice.gov.uk">Met Office</a>. See
-          <a href="rose-terms-of-use.html">Terms of Use</a>.<br>
+          <a href="../../rose-terms-of-use.html">Terms of Use</a>.<br>
           This document is released under the <a href=
           "http://www.nationalarchives.gov.uk/doc/open-government-licence/"
           rel="license">Open Government

--- a/doc/etc/rose-rug-advanced-tutorials-widget/username.py.html
+++ b/doc/etc/rose-rug-advanced-tutorials-widget/username.py.html
@@ -50,7 +50,7 @@
           <li><span class="navbar-text"><span class=
           "compliance">&#169; British Crown Copyright 2012-6
           <a href="http://www.metoffice.gov.uk">Met Office</a>. See
-          <a href="rose-terms-of-use.html">Terms of Use</a>.<br />
+          <a href="../../rose-terms-of-use.html">Terms of Use</a>.<br />
           This document is released under the <a href=
           "http://www.nationalarchives.gov.uk/doc/open-government-licence/"
           rel="license">Open Government

--- a/doc/etc/rose-rug-advanced-tutorials-widget/username.py.start.html
+++ b/doc/etc/rose-rug-advanced-tutorials-widget/username.py.start.html
@@ -50,7 +50,7 @@
           <li><span class="navbar-text"><span class=
           "compliance">&#169; British Crown Copyright 2012-6
           <a href="http://www.metoffice.gov.uk">Met Office</a>. See
-          <a href="rose-terms-of-use.html">Terms of Use</a>.<br />
+          <a href="../../rose-terms-of-use.html">Terms of Use</a>.<br />
           This document is released under the <a href=
           "http://www.nationalarchives.gov.uk/doc/open-government-licence/"
           rel="license">Open Government

--- a/doc/etc/rose-rug-suite-writing-tutorial/src/dead_reckoning.f90.html
+++ b/doc/etc/rose-rug-suite-writing-tutorial/src/dead_reckoning.f90.html
@@ -51,7 +51,7 @@
           <li><span class="navbar-text"><span class=
           "compliance">&#169; British Crown Copyright 2012-6
           <a href="http://www.metoffice.gov.uk">Met Office</a>. See
-          <a href="rose-terms-of-use.html">Terms of Use</a>.<br />
+          <a href="../../../rose-terms-of-use.html">Terms of Use</a>.<br />
           This document is released under the <a href=
           "http://www.nationalarchives.gov.uk/doc/open-government-licence/"
           rel="license">Open Government

--- a/doc/etc/rose-rug-suite-writing-tutorial/suite.rc.html
+++ b/doc/etc/rose-rug-suite-writing-tutorial/suite.rc.html
@@ -26,7 +26,7 @@
   "../../js/prettify-rose-conf.js">
 </script>
   <script type="text/javascript" src=
-  "../../prettify-cylc-suite-rc.js">
+  "../../js/prettify-cylc-suite-rc.js">
 </script>
   <script type="text/javascript" src="../../js/bootstrap.min.js">
 </script>
@@ -51,7 +51,7 @@
           <li><span class="navbar-text"><span class=
           "compliance">&#169; British Crown Copyright 2012-6
           <a href="http://www.metoffice.gov.uk">Met Office</a>. See
-          <a href="rose-terms-of-use.html">Terms of Use</a>.<br />
+          <a href="../../rose-terms-of-use.html">Terms of Use</a>.<br />
           This document is released under the <a href=
           "http://www.nationalarchives.gov.uk/doc/open-government-licence/"
           rel="license">Open Government

--- a/doc/rose-api.html
+++ b/doc/rose-api.html
@@ -51,9 +51,8 @@
           <a href="http://www.metoffice.gov.uk">Met Office</a>. See
           <a href="rose-terms-of-use.html">Terms of Use</a>.<br />
           This document is released under the <a href=
-          "http://www.nationalarchives.html/rose-api.htmlgov.uk/doc/open-government-licence/"
-          rel="license">Open Government
-          Licence</a>.</span></span></li>
+          "http://www.nationalarchives.gov.uk/doc/open-government-licence/"
+          rel="license">Open Government Licence</a>.</span></span></li>
 
           <li><span id="rose-version" class=
           "navbar-text"></span></li>
@@ -76,7 +75,7 @@
             <h2 id="intro">Introduction</h2>
 
             <p>Rose is mainly implemented in <a href=
-            "www.python.org">Python</a> and <a href=
+            "http://www.python.org">Python</a> and <a href=
             "http://www.gnu.org/software/bash/">bash</a>.</p>
 
             <p>The sub-sections below explain how to make use of
@@ -92,7 +91,7 @@
 
             <p>The Rose/Rosie GUIs (such as the config editor) are
             written using the Python bindings for the GTK GUI
-            toolkit (<a href="www.pygtk.org">PyGTK</a>). You can
+            toolkit (<a href="http://www.pygtk.org">PyGTK</a>). You can
             write your own custom GTK widgets and use them within
             Rose. They should live with the metadata under the
             <code>lib/python/widget/</code> directory.</p>
@@ -1413,7 +1412,7 @@ class Upgrade272to273(rose.upgrade.MacroUpgrade):
             "http://en.wikipedia.org/wiki/Representational_state_transfer">
             RESTful</a> API to interrogate a web server, which then
             interrogates an <a href=
-            "http://planetofcoders.com/rdbms/">RDBMS</a>. Returned
+            "http://www.planetofcoders.com/rdbms/">RDBMS</a>. Returned
             data is encoded in the <a href=
             "http://www.json.org/">JSON</a> format.</p>
 

--- a/doc/rose-configuration.html
+++ b/doc/rose-configuration.html
@@ -980,7 +980,7 @@ delays=0,6*PT10S,60*PT1M,PT1H
             File: Built-in Application: rose_ana</h3>
 
             <p>See <a href=
-            "rose-rug-task-run.html#rose-task-run.built-in-app.rose_ana">
+            "rose-rug-task-run.html#rose-task-run.util.rose_ana">
             Running Tasks &gt; rose task-run &gt; Built-in
             Application: rose_ana</a> and <a href=
             "rose-rug-stem.html#rose-ana">rose stem &gt; Analysing
@@ -990,7 +990,7 @@ delays=0,6*PT10S,60*PT1M,PT1H
             File: Built-in Application: rose_arch</h3>
 
             <p>See <a href=
-            "rose-rug-task-run.html#rose-task-run.built-in-app.rose_arch">
+            "rose-rug-task-run.html#rose-task-run.util.rose_arch">
             Running Tasks &gt; rose task-run &gt; Built-in
             Application: rose_arch</a>.</p>
 
@@ -998,7 +998,7 @@ delays=0,6*PT10S,60*PT1M,PT1H
             File: Built-in Application: rose_prune</h3>
 
             <p>See <a href=
-            "rose-rug-task-run.html#rose-task-run.built-in-app.rose_prune">
+            "rose-rug-task-run.html#rose-task-run.util.rose_prune">
             Running Tasks &gt; rose task-run &gt; Built-in
             Application: rose_prune</a>.</p>
 

--- a/doc/rose-rug-advanced-tutorials-arch.html
+++ b/doc/rose-rug-advanced-tutorials-arch.html
@@ -134,7 +134,7 @@
             <div class="slide">
               <h2 id="example">Example</h2>
 
-              <p>Create a <a href="rose-rug-brief-tour#cli">new
+              <p>Create a <a href="rose-rug-brief-tour.html#cli">new
               suite</a> (or just a new directory somewhere - e.g.
               in your homespace) containing a blank
               <samp>rose-suite.conf</samp> and a

--- a/doc/rose-rug-advanced-tutorials-broadcast.html
+++ b/doc/rose-rug-advanced-tutorials-broadcast.html
@@ -118,7 +118,7 @@
             <div class="slide">
               <h2 id="example-task">Task-based Example</h2>
 
-              <p>Create a <a href="rose-rug-brief-tour#cli">new
+              <p>Create a <a href="rose-rug-brief-tour.html#cli">new
               suite</a> (or just a new directory somewhere - e.g.
               in your homespace) containing a blank
               <samp>rose-suite.conf</samp> and a

--- a/doc/rose-rug-advanced-tutorials-bunch.html
+++ b/doc/rose-rug-advanced-tutorials-bunch.html
@@ -142,7 +142,7 @@
               carried and the resulting timings for each stage of
               the landing process.</p>
 
-              <p>Create a <a href="rose-rug-brief-tour#cli">new
+              <p>Create a <a href="rose-rug-brief-tour.html#cli">new
               suite</a> (or just a new directory somewhere - e.g.
               in your homespace) containing a blank
               <samp>rose-suite.conf</samp> and a

--- a/doc/rose-rug-advanced-tutorials-clock-triggered.html
+++ b/doc/rose-rug-advanced-tutorials-clock-triggered.html
@@ -131,7 +131,7 @@
               <p>Our example suite will simulate a clock chiming on
               the hour.</p>
 
-              <p>Create a <a href="rose-rug-brief-tour#cli">new
+              <p>Create a <a href="rose-rug-brief-tour.html#cli">new
               suite</a> (or just a new directory somewhere - e.g.
               in your homespace) containing a blank
               <samp>rose-suite.conf</samp> and a

--- a/doc/rose-rug-advanced-tutorials-command-key.html
+++ b/doc/rose-rug-advanced-tutorials-command-key.html
@@ -111,7 +111,7 @@
             <div class="slide">
               <h2 id="example-task">Example</h2>
 
-              <p>Create a <a href="rose-rug-brief-tour#cli">new
+              <p>Create a <a href="rose-rug-brief-tour.html#cli">new
               suite</a> (or just a new directory somewhere - e.g.
               in your homespace) containing a blank
               <samp>rose-suite.conf</samp> and a

--- a/doc/rose-rug-advanced-tutorials-family-trigs.html
+++ b/doc/rose-rug-advanced-tutorials-family-trigs.html
@@ -116,7 +116,7 @@
             <div class="slide">
               <h2 id="example-task">Example</h2>
 
-              <p>Create a <a href="rose-rug-brief-tour#cli">new
+              <p>Create a <a href="rose-rug-brief-tour.html#cli">new
               suite</a> (or just a new directory somewhere - e.g.
               in your homespace) containing a blank
               <samp>rose-suite.conf</samp> and a

--- a/doc/rose-rug-advanced-tutorials-multi-inherit.html
+++ b/doc/rose-rug-advanced-tutorials-multi-inherit.html
@@ -109,7 +109,7 @@
               width="70%" alt=
               "Drag race starting in Saskatoon, Saskatchewan" />
 
-              <p>Create a <a href="rose-rug-brief-tour#cli">new
+              <p>Create a <a href="rose-rug-brief-tour.html#cli">new
               suite</a> (or just a new directory somewhere - e.g.
               in your homespace) containing a blank
               <samp>rose-suite.conf</samp> and a
@@ -130,7 +130,7 @@
               the suite output.</p>
 
               <p>We also need to copy the library <a href=
-              "jquery.min.js">jquery.min.js</a> into the same
+              "js/jquery.min.js">jquery.min.js</a> into the same
               directory.</p>
             </div>
 
@@ -475,7 +475,7 @@ extended/overwritten by red_car
               Inheritance (5)</h3>
               <p>This is a case of
               <a href=
-              "http://mypythonnotes.wordpress.com/2008/11/01/python-multiple-inheritance-and-the-diamond-problem/">
+                "https://en.wikipedia.org/wiki/Multiple_inheritance#The_diamond_problem">
               diamond inheritance</a>, where the diagram goes:</p>
               <pre>
         root

--- a/doc/rose-rug-advanced-tutorials-opt-conf.html
+++ b/doc/rose-rug-advanced-tutorials-opt-conf.html
@@ -111,7 +111,7 @@
               "http://upload.wikimedia.org/wikipedia/commons/3/37/Helados.jpg"
               width="30%" alt="Icecreams (wikipedia)" />
 
-              <p>Create a <a href="rose-rug-brief-tour#cli">new
+              <p>Create a <a href="rose-rug-brief-tour.html#cli">new
               suite</a> (or just a new directory somewhere - e.g.
               in your homespace) containing a blank
               <samp>rose-suite.conf</samp> and a

--- a/doc/rose-rug-advanced-tutorials-polling.html
+++ b/doc/rose-rug-advanced-tutorials-polling.html
@@ -111,7 +111,7 @@
             <div class="slide">
               <h2 id="example-task">Example</h2>
 
-              <p>Create a <a href="rose-rug-brief-tour#cli">new
+              <p>Create a <a href="rose-rug-brief-tour.html#cli">new
               suite</a> (or just a new directory somewhere - e.g.
               in your homespace) containing a blank
               <samp>rose-suite.conf</samp> and a

--- a/doc/rose-rug-advanced-tutorials-queues.html
+++ b/doc/rose-rug-advanced-tutorials-queues.html
@@ -113,7 +113,7 @@
               <p>In this example, our suite manages a particularly
               understaffed restaurant.</p>
 
-              <p>Create a <a href="rose-rug-brief-tour#cli">new
+              <p>Create a <a href="rose-rug-brief-tour.html#cli">new
               suite</a> (or just a new directory somewhere - e.g.
               in your homespace) containing a blank
               <samp>rose-suite.conf</samp> and a

--- a/doc/rose-rug-advanced-tutorials-remotes.html
+++ b/doc/rose-rug-advanced-tutorials-remotes.html
@@ -112,7 +112,7 @@
             <div class="slide">
               <h2 id="example-task">Example</h2>
 
-              <p>Create a <a href="rose-rug-brief-tour#cli">new
+              <p>Create a <a href="rose-rug-brief-tour.html#cli">new
               suite</a> (or just a new directory somewhere - e.g.
               in your homespace) containing a blank
               <samp>rose-suite.conf</samp> and a

--- a/doc/rose-rug-advanced-tutorials-retries.html
+++ b/doc/rose-rug-advanced-tutorials-retries.html
@@ -121,7 +121,7 @@
               <p>Our example suite will simulate trying to roll
               doubles using two dice.</p>
 
-              <p>Create a <a href="rose-rug-brief-tour#cli">new
+              <p>Create a <a href="rose-rug-brief-tour.html#cli">new
               suite</a> (or just a new directory somewhere - e.g.
               in your homespace) containing a blank
               <samp>rose-suite.conf</samp> and a

--- a/doc/rose-rug-advanced-tutorials-suicide.html
+++ b/doc/rose-rug-advanced-tutorials-suicide.html
@@ -112,7 +112,7 @@
             <div class="slide">
               <h2 id="example-task">Example</h2>
 
-              <p>Create a <a href="rose-rug-brief-tour#cli">new
+              <p>Create a <a href="rose-rug-brief-tour.html#cli">new
               suite</a> (or just a new directory somewhere - e.g.
               in your homespace) containing a blank
               <samp>rose-suite.conf</samp> and a
@@ -331,7 +331,7 @@ fi
               <samp>check</samp> or <samp>recovery</samp>
               tasks.</p>
 
-              <p>Create a <a href="rose-rug-brief-tour#cli">new
+              <p>Create a <a href="rose-rug-brief-tour.html#cli">new
               suite</a> (or just a new directory somewhere - e.g.
               in your homespace) containing a <samp>suite.rc</samp>
               file that looks like this:</p>
@@ -435,7 +435,7 @@ fi
               if they succeed or fail then then go to the
               <samp>housekeep</samp> task.</p>
 
-              <p>Create a <a href="rose-rug-brief-tour#cli">new
+              <p>Create a <a href="rose-rug-brief-tour.html#cli">new
               suite</a> (or just a new directory somewhere - e.g.
               in your homespace) containing a <samp>suite.rc</samp>
               file that looks like this:</p>
@@ -554,7 +554,7 @@ fi
               <samp>move_data</samp> then go to
               the<samp>housekeep</samp> task.</p>
 
-              <p>Create a <a href="rose-rug-brief-tour#cli">new
+              <p>Create a <a href="rose-rug-brief-tour.html#cli">new
               suite</a> (or just a new directory somewhere - e.g.
               in your homespace) containing a <samp>suite.rc</samp>
               file that looks like this:</p>

--- a/doc/rose-rug-advanced-tutorials-suite-date-time.html
+++ b/doc/rose-rug-advanced-tutorials-suite-date-time.html
@@ -114,7 +114,7 @@
               width="30%" alt=
               "Bora-Bora Airport, French Polynesia (wikipedia)" />
 
-              <p>Create a <a href="rose-rug-brief-tour#cli">new
+              <p>Create a <a href="rose-rug-brief-tour.html#cli">new
               suite</a> (or just a new directory somewhere - e.g.
               in your homespace) containing a blank
               <samp>rose-suite.conf</samp> and a

--- a/doc/rose-rug-advanced-tutorials-trigger.html
+++ b/doc/rose-rug-advanced-tutorials-trigger.html
@@ -187,7 +187,8 @@ trigger=namelist:pizza_order=truffle: this &gt; 25;
               25</samp> part). Here, <samp>this</samp> is a
               placeholder for the value of <var>env=BUDGET</var>;
               the expression syntax is essentially <a href=
-              "rose-rug-metadata.html#logicsyntax">Pythonic</a>.</p>
+              "rose-rug-metadata.html#metadata-fancy-logicsyntax"
+              >Pythonic</a>.</p>
             </div>
 
             <div class="slide">

--- a/doc/rose-rug-appendix-training.html
+++ b/doc/rose-rug-appendix-training.html
@@ -121,11 +121,11 @@
               <li>1430 - 1545: Desk Work: Selected <a href=
               "rose.html#advanced-meta">Advanced Metadata
               Tutorials</a> (upgrading <a href=
-              "rose-rug-advanced-tutorial-upgrade-usage.html">usage</a>
+              "rose-rug-advanced-tutorials-upgrade-usage.html">usage</a>
               and <a href=
-              "rose-rug-advanced-tutorial-upgrade-dev.html">macro
+              "rose-rug-advanced-tutorials-upgrade-dev.html">macro
               development</a> and <a href=
-              "rose-rug-advanced-tutorial-trigger.html">trigger</a>
+              "rose-rug-advanced-tutorials-trigger.html">trigger</a>
               tutorials are recommended)</li>
 
               <li>1545 - 1615: User Feedback and Conclusion</li>

--- a/doc/rose-rug-brief-tour.html
+++ b/doc/rose-rug-brief-tour.html
@@ -106,8 +106,8 @@
                 correctly on your system.</p>
 
                 <p>You should also have looked at the <a href=
-                "rose-rug-getting-started.html#user">Getting
-                Started (User)</a> page.</p>
+                "rose-rug-getting-started.html">Getting
+                Started</a> page.</p>
               </div>
 
               <div class="slide">

--- a/doc/rose-rug-introduction.html
+++ b/doc/rose-rug-introduction.html
@@ -529,7 +529,7 @@ l_exclamation_mark=.true.,
                 more often in a shared central location.</p>
 
                 <p>You'll be looking at metadata in the <a href=
-                "rose-rug-metadata-tutorial">Metadata Tutorial</a>
+                "rose-rug-metadata-tutorial.html">Metadata Tutorial</a>
                 later.</p>
               </div>
 

--- a/doc/rose-rug-metadata.html
+++ b/doc/rose-rug-metadata.html
@@ -177,7 +177,7 @@ meta=rose-demo/upgrade/27.1
                 <samp>meta/</samp> subdirectory in a suite or an
                 application, which will override the others (e.g.
                 as in the <a href=
-                "rose-rug-metadata-tutorial">Metadata
+                "rose-rug-metadata-tutorial.html">Metadata
                 Tutorial</a>).</p>
               </div>
 

--- a/doc/rose-rug-suites-I.html
+++ b/doc/rose-rug-suites-I.html
@@ -151,8 +151,8 @@
                 <p>cylc was originally developed by <a href=
                 "https://github.com/hjoliver">Hilary Oliver</a> at
                 <a href="http://www.niwa.co.nz/">NIWA</a>. It runs
-                their <a href=
-                "http://ecoconnect.niwa.co.nz/">EcoConnect</a>
+                their <!--a href=   ### REMOVING LINK UNTIL SITE FIXED ###
+                "http://ecoconnect.niwa.co.nz/"-->EcoConnect<!--/a-->
                 operational suite.</p><img class="centre-slide" src=
                 "http://cylc.github.io/cylc/graphics/png/scaled/niwa-colour-small.png"
                 alt="NIWA logo" />
@@ -174,8 +174,8 @@
                 the Met Office.</p>
 
                 <p>cylc is written in <a href=
-                "www.python.org">Python</a> and uses <a href=
-                "www.pygtk.org">PyGTK</a> for its GUIs. It is open
+                "http://www.python.org">Python</a> and uses <a href=
+                "http://www.pygtk.org">PyGTK</a> for its GUIs. It is open
                 source and licensed under <a href=
                 "http://www.gnu.org/licenses/gpl.html">GPL
                 v3</a>.</p>

--- a/doc/rose-rug-task-run.html
+++ b/doc/rose-rug-task-run.html
@@ -448,7 +448,7 @@ file-test=test -e {} &amp;&amp; grep -q 'hello' {}
             The syntax looks like <var>[R*][P]</var>, where
             <var>R</var> is the number of repeats, <var>P</var> is
             the ISO8601 date-time format syntax, see <a href=
-            "wiki:http://en.wikipedia.org/wiki/ISO_8601">wikipedia
+            "http://en.wikipedia.org/wiki/ISO_8601">wikipedia
             entry</a> (last checked on 2015-05-29). E.g.:</p>
             <pre class="prettyprint lang-rose_conf">
 # Default

--- a/doc/template/etc.html
+++ b/doc/template/etc.html
@@ -37,7 +37,7 @@
               <span class="compliance">
                 &#169; British Crown Copyright 2012-6
                 <a href="http://www.metoffice.gov.uk">Met Office</a>.
-                See <a href="rose-terms-of-use.html">Terms of Use</a>.<br />
+                See <a href="../rose-terms-of-use.html">Terms of Use</a>.<br />
                 This document is released under the
                 <a href=
                 "http://www.nationalarchives.gov.uk/doc/open-government-licence/"

--- a/doc/template/regular.html
+++ b/doc/template/regular.html
@@ -33,7 +33,7 @@
       <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
         <ul class="nav navbar-nav">
           <li>
-            <a href="rose-single-page.html">Single Page Version</a>
+            <a href="../rose-single-page.html">Single Page Version</a>
           </li>
         </ul>
 
@@ -44,7 +44,7 @@
               <span class="compliance">
                 &#169; British Crown Copyright 2012-6
                 <a href="http://www.metoffice.gov.uk">Met Office</a>.
-                See <a href="rose-terms-of-use.html">Terms of Use</a>.<br />
+                See <a href="../rose-terms-of-use.html">Terms of Use</a>.<br />
                 This document is released under the
                 <a href=
                 "http://www.nationalarchives.gov.uk/doc/open-government-licence/"

--- a/doc/template/slides.html
+++ b/doc/template/slides.html
@@ -38,7 +38,7 @@
       <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
         <ul class="nav navbar-nav">
           <li>
-            <a href="rose-single-page.html">Single Page Version</a>
+            <a href="../rose-single-page.html">Single Page Version</a>
           </li>
           <li><a href="javascript:toggle()">S5 Slideshow</a></li>
         </ul>
@@ -50,7 +50,7 @@
               <span class="compliance">
                 &#169; British Crown Copyright 2012-6
                 <a href="http://www.metoffice.gov.uk">Met Office</a>.
-                See <a href="rose-terms-of-use.html">Terms of Use</a>.<br />
+                See <a href="../rose-terms-of-use.html">Terms of Use</a>.<br />
                 This document is released under the
                 <a href=
                 "http://www.nationalarchives.gov.uk/doc/open-government-licence/"

--- a/t/docs/00-urls.t
+++ b/t/docs/00-urls.t
@@ -1,0 +1,30 @@
+#!/bin/bash
+#-------------------------------------------------------------------------------
+# (C) British Crown Copyright 2012-6 Met Office.
+#
+# This file is part of Rose, a framework for meteorological suites.
+#
+# Rose is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Rose is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Rose. If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test "rose date".
+#-------------------------------------------------------------------------------
+. $(dirname $0)/test_header
+#-------------------------------------------------------------------------------
+tests 2
+#-------------------------------------------------------------------------------
+# Validate URLs in the rose docs (see test 01-validate-validator.t for defailt.
+run_pass ${TEST_KEY_BASE} python $TEST_SOURCE_DIR/lib/python/urlvalidator.py "${ROSE_HOME}/doc/"
+file_cmp "${TEST_KEY_BASE}.err" "${TEST_KEY_BASE}.err" <'/dev/null'
+
+exit

--- a/t/docs/00-urls.t
+++ b/t/docs/00-urls.t
@@ -17,13 +17,12 @@
 # You should have received a copy of the GNU General Public License
 # along with Rose. If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
-# Test "rose date".
+# Test rose documentation for broken links.
 #-------------------------------------------------------------------------------
 . $(dirname $0)/test_header
 #-------------------------------------------------------------------------------
 tests 2
 #-------------------------------------------------------------------------------
-# Validate URLs in the rose docs (see test 01-validate-validator.t for defailt.
 run_pass ${TEST_KEY_BASE} python $TEST_SOURCE_DIR/lib/python/urlvalidator.py "${ROSE_HOME}/doc/"
 file_cmp "${TEST_KEY_BASE}.err" "${TEST_KEY_BASE}.err" <'/dev/null'
 

--- a/t/docs/01-validate-validator.t
+++ b/t/docs/01-validate-validator.t
@@ -1,0 +1,39 @@
+#!/bin/bash
+#-------------------------------------------------------------------------------
+# (C) British Crown Copyright 2012-6 Met Office.
+#
+# This file is part of Rose, a framework for meteorological suites.
+#
+# Rose is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Rose is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Rose. If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test "rose date".
+#-------------------------------------------------------------------------------
+. $(dirname $0)/test_header
+#-------------------------------------------------------------------------------
+tests 10
+#-------------------------------------------------------------------------------
+# Test the URL validator script for correct functioning.
+run_fail ${TEST_KEY_BASE} python $TEST_SOURCE_DIR/lib/python/urlvalidator.py \
+  "$TEST_SOURCE_DIR"
+file_grep $TEST_KEY_BASE-link "some-file\.css" "${TEST_KEY_BASE}.err"
+file_grep $TEST_KEY_BASE-script "some-file\.js" "${TEST_KEY_BASE}.err"
+file_grep $TEST_KEY_BASE-link2 "some-file\.png" "${TEST_KEY_BASE}.err"
+file_grep $TEST_KEY_BASE-img "some-file\.jpeg" "${TEST_KEY_BASE}.err"
+file_grep $TEST_KEY_BASE-anchor "some-link\.html" "${TEST_KEY_BASE}.err"
+file_grep $TEST_KEY_BASE-anchor2 "another-link\.html" "${TEST_KEY_BASE}.err"
+file_grep $TEST_KEY_BASE-nested-img "another-file\.jpeg" "${TEST_KEY_BASE}.err"
+file_grep $TEST_KEY_BASE-malformed "www.malformed\.html" "${TEST_KEY_BASE}.err"
+file_grep_fail $TEST_KEY_BASE-pre "dont-match\.html" "${TEST_KEY_BASE}.err"
+
+exit

--- a/t/docs/01-validate-validator.t
+++ b/t/docs/01-validate-validator.t
@@ -17,13 +17,12 @@
 # You should have received a copy of the GNU General Public License
 # along with Rose. If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
-# Test "rose date".
+# Test the URL validator used in t/docs/00-urls.t.
 #-------------------------------------------------------------------------------
 . $(dirname $0)/test_header
 #-------------------------------------------------------------------------------
 tests 10
 #-------------------------------------------------------------------------------
-# Test the URL validator script for correct functioning.
 run_fail ${TEST_KEY_BASE} python $TEST_SOURCE_DIR/lib/python/urlvalidator.py \
   "$TEST_SOURCE_DIR"
 file_grep $TEST_KEY_BASE-link "some-file\.css" "${TEST_KEY_BASE}.err"

--- a/t/docs/02-macro-tutorial.t
+++ b/t/docs/02-macro-tutorial.t
@@ -1,0 +1,30 @@
+#!/bin/bash
+#-------------------------------------------------------------------------------
+# (C) British Crown Copyright 2012-6 Met Office.
+#
+# This file is part of Rose, a framework for meteorological suites.
+#
+# Rose is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Rose is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Rose. If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test "rose date".
+#-------------------------------------------------------------------------------
+. $(dirname $0)/test_header
+#-------------------------------------------------------------------------------
+tests 2
+#-------------------------------------------------------------------------------
+# Validate URLs in the rose docs (see test 01-validate-validator.t for defailt.
+run_pass ${TEST_KEY_BASE} python $TEST_SOURCE_DIR/lib/python/heavens_above.py
+file_cmp "${TEST_KEY_BASE}.err" "${TEST_KEY_BASE}.err" <'/dev/null'
+
+exit

--- a/t/docs/02-macro-tutorial.t
+++ b/t/docs/02-macro-tutorial.t
@@ -17,13 +17,12 @@
 # You should have received a copy of the GNU General Public License
 # along with Rose. If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
-# Test "rose date".
+# Test that the rose macro tutorials still work.
 #-------------------------------------------------------------------------------
 . $(dirname $0)/test_header
 #-------------------------------------------------------------------------------
 tests 2
 #-------------------------------------------------------------------------------
-# Validate URLs in the rose docs (see test 01-validate-validator.t for defailt.
 run_pass ${TEST_KEY_BASE} python $TEST_SOURCE_DIR/lib/python/heavens_above.py
 file_cmp "${TEST_KEY_BASE}.err" "${TEST_KEY_BASE}.err" <'/dev/null'
 

--- a/t/docs/lib/python/heavens_above.py
+++ b/t/docs/lib/python/heavens_above.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2012-6 Met Office.
+#
+# This file is part of Rose, a framework for meteorological suites.
+#
+# Rose is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Rose is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Rose. If not, see <http://www.gnu.org/licenses/>.
+# -----------------------------------------------------------------------------
+"""Tests the data-scraping algorithm used in the rose macro advanced tutorial
+is still working."""
+import re
+import requests
+import sys
+
+def main():
+    # Get data
+    ret = requests.get("http://www.heavens-above.com/planetsummary.aspx")
+    assert ret.status_code == 200
+    text = '\n'.join(list(ret.iter_lines()))
+    planets = re.findall("(\w+)</td>",
+                         re.sub(r'(?s)^.*(<thead.*?ascension).*$',
+                                r"\1", text))
+
+    # Test code used in the validator macro
+    distances = re.findall("([\d.]+)</td>",
+                           re.sub('(?s)^.*(Range.*?Brightness).*$',
+                                  r"\1", text))
+    assert len(planets) == len(distances)
+    map(float, distances)
+
+    # Test code used in the reporter macro
+    constellations = re.findall("(\w+)</a>",
+                           re.sub('(?s)^.*(Constellation.*?Meridian).*$',
+                                  r"\1", text))
+    assert len(planets) == len(constellations)
+
+if __name__ == '__main__':
+    main()
+    sys.exit(0)

--- a/t/docs/lib/python/urlvalidator.py
+++ b/t/docs/lib/python/urlvalidator.py
@@ -1,0 +1,184 @@
+"""A crude URL validator"""
+from multiprocessing import Pool
+import os
+import re
+import requests
+import sys
+import warnings
+
+# Ignore warnings raised as a result of negating verification in ssl requests.
+from requests.packages.urllib3.exceptions import InsecureRequestWarning
+warnings.filterwarnings('ignore', category=InsecureRequestWarning)
+
+
+# Regexes.
+URL_PATTERN = re.compile(r'<(?:a|img|link|script)[^>]+(?:src|href)='
+                         r'(?:[\s\n]+)?"([^"]+)"(?:[^>]+)?>')
+FRAG_PATTERN = re.compile(r'(?:id)=(?:[\n\s]+)?"([^"]+)"')
+
+# External URL validation parameters.
+POOL_THROTTLE = 5
+TIMEOUT = 5
+
+# Error types.
+PAGE_NOT_FOUND = 'Page not found'
+FRAGMENT_NOT_FOUND = 'Fragment not found'
+URL_REDIRECT = 'Encountered a permanent redirect'
+URL_TIMEOUT_STRING = 'Server timeout.'
+INVALID_URL = 'Invalid URL'
+CONNECTION_ERROR = 'Connection error.'
+HTTP_ERROR = 'Non 2xx return code detected "{0}".'
+
+
+def get_files_by_extension(root_dir, extension):
+    """Rough equivalent to `find <root_dir> -name \*.<extension>`."""
+    for root, _, files in os.walk(root_dir):
+        for file_ in files:
+            if os.path.splitext(file_)[1] != '.' + extension:
+                continue
+            yield os.path.join(root, file_)
+
+def validate_fragments(fragments):
+    """Ensure URL fragments for internal links match DOM elements (id=...)."""
+    errors = []
+    ids = {}
+    for fragment, file_, src in fragments:
+        if file_ not in ids:
+            if not os.path.exists(file_):
+                errors.append((fragment, file_, PAGE_NOT_FOUND))
+                continue
+            with open(file_, 'r') as html_file:
+                matches = FRAG_PATTERN.findall(html_file.read())
+                ids[file_] = matches
+        if fragment not in ids[file_]:
+            errors.append((file_ + '#' + fragment, src, FRAGMENT_NOT_FOUND))
+    return errors
+
+def validate_internal(urls):
+    """Ensure internal URLs match files, return URL fragments for further
+    validation."""
+    errors = []
+    fragments = []
+    for url, file_ in urls:
+        if '#' in url:
+            path, fragment = url.rsplit('#', 1)
+        else:
+            path = url
+            fragment = None
+        path = os.path.join(os.path.dirname(file_), path)
+        if not os.path.exists(path):
+            errors.append((url, file_, PAGE_NOT_FOUND))
+            continue
+        if fragment:
+            fragments.append((fragment, path, file_))
+    return errors, fragments
+
+def validate_external(urls):
+    """Ensure external URLs point to valid sites.
+
+    Uses a multiprocessing pool for performing http requests."""
+    errors = []
+    pool = Pool(POOL_THROTTLE)
+    rets = pool.map(validate_url, urls.keys())
+    for error, (url, file_) in zip(rets, urls.iteritems()):
+        if error:
+            errors.append((url, file_, error,))
+    return errors
+
+def validate_url(url, full=False, verify=True):
+    """Test that a URL points to a valid page.
+
+    Ignores status codes 2xx, 301, 302, 303, 308, reports anything else."""
+    # Some sites don't like the python user agent.
+    headers = {'User-Agent': 'Mozilla/5.0'}
+    # Request method.
+    if full:
+        method = requests.get
+    else:
+        method = requests.head
+    try:
+        response = method(url, timeout=TIMEOUT, allow_redirects=True,
+                          headers=headers, verify=verify)
+    except requests.exceptions.Timeout:
+        return URL_TIMEOUT_STRING
+    except requests.exceptions.MissingSchema:
+        return INVALID_URL
+    except requests.exceptions.ConnectionError:
+        if verify:
+            # Try again without ssl verification (ok with safe urls).
+            return validate_url(url, full, verify=False)
+        return CONNECTION_ERROR
+    except requests.exceptions.HTTPError:
+        return PAGE_NOT_FOUND
+    else:
+        code = int(response.status_code)
+        if code in [301, 302, 303, 308]:
+            #errors.append((url, file_, URL_REDIRECT))
+            pass
+        if code == 405 and not full:
+            # If we get a "method not allowed" try using a get request (slow).
+            return validate_url(url, full=True)
+        elif code < 200 or code >= 300:
+            return HTTP_ERROR.format(code)
+    return None
+
+def report_invalid_urls(int_errors, ext_errors, frg_errors, malformed):
+    """Print out list of errors."""
+    errors_by_file = {}
+    for url, file_, error in int_errors + ext_errors + frg_errors + malformed:
+        if file_ not in errors_by_file:
+            errors_by_file[file_] = []
+        errors_by_file[file_].append((url, error,))
+
+    if errors_by_file:
+        print >> sys.stderr, 'Errors found in the following files:'
+    for file_, errors in errors_by_file.iteritems():
+        print >> sys.stderr
+        print >> sys.stderr, '\t', file_
+        for url, error in errors:
+            print >> sys.stderr, '\t\t"{url}"  -  "{error}"'.format(
+                url=url, error=error)
+
+def main(root):
+    """Extract and check all URLs on the site located at root."""
+    external = {}
+    internal = []
+    fragments = []
+    malformed = []
+    for file_ in get_files_by_extension(root, 'html'):
+        with open(file_, 'r') as html_file:
+            matches = URL_PATTERN.findall(html_file.read())
+            for url in matches:
+                if url.startswith('mailto:'):
+                    # We aren't validating email addresses.
+                    continue
+                if url.startswith('javascript:'):
+                    # We arent validating javascript functions.
+                    continue
+                if url.startswith('#') and len(url) > 1:
+                    # URL fragment (on current page).
+                    fragments.append((url[1:], file_, file_))
+                elif url.startswith('www.'):
+                    malformed.append((url, file_, INVALID_URL))
+                elif url.startswith('http'):
+                    if url not in external:
+                        external[url] = file_
+                else:
+                    internal.append((url, file_,))
+
+    int_errors, new_frags = validate_internal(internal)
+    ext_errors = validate_external(external)
+    frg_errors = validate_fragments(new_frags + fragments)
+
+    report_invalid_urls(int_errors, ext_errors, frg_errors, malformed)
+
+    if int_errors or ext_errors or frg_errors or malformed:
+        sys.exit(1)
+    sys.exit(0)
+
+if __name__ == '__main__':
+    if len(sys.argv) != 2:
+        print ('Usage: Please supply root directory to validate the contents '
+               'of.')
+        sys.exit(1)
+    main(sys.argv[1])

--- a/t/docs/lib/python/urlvalidator.py
+++ b/t/docs/lib/python/urlvalidator.py
@@ -197,7 +197,6 @@ def main(root):
 
 if __name__ == '__main__':
     if len(sys.argv) != 2:
-        print ('Usage: Please supply root directory to validate the contents '
-               'of.')
-        sys.exit(1)
+        sys.exit('Usage: Please supply root directory to validate the '
+                 'contents of.')
     main(sys.argv[1])

--- a/t/docs/lib/python/urlvalidator.py
+++ b/t/docs/lib/python/urlvalidator.py
@@ -1,3 +1,22 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2012-6 Met Office.
+#
+# This file is part of Rose, a framework for meteorological suites.
+#
+# Rose is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Rose is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Rose. If not, see <http://www.gnu.org/licenses/>.
+# -----------------------------------------------------------------------------
 """A crude URL validator"""
 from multiprocessing import Pool
 import os

--- a/t/docs/test_header
+++ b/t/docs/test_header
@@ -1,0 +1,1 @@
+../lib/bash/test_header

--- a/t/docs/validation/example.html
+++ b/t/docs/validation/example.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" href=
+    "some-file.css" type="test/css" />
+    <script
+    type=
+    "text/javascript"
+    src=
+    "some-file.js"
+    ></script>
+    <link rel="icon" href="some-file.png" />
+  </head>
+  <body>
+    <img width="20px" src="some-file.jpeg" height="20px" />
+    <a data-key="value" href="http://some-link.html">meh</a>
+    <a href="http://another-link.html">
+      <img src="another-file.jpeg" />
+    </a>
+    <pre>
+&gt;a href="http://dont-match.html"&lt;link&gt;/a&lt;
+    </pre>
+    <a data-key="value" href="www.malformed.html">meh</a>
+  </body>
+</html>


### PR DESCRIPTION
Added a test to detect broken links. Detects:
- External Links
    - Page exists and returns a sensible HTTP code.
- Internal Links
    - Page exists
    - URL fragments (e.g. example.com#fragment) reference sections that are present

Fixed many broken links.

Caveats:
- At present some URLs fail for SSL reasons, the crude solution implemented is to retry the affected URLs with SSL verification turned **OFF**! As this testing will only be done on URLs we have put into the docs. If you think this is a problem I can spend some time trying to get around it.
- Does not check URL fragments on external sites (would require downloading the whole page).

@matthewrmshin @arjclark Please Review.
