### PR TITLE
rose bush: job entry: disable seq zero size

### DIFF
--- a/lib/html/template/rose-bush/job-entry.html
+++ b/lib/html/template/rose-bush/job-entry.html
@@ -210,6 +210,7 @@
                     {% for index, key in indexes|dictsort -%}
                       {% set log = entry.logs[key] -%}
                       <option title="{{log.size}} bytes"
+                      {% if log.size == 0 -%}disabled="disabled"{% endif -%}
                       value="{{log.path_in_tar}}">{{key}}</option>
                     {% endfor -%}
                   </select>
@@ -220,6 +221,7 @@
                     {% for index, key in indexes|dictsort -%}
                       {% set log = entry.logs[key] -%}
                       <option title="{{log.size}} bytes"
+                      {% if log.size == 0 -%}disabled="disabled"{% endif -%}
                       value="{{log.path}}">{{key}}</option>
                     {% endfor -%}
                   </select>


### PR DESCRIPTION
Disable links to zero-size files in the drop down box for sequential
logs. Close #2040.