### PR TITLE
Fix doc link: use Wikipedia for RDBMS definition

### DIFF
--- a/doc/rose-api.html
+++ b/doc/rose-api.html
@@ -1421,11 +1421,11 @@ class Upgrade272to273(rose.upgrade.MacroUpgrade):
             service API. All Rosie discovery services (e.g.
             <code>rosie search</code>, <code>rosie go</code>, web
             page) use a <a href=
-            "http://en.wikipedia.org/wiki/Representational_state_transfer">
+            "https://en.wikipedia.org/wiki/Representational_state_transfer">
             RESTful</a> API to interrogate a web server, which then
             interrogates an <a href=
-            "http://www.planetofcoders.com/rdbms/">RDBMS</a>. Returned
-            data is encoded in the <a href=
+            "https://en.wikipedia.org/wiki/Relational_database_management_system">RDBMS</a>.
+            Returned data is encoded in the <a href=
             "http://www.json.org/">JSON</a> format.</p>
 
             <p>You may wish to utilise the Python class


### PR DESCRIPTION
(The original link is currently broken, and also because we are already linking to Wikipedia a few lines above.)