### PR TITLE
rose macro: improve feedback for invalid input

### DIFF
--- a/lib/python/rose/macro.py
+++ b/lib/python/rose/macro.py
@@ -1419,9 +1419,11 @@ def get_user_values(options, ignore=None):
                 try:
                     options[key] = ast.literal_eval(user_input)
                     entered = True
-                except ValueError:
+                except (SyntaxError, ValueError):
                     rose.reporter.Reporter()(
-                        "Invalid entry, please try again\n",
+                        "Invalid entry: Input should be a valid python "
+                        "value.\nNote that strings should be quoted. "
+                        "Please try again:\n",
                         kind=rose.reporter.Reporter.KIND_ERR,
                         level=rose.reporter.Reporter.FAIL
                     )


### PR DESCRIPTION
When `rose macro` prompts users to provide values the resulting input is passes through `ast.literal_eval`. If the user provides an unquoted value they see an "Invalid entry..." notice, that is, unless the value uses any python characters, in which case they will see traceback. File system paths are a good example of this, `filename` is fine whereas `../filename` causes traceback.