### PR TITLE
Doc: remove dead cylon image link

### DIFF
--- a/doc/rose-rug-suites-I.html
+++ b/doc/rose-rug-suites-I.html
@@ -138,17 +138,13 @@
 
               <div class="slide">
               <h2 id="background">Background</h2>
-
-              <p class="caption">Original name
-              inspiration:</p><img src=
-              "http://upload.wikimedia.org/wikipedia/en/1/1e/Cylon_Centurion.png"
-              alt=
-              "Battlestar Galactica Cylon (re-imagined)" /></div>
+              </div>
 
               <div class="slide">
                 <h3 class="alwayshidden">Background - NIWA</h3>
 
-                <p>cylc was originally developed by <a href=
+                <p>Originally called <em>cylon</em>,
+                cylc was first started by <a href=
                 "https://github.com/hjoliver">Hilary Oliver</a> at
                 <a href="http://www.niwa.co.nz/">NIWA</a>. It runs
                 their <!--a href=   ### REMOVING LINK UNTIL SITE FIXED ###


### PR DESCRIPTION
Remove a dead link that is causing the test battery to fail.