### PR TITLE
Rose mpi launch

### DIFF
--- a/bin/rose-mpi-launch
+++ b/bin/rose-mpi-launch
@@ -131,7 +131,7 @@ while (($# > 0)); do
                       err "ROSE_LAUNCHER_ULIMIT_OPTS=$ROSE_LAUNCHER_ULIMIT_OPTS"
                       :;;
                     *)
-                      ulimit -$OPT $OPTARG || err \
+                      ulimit -$OPT ${OPTARG:-} || err \
                           "ROSE_LAUNCHER_ULIMIT_OPTS=$ROSE_LAUNCHER_ULIMIT_OPTS"
                       :;;
                 esac

--- a/t/rose-mpi-launch/01-command-inner.t
+++ b/t/rose-mpi-launch/01-command-inner.t
@@ -34,15 +34,18 @@ file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
 #-------------------------------------------------------------------------------
 # Use ROSE_LAUNCHER_ULIMIT_OPTS.
 TEST_KEY=$TEST_KEY_BASE-ulimit-good
-ULIMIT_STACK=$(ulimit -s)
-if [[ $ULIMIT_STACK == 'unlimited' ]]; then
-    ULIMIT_STACK_NEW=$ULIMIT_STACK
+ULIMIT_FILE_SIZE=$(ulimit -f)
+if [[ $ULIMIT_FILE_SIZE == 'unlimited' ]]; then
+    ULIMIT_FILE_SIZE_NEW=100000
 else
-    ULIMIT_STACK_NEW=$(($(ulimit -s) / 2))
+    ULIMIT_FILE_SIZE_NEW=$(($(ulimit -f) / 2))
 fi
-ROSE_LAUNCHER_ULIMIT_OPTS="-s $ULIMIT_STACK_NEW" \
-    run_pass "$TEST_KEY" rose mpi-launch --inner bash -c 'ulimit -s'
-file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<<$ULIMIT_STACK_NEW
+ROSE_LAUNCHER_ULIMIT_OPTS="-f $ULIMIT_FILE_SIZE_NEW -H" \
+    run_pass "$TEST_KEY" rose mpi-launch --inner bash -c 'ulimit -f'
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<__OUT__
+$ULIMIT_FILE_SIZE_NEW
+$ULIMIT_FILE_SIZE_NEW
+__OUT__
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
 #-------------------------------------------------------------------------------
 # Use bad ROSE_LAUNCHER_ULIMIT_OPTS.


### PR DESCRIPTION
@matthewrmshin I have tested this in my own space and with:

`rose test-battery t/rose-mpi-launch`

and also demonstrated that without the fix the modified test fails. I decided to use file size (`ulimit -f`) rather than stack size as that is the default value that `-H` or `-S` reports. In practice `-a` is the option we would normally use, but that produces many lines of output and would have been harder to create a control.