### PR TITLE
Fix doc with extra </dd>

### DIFF
--- a/doc/rose-configuration.html
+++ b/doc/rose-configuration.html
@@ -1168,7 +1168,6 @@ source=http://host/svn-repos/path/to/bar.txt
               <a href="http://man.openbsd.org/ssh_config#User">User</a>
               setting in <var>~/.ssh/config</var> to specify the user
               ID for logging into <var>HOST</var>.)</dd>
-              </dd>
             </dl>
 
             <p>The application launcher will use the following


### PR DESCRIPTION
Sorry an extra `</dd>` is left behind in #2065. This causes a failure on my desktop, (but not Travis CI for some reason).