### PR TITLE
Correct mistake in Jinja2 part of training slides.

### DIFF
--- a/doc/rose-rug-suites-I.html
+++ b/doc/rose-rug-suites-I.html
@@ -720,9 +720,9 @@ default=echo 'Hello World'
     [[[dependencies]]]
         graph = """
                 HELLO_FAMILY
-{%- if ARCHIVE_RESULTS %}
+{% if ARCHIVE_RESULTS %}
                 HELLO_FAMILY:succeed-all => archive_results
-{%- endfor %}
+{% endif %}
                 """
 </pre>
               </div>


### PR DESCRIPTION
Mistakenly left an `endfor` in rather than an `endif` in for the refactored jinja2 part of the taught training slides.