### PR TITLE
rose suite-run: no-remote-login-shell

### DIFF
--- a/etc/rose.conf.example
+++ b/etc/rose.conf.example
@@ -252,6 +252,19 @@
 #  scan-hosts=HOST-GROUP|HOST ...
 ## E.g.:
 #  scan-hosts=localhost rose-vm
+## Don't use login shell to invoke "rose suite-run --remote"? (default=false)
+#  remote-no-login-shell=HOST-GLOB=true|false
+## where HOST-GLOB is a glob for matching host names.
+## E.g.:
+#  remote-no-login-shell=myhpc*=true
+#                        mycluster*=true
+## Path to "rose" executable on remote hosts (default=rose)
+#  remote-rose-bin=HOST-GLOB=ROSE-BIN-PATH
+## where HOST-GLOB is a glob for matching host names.
+##       ROSE-BIN-PATH is the path to the "rose" executable
+## E.g.:
+#  remote-rose-bin=myhpc*=/opt/rose/bin/rose
+#                  mycluster*=/usr/local/bin/rose
 ## Root location of a suite run directory (default=$HOME)
 #  root-dir=HOST-GLOB=$HOST-DIR
 #          =...
@@ -281,15 +294,6 @@
 ## Items to prepend to the a PATH-like environment variable, e.g. PYTHONPATH
 #  path-prepend.PYTHONPATH=
 [rose-task-run]
-
-# Calling "rose" on a remote host.
-[rose-home-at]
-#
-## Alternate path to "rose" for all hosts
-#  * =/opt/rose
-## Alternate path to "rose" for a specific host
-#  hostname=/opt/site/rose
-[rose-home-at]
 
 # Configuration related to the built-in "rose_ana" application.
 [rose-ana]

--- a/lib/python/rose/suite_run.py
+++ b/lib/python/rose/suite_run.py
@@ -303,58 +303,64 @@ class SuiteRunner(Runner):
         # Install items to user@host
         conf = ResourceLocator.default().get_conf()
         auths = self.suite_engine_proc.get_tasks_auths(suite_name)
-        queue = []  # [[pipe, command, "ssh"|"rsync", auth], ...]
+        proc_queue = []  # [[proc, command, "ssh"|"rsync", auth], ...]
         for auth in sorted(auths):
             host = auth
             if "@" in auth:
                 host = auth.split("@", 1)[1]
-            command = self.popen.get_cmd("ssh", auth, "bash", "--login", "-c")
-            rose_bin = "rose"
-            for name in [host, "*"]:
-                rose_home_node = conf.get(["rose-home-at", name],
-                                          no_ignore=True)
-                if rose_home_node is not None:
-                    rose_bin = "%s/bin/rose" % (rose_home_node.value)
-                    break
+            # Remote shell
+            command = self.popen.get_cmd("ssh", "-n", auth)
+            # Provide ROSE_VERSION and CYLC_VERSION in the environment
+            shcommand = "env ROSE_VERSION=%s %s=%s" % (
+                my_rose_version, suite_engine_key, suite_engine_version)
+            # Use login shell?
+            no_login_hell = self._run_conf(
+                "remote-no-login-shell", host=host, conf_tree=conf_tree)
+            if not no_login_hell or no_login_hell.lower() != "true":
+                shcommand += r""" bash -l -c '"$0" "$@"'"""
+            # Path to "rose" command, if applicable
+            rose_bin = self._run_conf(
+                "remote-rose-bin", host=host, conf_tree=conf_tree,
+                default="rose")
             # Build remote "rose suite-run" command
-            rose_sr = "ROSE_VERSION=%s %s" % (my_rose_version, rose_bin)
-            rose_sr += " suite-run -v -v --name=%s" % suite_name
+            shcommand += " %s suite-run -vv -n %s" % (rose_bin, suite_name)
             for key in ["new", "debug", "install-only"]:
                 attr = key.replace("-", "_") + "_mode"
                 if getattr(opts, attr, None) is not None:
-                    rose_sr += " --" + key
+                    shcommand += " --%s" % key
             if opts.log_keep:
-                rose_sr += " --log-keep=" + opts.log_keep
+                shcommand += " --log-keep=%s" % opts.log_keep
             if opts.log_name:
-                rose_sr += " --log-name=" + opts.log_name
+                shcommand += " --log-name=%s" % opts.log_name
             if not opts.log_archive_mode:
-                rose_sr += " --no-log-archive"
-            rose_sr += " --run=" + opts.run_mode
+                shcommand += " --no-log-archive"
+            shcommand += " --run=%s" % opts.run_mode
+            # Build --remote= option
+            shcommand += " --remote=uuid=%s" % uuid
             host_confs = [
                 "root-dir",
                 "root-dir{share}",
                 "root-dir{share/cycle}",
                 "root-dir{work}"]
-            rose_sr += " --remote=uuid=" + uuid
             locs_conf.set([auth])
             for key in host_confs:
                 value = self._run_conf(key, host=host, conf_tree=conf_tree)
                 if value is not None:
                     val = self.popen.list_to_shell_str([str(value)])
-                    rose_sr += "," + key + "=" + val
+                    shcommand += ",%s=%s" % (key, val)
                     locs_conf.set([auth, key], value)
-            command += ["'" + rose_sr + "'"]
-            pipe = self.popen.run_bg(*command)
-            queue.append([pipe, command, "ssh", auth])
+            command.append(shcommand)
+            proc = self.popen.run_bg(*command)
+            proc_queue.append([proc, command, "ssh", auth])
 
-        while queue:
+        while proc_queue:
             sleep(self.SLEEP_PIPE)
-            pipe, command, command_name, auth = queue.pop(0)
-            if pipe.poll() is None:
-                queue.append([pipe, command, command_name, auth])  # put back
+            proc, command, command_name, auth = proc_queue.pop(0)
+            if proc.poll() is None:  # put it back in proc_queue
+                proc_queue.append([proc, command, command_name, auth])
                 continue
-            ret_code = pipe.wait()
-            out, err = pipe.communicate()
+            ret_code = proc.wait()
+            out, err = proc.communicate()
             if ret_code:
                 raise RosePopenError(command, ret_code, out, err)
             if command_name == "rsync":
@@ -372,7 +378,8 @@ class SuiteRunner(Runner):
                     filters["excludes"].append(name + uuid)
                 target = auth + ":" + suite_dir_rel
                 cmd = self._get_cmd_rsync(target, **filters)
-                queue.append([self.popen.run_bg(*cmd), cmd, "rsync", auth])
+                proc_queue.append(
+                    [self.popen.run_bg(*cmd), cmd, "rsync", auth])
 
         # Install ends
         ConfigDumper()(locs_conf, os.path.join("log", "rose-suite-run.locs"))

--- a/lib/python/rose/suite_run.py
+++ b/lib/python/rose/suite_run.py
@@ -314,9 +314,9 @@ class SuiteRunner(Runner):
             shcommand = "env ROSE_VERSION=%s %s=%s" % (
                 my_rose_version, suite_engine_key, suite_engine_version)
             # Use login shell?
-            no_login_hell = self._run_conf(
+            no_login_shell = self._run_conf(
                 "remote-no-login-shell", host=host, conf_tree=conf_tree)
-            if not no_login_hell or no_login_hell.lower() != "true":
+            if not no_login_shell or no_login_shell.lower() != "true":
                 shcommand += r""" bash -l -c '"$0" "$@"'"""
             # Path to "rose" command, if applicable
             rose_bin = self._run_conf(

--- a/t/rose-suite-run/12-run-dir-root.t
+++ b/t/rose-suite-run/12-run-dir-root.t
@@ -75,7 +75,7 @@ else
 fi
 if [[ -n $JOB_HOST_OPT ]]; then
     RUN_ROOT=$(ssh $JOB_HOST "bash -l -c echo\\ \\$JOB_HOST_RUN_ROOT" | tail -1)
-    RUN_DIR=$(ssh $JOB_HOST "bash -l -c readlink\\ ~/cylc-run/$NAME" | tail -1)
+    RUN_DIR=$(ssh $JOB_HOST "readlink ~/cylc-run/$NAME" | tail -1)
     if [[ $RUN_DIR == $RUN_ROOT/cylc-run/$NAME ]]; then
         pass "$TEST_KEY.$JOB_HOST"
     else

--- a/t/rose-suite-run/19-restart-init-dir-remote.t
+++ b/t/rose-suite-run/19-restart-init-dir-remote.t
@@ -42,12 +42,13 @@ __PYTHON__
 T_HOST_ROSE_HOME=$(ssh_mkdtemp $T_HOST)
 rsync -a --exclude=*.pyc $ROSE_HOME/* $T_HOST:$T_HOST_ROSE_HOME/
 
-mkdir -p conf
-cat >conf/rose.conf <<__CONF__
-[rose-home-at]
-$T_HOST=$T_HOST_ROSE_HOME
+mkdir -p 'conf'
+cat >'conf/rose.conf' <<__CONF__
+[rose-suite-run]
+remote-no-login-shell=${T_HOST}=true
+remote-host-bin=${T_HOST}=${T_HOST_ROSE_HOME}/bin/rose
 __CONF__
-export ROSE_CONF_PATH=$PWD/conf
+export ROSE_CONF_PATH="${PWD}/conf"
 
 tests 3
 


### PR DESCRIPTION
Support running `rose suite-run --remote=...` without invoking the login shell.