### PR TITLE
bush: turned auto-complete off for seq-log forms.

### DIFF
--- a/lib/html/template/rose-bush/job-entry.html
+++ b/lib/html/template/rose-bush/job-entry.html
@@ -195,7 +195,8 @@
         <ul class="list-inline">
           {% for seq_key, indexes in entry.seq_logs_indexes|dictsort -%}
             <li>
-              <form action="{{script}}/view" class="form-inline">
+              <form action="{{script}}/view" class="form-inline"
+                autocomplete="off">
                 <input type="hidden" name="user" value="{{user}}"/>
                 <input type="hidden" name="suite" value="{{suite|replace("/", "%2F")}}"/>
                 <input type="hidden" name="no_fuzzy_time"


### PR DESCRIPTION
From user request. Browsers can attempt to auto-fill the sequential log forms.

Simple example to replicate:
- goto task-jobs page (for a suite with a task that has sequential logs)
- use the combo-box to view a log file
- press back in the browser
- try to open the log file again in the same way