### PR TITLE
macro: fix bug with opt and info configs files.

### DIFF
--- a/lib/python/rose/macro.py
+++ b/lib/python/rose/macro.py
@@ -1268,6 +1268,8 @@ def dump_config(config, opt_conf_dir, opt_output_dir=None,
 
 def load_conf_from_file(conf_dir, config_file_path, mode="macro"):
     """Loads config data from the file config_file_path."""
+    is_info_config = (os.path.basename(config_file_path) ==
+                      rose.INFO_CONFIG_NAME)
     optional_keys = []
     optional_dir = os.path.join(conf_dir, rose.config.OPT_CONFIG_DIR)
     optional_glob = os.path.join(optional_dir, rose.GLOB_OPT_CONFIG_FILE)
@@ -1281,6 +1283,8 @@ def load_conf_from_file(conf_dir, config_file_path, mode="macro"):
 
     # Load the configuration and the metadata macros.
     config_loader = rose.config.ConfigLoader()
+    if is_info_config:
+        optional_keys = None
     app_config, config_map = config_loader.load_with_opts(
         config_file_path, more_keys=optional_keys,
         return_config_map=True)
@@ -1291,7 +1295,8 @@ def load_conf_from_file(conf_dir, config_file_path, mode="macro"):
     # Load meta config if it exists.
     meta_config = rose.config.ConfigNode()
     meta_path, warning = load_meta_path(app_config, conf_dir)
-    if meta_path is None:
+
+    if meta_path is None and not is_info_config:
         if mode == "macro":
             text = ERROR_LOAD_METADATA.format("")
             if warning:

--- a/t/rose-macro/25-suite-level.t
+++ b/t/rose-macro/25-suite-level.t
@@ -28,15 +28,27 @@ tests 30
 # Setup.
 TEST_SUITE=test-suite
 
-# suite
-mkdir -p $TEST_DIR/$TEST_SUITE/meta/lib/python/macros
+# rose-suite.conf
+mkdir $TEST_DIR/$TEST_SUITE -p
 cat >$TEST_DIR/$TEST_SUITE/rose-suite.conf <<'__SUITE_CONF__'
 [env]
 ANSWER=quarante deux
 __SUITE_CONF__
+
+# rose-suite.info
 cat >$TEST_DIR/$TEST_SUITE/rose-suite.info <<'__SUITE_INFO__'
 title=incorrect-title
 __SUITE_INFO__
+
+# opt/
+mkdir $TEST_DIR/$TEST_SUITE/opt
+cat >$TEST_DIR/$TEST_SUITE/opt/rose-suite-optional.conf <<'__OPT_SUITE_CONF__'
+[env]
+ANSWER=caurenta y dos
+__OPT_SUITE_CONF__
+
+# meta/
+mkdir -p $TEST_DIR/$TEST_SUITE/meta/lib/python/macros
 cat >$TEST_DIR/$TEST_SUITE/meta/rose-meta.conf <<'__META_CONF__'
 [env=ANSWER]
 type=integer
@@ -325,11 +337,15 @@ file_cmp $TEST_KEY.err $TEST_KEY.err <<'__ERR__'
 [V] rose.macros.DefaultValidators: issues: 1
     env=FOO=baz
         Not an integer: 'baz'
-[V] rose.macros.DefaultValidators: issues: 1
+[V] rose.macros.DefaultValidators: issues: 2
     env=ANSWER=quarante deux
         Not an integer: 'quarante deux'
-[V] suite.SuiteChecker: issues: 1
+    (opts=optional)env=ANSWER=caurenta y dos
+        Not an integer: 'caurenta y dos'
+[V] suite.SuiteChecker: issues: 2
     env=ANSWER=quarante deux
+        Incorrectanswer
+    (opts=optional)env=ANSWER=caurenta y dos
         Incorrectanswer
 [V] rose.macros.DefaultValidators: issues: 3
     =owner=None
@@ -389,11 +405,15 @@ __OUT__
 TEST_KEY=$TEST_KEY_BASE-validate-all-suite-only-suite
 run_fail $TEST_KEY rose macro -C $TEST_DIR/$TEST_SUITE -V --suite-only
 file_cmp $TEST_KEY.err $TEST_KEY.err <<'__ERR__'
-[V] rose.macros.DefaultValidators: issues: 1
+[V] rose.macros.DefaultValidators: issues: 2
     env=ANSWER=quarante deux
         Not an integer: 'quarante deux'
-[V] suite.SuiteChecker: issues: 1
+    (opts=optional)env=ANSWER=caurenta y dos
+        Not an integer: 'caurenta y dos'
+[V] suite.SuiteChecker: issues: 2
     env=ANSWER=quarante deux
+        Incorrectanswer
+    (opts=optional)env=ANSWER=caurenta y dos
         Incorrectanswer
 [V] rose.macros.DefaultValidators: issues: 3
     =owner=None
@@ -412,11 +432,15 @@ __OUT__
 TEST_KEY=$TEST_KEY_BASE-validate-all-suite-only-app-foo
 run_fail $TEST_KEY rose macro -C $TEST_DIR/$TEST_SUITE/app/foo -V --suite-only
 file_cmp $TEST_KEY.err $TEST_KEY.err <<'__ERR__'
-[V] rose.macros.DefaultValidators: issues: 1
+[V] rose.macros.DefaultValidators: issues: 2
     env=ANSWER=quarante deux
         Not an integer: 'quarante deux'
-[V] suite.SuiteChecker: issues: 1
+    (opts=optional)env=ANSWER=caurenta y dos
+        Not an integer: 'caurenta y dos'
+[V] suite.SuiteChecker: issues: 2
     env=ANSWER=quarante deux
+        Incorrectanswer
+    (opts=optional)env=ANSWER=caurenta y dos
         Incorrectanswer
 [V] rose.macros.DefaultValidators: issues: 3
     =owner=None


### PR DESCRIPTION
Fix traceback which occurs when running rose macro on a suite with both a rose-suite.info file and optional (rose-suite-xxx.conf) configs.