### PR TITLE
suite-run/restart: fix host select logic

### DIFF
--- a/lib/python/rose/suite_restart.py
+++ b/lib/python/rose/suite_restart.py
@@ -84,8 +84,7 @@ class SuiteRestarter(object):
             hosts = []
             val = ResourceLocator.default().get_conf().get_value(
                 ["rose-suite-run", "hosts"], "localhost")
-            known_hosts = self.host_selector.expand(val.split())[0]
-            for known_host in known_hosts:
+            for known_host in val.split():
                 if known_host not in hosts:
                     hosts.append(known_host)
 

--- a/lib/python/rose/suite_run.py
+++ b/lib/python/rose/suite_run.py
@@ -405,7 +405,7 @@ class SuiteRunner(Runner):
                 names = shlex.split(
                     conf.get_value(["rose-suite-run", "hosts"], ""))
                 if names:
-                    hosts += self.host_selector.expand(names)[0]
+                    hosts += names
 
         if (hosts and len(hosts) == 1 and
                 self.host_selector.is_local_host(hosts[0])):


### PR DESCRIPTION
Rank and threshold settings for suite host group were lost due to
premature value expansion.