### PR TITLE
Fix get_util_name exception.

### DIFF
--- a/lib/python/rose/resource.py
+++ b/lib/python/rose/resource.py
@@ -140,9 +140,9 @@ class ResourceLocator(object):
         util = self.util
         try:
             if namespace is None:
-                namespace = os.getenv("ROSE_NS")
+                namespace = os.environ["ROSE_NS"]
             if util is None:
-                util = os.getenv("ROSE_UTIL")
+                util = os.environ["ROSE_UTIL"]
             return namespace + separator + util
         except KeyError:
             return os.path.basename(sys.argv[0])


### PR DESCRIPTION
`os.getenv` will return `None` rather than raising `KeyError` so the `try`/`except` was failing to catch the error.