### PR TITLE
rose-ana grepper print stdout on failure

### DIFF
--- a/lib/python/rose/apps/ana_builtin/grepper.py
+++ b/lib/python/rose/apps/ana_builtin/grepper.py
@@ -59,6 +59,9 @@ class SingleCommandStatus(AnalysisTask):
             self.reporter(stdout, prefix="[INFO] ")
             self.passed = True
         else:
+            self.reporter("STDOUT:", prefix="[FAIL] ")
+            self.reporter(stdout, prefix="[FAIL] ")
+            self.reporter("STDERR:", prefix="[FAIL] ")
             self.reporter(stderr, prefix="[FAIL] ")
 
     def check_for_skip(self):


### PR DESCRIPTION
Since some programs report errors or useful additional information on `stdout` the `grepper` class should print both `stdout` and `stderr` when something has failed.