### PR TITLE
mini language: support len(this(N))

### DIFF
--- a/lib/python/rose/macros/rule.py
+++ b/lib/python/rose/macros/rule.py
@@ -246,6 +246,8 @@ class RuleEvaluator(rose.macro.MacroBase):
             start, var_id, end = search_result
             if var_id == "this":
                 var_id = setting_id
+            elif self.REC_THIS_ELEMENT_ID.search(rule):
+                var_id = var_id.replace("this", setting_id)
             setting_value = get_value_from_id(
                 var_id, config, meta_config, setting_id)
             array_value = rose.variable.array_split(str(setting_value))

--- a/t/rose-metadata-check/06-rule.t
+++ b/t/rose-metadata-check/06-rule.t
@@ -21,7 +21,7 @@
 #-------------------------------------------------------------------------------
 . $(dirname $0)/test_header
 #-------------------------------------------------------------------------------
-tests 6
+tests 8
 #-------------------------------------------------------------------------------
 # Check fail-if/warn-if syntax checking.
 TEST_KEY=$TEST_KEY_BASE-ok
@@ -308,6 +308,17 @@ file_cmp "$TEST_KEY.err" "$TEST_KEY.err" <<'__ERR__'
     zoo=elephant=fail-if=zoo=num_mice > 0
         Not found: zoo=num_mice
 __ERR__
+teardown
+#-------------------------------------------------------------------------------
+TEST_KEY="${TEST_KEY_BASE}-len-this-1"
+setup
+init <<'__META_CONFIG__'
+[env=FOO]
+length=:
+warn-if=len(this(1)) > 2
+__META_CONFIG__
+run_pass "${TEST_KEY}" rose metadata-check -C ../config
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
 teardown
 #-------------------------------------------------------------------------------
 exit


### PR DESCRIPTION
Both `this(1)` and `len(this)` work but `len(this(1))` doesn't.

E.G:

```ini
[env=FOO]
length=:
warn-if=len(this(1)) > 2;
```