### PR TITLE
rose suite-scan: fix `--comms-timeout` option

### DIFF
--- a/lib/python/rose/suite_engine_procs/cylc.py
+++ b/lib/python/rose/suite_engine_procs/cylc.py
@@ -658,7 +658,7 @@ class CylcProcessor(SuiteEngineProcessor):
             hosts = ["localhost"]
         if timeout is None:
             timeout = self.TIMEOUT
-        cmd = ["cylc", "scan", "--pyro-timeout=%s" % timeout] + list(hosts)
+        cmd = ["cylc", "scan", "--comms-timeout=%s" % timeout] + list(hosts)
         proc = self.popen.run_bg(*cmd)
         results = {}
         exceptions = []


### PR DESCRIPTION
The new option replaces the old `--pyro-timeout` option. Bug detected while testing #2044.