### PR TITLE
app-upgrade: fix cli help

### DIFF
--- a/bin/rose-app-upgrade
+++ b/bin/rose-app-upgrade
@@ -32,8 +32,7 @@
 #     --non-interactive, --yes, -y
 #         Switch off interactive prompting.
 #     --output=DIR, -O DIR
-#         The location of the output directory. Only meaningful if
-#         there is at least one transformer in the argument list.
+#         The location of the output directory.
 #     --quiet, -q
 #         Reduce verbosity.
 #

--- a/doc/rose-command.html
+++ b/doc/rose-command.html
@@ -554,9 +554,7 @@ rosie UTIL [OPTS] [ARG ...]
 
               <dt><kbd>--output=DIR, -O DIR</kbd></dt>
 
-              <dd>The location of the output directory. Only
-              meaningful if there is at least one transformer in
-              the argument list.</dd>
+              <dd>The location of the output directory.</dd>
 
               <dt><kbd>--quiet, -q</kbd></dt>
 


### PR DESCRIPTION
The cli text for the `--output` option appears to have been copied from `rose macro`.