### PR TITLE
edit: prevent radio buttons from filling full page width

### DIFF
--- a/lib/python/rose/config_editor/valuewidget/radiobuttons.py
+++ b/lib/python/rose/config_editor/valuewidget/radiobuttons.py
@@ -42,7 +42,7 @@ class RadioButtonsValueWidget(gtk.HBox):
 
         if var_titles:
             vbox = gtk.VBox()
-            self.pack_start(vbox)
+            self.pack_start(vbox, expand=False)
             vbox.show()
 
         for k, item in enumerate(var_values):


### PR DESCRIPTION
Close #1936 

Turned out to be a really simple fix, see issue for reproduction instructions.