### PR TITLE
rose bush: suites list: misc fixes

### DIFF
--- a/lib/html/template/rose-bush/suites.html
+++ b/lib/html/template/rose-bush/suites.html
@@ -170,13 +170,13 @@ class="table table-bordered table-condensed table-striped">
       <td><small>{{entry.name}}</small></td>
       <td>
         <small>
-          <a href="{{script}}/cycles/{{user}}/{{entry.name|replace('/', '%2F')}}">cycles list</a>
+          <a href="{{script}}/cycles/{{user}}/?suite={{entry.name|replace('/', '%2F')}}">cycles list</a>
         </small>
       </td>
 
       <td>
         <small>
-          <a href="{{script}}/taskjobs/{{user}}/{{entry.name|replace('/', '%2F')}}">task jobs list</a>
+          <a href="{{script}}/taskjobs/{{user}}/?suite={{entry.name|replace('/', '%2F')}}">task jobs list</a>
         </small>
       </td>
 

--- a/lib/python/rose/bush.py
+++ b/lib/python/rose/bush.py
@@ -413,7 +413,8 @@ class RoseBushService(object):
         # Get entries
         sub_names = [
             ".service", "log", "share", "work", self.bush_dao.SUITE_CONF]
-        for dirpath, dnames, fnames in os.walk(user_suite_dir_root):
+        for dirpath, dnames, fnames in os.walk(
+                user_suite_dir_root, followlinks=True):
             if any([name in dnames or name in fnames for name in sub_names]):
                 dnames[:] = []
             else:

--- a/t/rose-bush/08-suites-page.t
+++ b/t/rose-bush/08-suites-page.t
@@ -54,7 +54,13 @@ SUITE_NAME_1_PREFIX="rtb-rose-bush-08-$(uuidgen)-"
 for SUFFIX in 'b' 'a' 'c'; do
     SUITE_NAME="${SUITE_NAME_1_PREFIX}${SUFFIX}"
     SUITE_DIR="${HOME}/cylc-run/${SUITE_NAME}"
-    mkdir -p "${SUITE_DIR}"
+    # Make one of these a symlink
+    if [[ "${SUFFIX}" == 'a' ]]; then
+        mkdir "${SUITE_NAME}"
+        ln -s "${PWD}/${SUITE_NAME}" "${SUITE_DIR}"
+    else
+        mkdir -p "${SUITE_DIR}"
+    fi
     cp -p 'suite.rc' "${SUITE_DIR}/suite.rc"
     cylc register "${SUITE_NAME}" "${SUITE_DIR}"
     cylc run --debug "${SUITE_NAME}" 2>'/dev/null' \


### PR DESCRIPTION
Fix link to suites with slashes - the normal cherrypy magic
does not work here - suite names need to be proper arguments.

Ensure `os.walk` follows symbolic links when looking for suites.