### PR TITLE
Rose bush cylc-dir fix

### DIFF
--- a/lib/python/rose/bush.py
+++ b/lib/python/rose/bush.py
@@ -417,7 +417,7 @@ class RoseBushService(object):
                 user_suite_dir_root, followlinks=True):
             if dirpath != user_suite_dir_root and (
                     any(name in dnames or name in fnames
-                            for name in sub_names)):
+                        for name in sub_names)):
                 dnames[:] = []
             else:
                 continue

--- a/lib/python/rose/bush.py
+++ b/lib/python/rose/bush.py
@@ -415,7 +415,9 @@ class RoseBushService(object):
             ".service", "log", "share", "work", self.bush_dao.SUITE_CONF]
         for dirpath, dnames, fnames in os.walk(
                 user_suite_dir_root, followlinks=True):
-            if any(name in dnames or name in fnames for name in sub_names):
+            if dirpath != user_suite_dir_root and (
+                    any(name in dnames or name in fnames
+                            for name in sub_names)):
                 dnames[:] = []
             else:
                 continue


### PR DESCRIPTION
Fixes issue where top level `cylc-run` dir was being treated as a suite directory and blocking user's other suites from dislaying in rose bush. Closes #2088.