### PR TITLE
Add PyOpenSSL to Travis CI install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ install:
     - sudo apt-get install -y libxml-parser-perl libconfig-inifiles-perl
     - sudo apt-get install -y libdbi-perl libdbd-sqlite3-perl
     - sudo apt-get install python-pip python-dev graphviz libgraphviz-dev python-jinja2 python-sqlalchemy
-    - pip install cherrypy Jinja2 requests simplejson sqlalchemy
+    - pip install cherrypy Jinja2 requests simplejson sqlalchemy pyopenssl
     - pip install pygraphviz --install-option="--include-path=/usr/include/graphviz" --install-option="--library-path=/usr/lib/graphviz/"
     - pip install pep8
     - sudo sh -c 'echo "deb http://opensource.wandisco.com/ubuntu `lsb_release -cs` svn19" >> /etc/apt/sources.list.d/subversion19.list'


### PR DESCRIPTION
In response to cylc/cylc#2355, we need to have PyOpenSSL for the Python environment in Travis CI.