### PR TITLE
Fixes for some issues with rose_ana KGO database

### DIFF
--- a/lib/python/rose/apps/rose_ana.py
+++ b/lib/python/rose/apps/rose_ana.py
@@ -51,12 +51,12 @@ class KGODatabase(object):
     # (as it must uniquely identify each row)
     CREATE_COMPARISON_TABLE = """
         CREATE TABLE IF NOT EXISTS comparisons (
-        app_task TEXT,
+        comp_task TEXT,
         kgo_file TEXT,
         suite_file TEXT,
         status TEXT,
         comparison TEXT,
-        PRIMARY KEY(app_task))
+        PRIMARY KEY(comp_task))
         """
     # This SQL command ensures a "tasks" table exists in the database
     # and then populates it with a pair of columns (the task name and
@@ -79,7 +79,7 @@ class KGODatabase(object):
         self.task_name = "task_name not set"
 
     def enter_comparison(
-            self, app_task, kgo_file, suite_file, status, comparison):
+            self, comp_task, kgo_file, suite_file, status, comparison):
         """Add a command to insert a new comparison entry to the database."""
         # This SQL command indicates that a single "row" is to be entered into
         # the "comparisons" table
@@ -88,21 +88,21 @@ class KGODatabase(object):
         # Prepend the task_name onto each entry, to try and ensure it is
         # unique (the individual comparison names may not be, but the rose
         # task name + the comparison task name should)
-        sql_args = [self.task_name + " - " + app_task,
+        sql_args = [self.task_name + " - " + comp_task,
                     kgo_file, suite_file, status, comparison]
         # Add the command and arguments to the buffer
         self.statement_buffer.append((sql_statement, sql_args))
 
-    def enter_task(self, app_task, status):
+    def enter_task(self, task_name, status):
         """Add a command to insert a new task entry to the database."""
         # This SQL command indicates that a single "row" is to be entered into
         # the "tasks" table
         sql_statement = "INSERT OR REPLACE INTO tasks VALUES (?, ?)"
-        sql_args = [app_task, status]
+        sql_args = [task_name, status]
         # Add the command and arguments to the buffer
         self.statement_buffer.append((sql_statement, sql_args))
         # Save the name for use in any comparisons later
-        self.task_name = app_task
+        self.task_name = task_name
 
     @contextmanager
     def database_lock(self, lockfile, reporter=None):

--- a/lib/python/rose/apps/rose_ana.py
+++ b/lib/python/rose/apps/rose_ana.py
@@ -113,7 +113,7 @@ class KGODatabase(object):
             reporter("Acquired DB lock at: " + time.asctime())
         lock.write("{0}".format(os.getpid()))
         if reporter is not None:
-            reporter("Writing results to KGO Database...")
+            reporter("Writing to KGO Database...")
         yield
         fcntl.flock(lock, fcntl.LOCK_UN)
         if reporter is not None:

--- a/lib/python/rose/apps/rose_ana.py
+++ b/lib/python/rose/apps/rose_ana.py
@@ -69,9 +69,14 @@ class KGODatabase(object):
         PRIMARY KEY(task_name))
         """
 
+    # Task statuses
+    TASK_STATUS_RUNNING = 1
+    TASK_STATUS_SUCCEEDED = 0
+
     def __init__(self):
         "Initialise the object."
         self.statement_buffer = []
+        self.task_name = "task_name not set"
 
     def enter_comparison(
             self, app_task, kgo_file, suite_file, status, comparison):
@@ -80,7 +85,11 @@ class KGODatabase(object):
         # the "comparisons" table
         sql_statement = (
             "INSERT OR REPLACE INTO comparisons VALUES (?, ?, ?, ?, ?)")
-        sql_args = [app_task, kgo_file, suite_file, status, comparison]
+        # Prepend the task_name onto each entry, to try and ensure it is
+        # unique (the individual comparison names may not be, but the rose
+        # task name + the comparison task name should)
+        sql_args = [self.task_name + " - " + app_task,
+                    kgo_file, suite_file, status, comparison]
         # Add the command and arguments to the buffer
         self.statement_buffer.append((sql_statement, sql_args))
 
@@ -92,6 +101,8 @@ class KGODatabase(object):
         sql_args = [app_task, status]
         # Add the command and arguments to the buffer
         self.statement_buffer.append((sql_statement, sql_args))
+        # Save the name for use in any comparisons later
+        self.task_name = app_task
 
     @contextmanager
     def database_lock(self, lockfile, reporter=None):
@@ -101,7 +112,8 @@ class KGODatabase(object):
         if reporter is not None:
             reporter("Acquired DB lock at: " + time.asctime())
         lock.write("{0}".format(os.getpid()))
-        reporter("Writing results to KGO Database...")
+        if reporter is not None:
+            reporter("Writing results to KGO Database...")
         yield
         fcntl.flock(lock, fcntl.LOCK_UN)
         if reporter is not None:
@@ -190,6 +202,10 @@ class RoseAnaApp(BuiltinApp):
         self.kgo_db = None
         if use_kgo is not None and use_kgo == ".true.":
             self.kgo_db = KGODatabase()
+            self.kgo_db.enter_task(self.task_name,
+                                   self.kgo_db.TASK_STATUS_RUNNING)
+            self.titlebar("Initialising KGO database")
+            self.kgo_db.buffer_to_db(self.reporter)
 
         self.titlebar("Launching rose_ana")
 
@@ -244,18 +260,11 @@ class RoseAnaApp(BuiltinApp):
                               kind=self.reporter.KIND_ERR)
 
         # The KGO database (if needed by the task) also stores its status - to
-        # indicate whether there was some unexpected exception above.  If there
-        # were no such exceptions only output the task status to the database
-        # if there were other other commands added by the tasks.
-        if self.kgo_db is not None:
-            if task_error:
-                self._kgo_db_task_status(1)
-            elif len(self.kgo_db.statement_buffer) != 0:
-                self._kgo_db_task_status(0)
-
-            if len(self.kgo_db.statement_buffer) != 0:
-                self.titlebar("Updating KGO database")
-
+        # indicate whether there was some unexpected exception above.
+        if self.kgo_db is not None and not task_error:
+            self.kgo_db.enter_task(self.task_name,
+                                   self.kgo_db.TASK_STATUS_SUCCEEDED)
+            self.titlebar("Updating KGO database")
             self.kgo_db.buffer_to_db(self.reporter)
 
         # Summarise the results of the tasks
@@ -287,39 +296,6 @@ class RoseAnaApp(BuiltinApp):
             self.reporter = Reporter(self.opts.verbosity - self.opts.quietness)
         else:
             self.reporter = reporter
-
-    def _kgo_db_add_file_pair(self, name, user_info, status,
-                              suite_file, kgo_file):
-        """
-        Add information about a pair of compared files to the KGO database,
-        which some analysis (comparison) tasks may wish to make use of.
-
-        Args:
-            * name:
-                The name of the analysis (comparison) task.
-            * user_info:
-                Additional user-supplied details describing the task.
-            * status:
-                Numeric task status indicator.
-            * suite_file:
-                Full path to the file in the suite.
-            * kgo_file:
-                Full path to the file containing the KGO.
-
-        """
-        # The primary key in the database is composed from both the
-        # rose_ana app name and the task index (to make it unique)
-        app_task = "{0} ({1})".format(self.task_name, name)
-        self.kgo_db.enter_comparison(app_task, kgo_file, suite_file,
-                                     status, user_info)
-
-    def _kgo_db_task_status(self, status):
-        """
-        Update the entry for this task in the KGO database to indicate that
-        it has either finished processing analysis tasks or gone wrong.
-
-        """
-        self.kgo_db.enter_task(self.task_name, status)
 
     def _load_analysis_modules(self):
         """Populate the list of modules containing analysis methods."""

--- a/t/rose-ana/00-run-basic.t
+++ b/t/rose-ana/00-run-basic.t
@@ -139,86 +139,86 @@ done
 COMP_FILES=".*\(\w*\)/kgo.txt | .*\1/results.txt"
 
 # Comparison tasks for the rose_ana_t1 task
-TASK_NAME="grepper.FilePattern(Test of Exact Numeric Match Success)"
+TASK_NAME="rose_ana_t1 - grepper.FilePattern(Test of Exact Numeric Match Success)"
 TASK_STATUS=" OK "
 TEST_KEY=$TEST_KEY_BASE-db_check_t1_exact_numeric_success
 REGEXP="$COMP_NUMBER | $TASK_NAME | $COMP_FILES | $TASK_STATUS"
 file_grep $TEST_KEY "$REGEXP" $OUTPUT
 
-TASK_NAME="grepper.FilePattern(Test of Exact Numeric Match Fail)"
+TASK_NAME="rose_ana_t1 - grepper.FilePattern(Test of Exact Numeric Match Fail)"
 TASK_STATUS="FAIL"
 TEST_KEY=$TEST_KEY_BASE-db_check_t1_exact_numeric_fail
 REGEXP="$COMP_NUMBER | $TASK_NAME | $COMP_FILES | $TASK_STATUS"
 file_grep $TEST_KEY "$REGEXP" $OUTPUT
 
-TASK_NAME="grepper.FilePattern(Test of Exact Text Match Success)"
+TASK_NAME="rose_ana_t1 - grepper.FilePattern(Test of Exact Text Match Success)"
 TASK_STATUS=" OK "
 TEST_KEY=$TEST_KEY_BASE-db_check_t1_exact_text_success
 REGEXP="$COMP_NUMBER | $TASK_NAME | $COMP_FILES | $TASK_STATUS"
 file_grep $TEST_KEY "$REGEXP" $OUTPUT
 
-TASK_NAME="grepper.FilePattern(Test of Exact Text Match Fail)"
+TASK_NAME="rose_ana_t1 - grepper.FilePattern(Test of Exact Text Match Fail)"
 TASK_STATUS="FAIL"
 TEST_KEY=$TEST_KEY_BASE-db_check_t1_exact_text_fail
 REGEXP="$COMP_NUMBER | $TASK_NAME | $COMP_FILES | $TASK_STATUS"
 file_grep $TEST_KEY "$REGEXP" $OUTPUT
 
-TASK_NAME="grepper.FilePattern(Test of Within Match Percentage Success)"
+TASK_NAME="rose_ana_t1 - grepper.FilePattern(Test of Within Match Percentage Success)"
 TASK_STATUS=" OK "
 TEST_KEY=$TEST_KEY_BASE-db_check_t1_percentage_success
 REGEXP="$COMP_NUMBER | $TASK_NAME | $COMP_FILES | $TASK_STATUS"
 file_grep $TEST_KEY "$REGEXP" $OUTPUT
 
-TASK_NAME="grepper.FilePattern(Test of Within Match Percentage Fail)"
+TASK_NAME="rose_ana_t1 - grepper.FilePattern(Test of Within Match Percentage Fail)"
 TASK_STATUS="FAIL"
 TEST_KEY=$TEST_KEY_BASE-db_check_t1_percentage_fail
 REGEXP="$COMP_NUMBER | $TASK_NAME | $COMP_FILES | $TASK_STATUS"
 file_grep $TEST_KEY "$REGEXP" $OUTPUT
 
-TASK_NAME="grepper.FilePattern(Test of Within Match Absolute Success)"
+TASK_NAME="rose_ana_t1 - grepper.FilePattern(Test of Within Match Absolute Success)"
 TASK_STATUS=" OK "
 TEST_KEY=$TEST_KEY_BASE-db_check_t1_absolute_success
 REGEXP="$COMP_NUMBER | $TASK_NAME | $COMP_FILES | $TASK_STATUS"
 file_grep $TEST_KEY "$REGEXP" $OUTPUT
 
-TASK_NAME="grepper.FilePattern(Test of Within Match Absolute Fail)"
+TASK_NAME="rose_ana_t1 - grepper.FilePattern(Test of Within Match Absolute Fail)"
 TASK_STATUS="FAIL"
 TEST_KEY=$TEST_KEY_BASE-db_check_t1_absolute_fail
 REGEXP="$COMP_NUMBER | $TASK_NAME | $COMP_FILES | $TASK_STATUS"
 file_grep $TEST_KEY "$REGEXP" $OUTPUT
 
-TASK_NAME="grepper.FilePattern(Test of Exact List Match Success)"
+TASK_NAME="rose_ana_t1 - grepper.FilePattern(Test of Exact List Match Success)"
 TASK_STATUS=" OK "
 TEST_KEY=$TEST_KEY_BASE-db_check_t1_exact_list_success
 REGEXP="$COMP_NUMBER | $TASK_NAME | $COMP_FILES | $TASK_STATUS"
 file_grep $TEST_KEY "$REGEXP" $OUTPUT
 
-TASK_NAME="grepper.FilePattern(Test of Exact List Match Fail)"
+TASK_NAME="rose_ana_t1 - grepper.FilePattern(Test of Exact List Match Fail)"
 TASK_STATUS="FAIL"
 TEST_KEY=$TEST_KEY_BASE-db_check_t1_exact_list_fail
 REGEXP="$COMP_NUMBER | $TASK_NAME | $COMP_FILES | $TASK_STATUS"
 file_grep $TEST_KEY "$REGEXP" $OUTPUT
 
-TASK_NAME="grepper.FilePattern(Test of Within List Match Success)"
+TASK_NAME="rose_ana_t1 - grepper.FilePattern(Test of Within List Match Success)"
 TASK_STATUS=" OK "
 TEST_KEY=$TEST_KEY_BASE-db_check_t1_within_list_success
 REGEXP="$COMP_NUMBER | $TASK_NAME | $COMP_FILES | $TASK_STATUS"
 file_grep $TEST_KEY "$REGEXP" $OUTPUT
 
-TASK_NAME="grepper.FilePattern(Test of Within List Match Fail)"
+TASK_NAME="rose_ana_t1 - grepper.FilePattern(Test of Within List Match Fail)"
 TASK_STATUS="FAIL"
 TEST_KEY=$TEST_KEY_BASE-db_check_t1_within_list_fail
 REGEXP="$COMP_NUMBER | $TASK_NAME | $COMP_FILES | $TASK_STATUS"
 file_grep $TEST_KEY "$REGEXP" $OUTPUT
 
 # Comparison tasks for the rose_ana_t2 task(s)
-TASK_NAME="grepper.FilePattern(First Test)"
+TASK_NAME="rose_ana_t2_activated - grepper.FilePattern(First Test)"
 TASK_STATUS="FAIL"
 TEST_KEY=$TEST_KEY_BASE-db_check_t2_ignore_basic_1
 REGEXP="$COMP_NUMBER | $TASK_NAME | $COMP_FILES | $TASK_STATUS"
 file_grep $TEST_KEY "$REGEXP" $OUTPUT
 
-TASK_NAME="grepper.FilePattern(Second Test)"
+TASK_NAME="rose_ana_t2_deactivated - grepper.FilePattern(Second Test)"
 TASK_STATUS=" OK "
 TEST_KEY=$TEST_KEY_BASE-db_check_t2_ignore_basic_2
 REGEXP="$COMP_NUMBER | $TASK_NAME | $COMP_FILES | $TASK_STATUS"

--- a/t/rose-ana/00-run-basic/app/db_check/bin/print_db_contents.py
+++ b/t/rose-ana/00-run-basic/app/db_check/bin/print_db_contents.py
@@ -15,7 +15,7 @@ for itask, task in enumerate(res.fetchall()):
     print ("{0} | {1} | {2}".format(itask + 1, *task))
 
 # Print out the comparison entries
-res = conn.execute("SELECT app_task, kgo_file, suite_file, "
+res = conn.execute("SELECT comp_task, kgo_file, suite_file, "
                    "status, comparison FROM comparisons")
 for icomparison, comparison in enumerate(res.fetchall()):
     print ("{0} | ".format(icomparison + 1) + " | ".join(comparison))


### PR DESCRIPTION
Two slight problems have been identified with this functionality (though the impact is limited, only to those making use of the KGO database).  Two different problems exist:

**1.** The `rose_ana` re-write moved to using a buffer for the statment (to avoid many repeated calls to locking and/or commits to the database.  Unfortunately this defeats the point of the `tasks` database table - the original idea was that this table would initially be set to `1` for each task, and updated to `0` when the task finished (allowing scripts interfacing with the database the means to understand when something unexpected had stopped the task completing)...  Due to the use of the buffer everything is done in one go, meaning an unexpected error results in _nothing_ being written instead.  The solution is to have 2 calls per `rose_ana` task instead (one to set the `tasks` table entry at the start)

**2.** At some point during the writing of the analysis modules both externally and for the `grepper.py` class, the `_kgo_db_add_file_pair` method was somehow forgotten/overlooked and tasks instead directly called `self.parent.kgo_db.add_comparison`... this meant losing the behaviour of making the table key unique by appending the `rose_ana` task name.  Rather than fix the call in `grepper.py` and elsewhere it seems a little redundant having the `_kgo_db_*` methods at all in the app class, so these are now dropped