### PR TITLE
bush: fix links to line numbers and syntax highlighting

### DIFF
--- a/lib/html/static/js/search.js
+++ b/lib/html/static/js/search.js
@@ -83,8 +83,8 @@ var FileLoader = ( function () {
         num = parseInt(num);
 
         if (previous_search) {
-            loadFile("", num)
-            return
+            loadFile("", num);
+            return;
         }
 
         // Remove previously highlighted lines.

--- a/lib/html/static/js/search.js
+++ b/lib/html/static/js/search.js
@@ -82,6 +82,11 @@ var FileLoader = ( function () {
         * number. */
         num = parseInt(num);
 
+        if (previous_search) {
+            loadFile("", num)
+            return
+        }
+
         // Remove previously highlighted lines.
         var highlights = $($('#filecode')[0]).find('span.highlight');
         for (high=0; high<highlights.length; high++) {

--- a/lib/html/static/js/search.js
+++ b/lib/html/static/js/search.js
@@ -56,7 +56,7 @@ var FileLoader = ( function () {
 
         // asynchronously load file
         $.ajax({
-            mathod: 'POST',
+            method: 'POST',
             url: url,
             data: kwargs,
             success: function (result) {
@@ -77,25 +77,28 @@ var FileLoader = ( function () {
     };
 
 
-    var selectLine = function (num) {
+    this.selectLine = function (num) {
         /* Highlights and scrolls to the line of code with the provided
         * number. */
-        // insert highlight tags to selected line
-        var lines = $('#filecode').html().split('\n');
-        if (num < lines.length) {
-            lines[num - 1] = mark[0] + lines[num - 1] + mark[1];
+        num = parseInt(num);
+
+        // Remove previously highlighted lines.
+        var highlights = $($('#filecode')[0]).find('span.highlight');
+        for (high=0; high<highlights.length; high++) {
+            $(highlights[high]).replaceWith(highlights[high].innerHTML);
         }
+
+        // Extract text lines from document
+        var lines = $('#filecode')[0].innerHTML.split('\n');
+
+        // Mark highlighted line.
+        lines[num - 1] = mark[0] + lines[num - 1] + mark[1];
+
+        // Set filecode html content.
         $('#filecode').html(lines.join('\n'));
+
         // scroll to selected line
         $('html, body').animate({scrollTop: $('#' + num).offset().top}, 500);
-    };
-
-
-    this.gotoLine = function (num) {
-        /* Reloads the whole file and propts loadFile() to scroll to the
-         * specified line. */
-        loadFile("", num);
-        previous_search = null;
     };
 
 
@@ -130,20 +133,20 @@ var FileLoader = ( function () {
         /* Attatch handler on .line-number to goto the selected line number
          * when clicked. */
         $('.line-number').on('click', function () {
-            FileLoader.gotoLine(parseFloat($(this).attr('id')))
+            FileLoader.selectLine(parseFloat($(this).attr('id')));
         });
     }
 
 
     var self = {
         /* Export public functions. */
-        gotoLine: this.gotoLine,
+        selectLine: this.selectLine,
         fileSearch: this.fileSearch,
         init: this.init,
         bindLineNumbers: this.bindLineNumbers
     };
-    
-    
+
+
     return self;
 
 })();
@@ -152,7 +155,6 @@ var FileLoader = ( function () {
 $(function () {
     // load file once all resources (incl FileLoader) have been obtained
     FileLoader.init();
-    //FileLoader.fileSearch();
     FileLoader.bindLineNumbers();
     $('form[name="file-search"]').on('submit', function () {
         return FileLoader.fileSearch();
@@ -163,6 +165,14 @@ $(function () {
     $('form[name=file-search]').find('button span.toggle-target')
             .html(ele.html());
     $(document.forms['file-search']['search-mode']).val(ele.data('value'));
+
+    // scroll to line if specified in URL
+    $(document).ready(function (){
+        var hash = window.location.hash;
+        if (hash) {
+            FileLoader.selectLine(hash.split('#')[1]);
+        }
+    });
 });
 
 

--- a/lib/html/template/rose-bush/view-search.html
+++ b/lib/html/template/rose-bush/view-search.html
@@ -18,20 +18,20 @@
 {% else -%}
 <div class="col-md-11">
 {% endif -%}
-{% if not file_content -%}
-{% set lines = lines | map(
-    'replace', 'DEBUG', '<span class="nocode text-muted">DEBUG</span>') | map(
-    'replace', 'INFO', '<span class="nocode text-info">INFO</span>') | map(
-    'replace', 'ERROR', '<span class="nocode text-dander">ERROR</span>') | map(
-    'replace', 'CRITICAL', '<span class="nocode text-dander">CRITICAL</span>') | map(
-    'replace', 'WARNING', '<span class="nocode text-warning">WARNING</span>') -%}
-{% endif -%}
 <pre id="filecode" {% if file_content %}class="prettyprint lang-{{file_content}}"{% endif -%}>
 {% for line in lines -%}
 {% for part in line -%}
-{% if loop.index % 2 == 1 -%}{{part}}{% else 
--%}<span class="highlight">{{part}}</span>{% endif -%}
+{% if not file_content -%}
+{% set part = part | replace(
+    'DEBUG', '<span class="nocode text-muted">DEBUG</span>') | replace(
+    'INFO', '<span class="nocode text-info">INFO</span>') | replace(
+    'ERROR', '<span class="nocode text-dander">ERROR</span>') | replace(
+    'CRITICAL', '<span class="nocode text-dander">CRITICAL</span>') | replace(
+    'WARNING', '<span class="nocode text-warning">WARNING</span>') -%}
 {% endif -%}
+{% if loop.index % 2 == 1 -%}{{part}}{% else 
+-%}<span class="highlight">{{part}}</span>{%
+endif -%}
 {% endfor -%}
 {{ "" }} 
 {% endfor -%}

--- a/lib/html/template/rose-bush/view-search.html
+++ b/lib/html/template/rose-bush/view-search.html
@@ -6,7 +6,7 @@
 <div class="col-md-1 text-right">
 <pre id="filelinenumbers" class="prettyprint">
 {% for num in line_numbers -%}
-<span><a id="{{num}}" class="line-number">{{num}}</a></span>
+<span><a id="{{num}}" href="#{{num}}" class="line-number">{{num}}</a></span>
 {% endfor -%}
 </pre>
 </div>
@@ -18,19 +18,17 @@
 {% else -%}
 <div class="col-md-11">
 {% endif -%}
+{% if not file_content -%}
+{% set lines = lines | map(
+    'replace', 'DEBUG', '<span class="nocode text-muted">DEBUG</span>') | map(
+    'replace', 'INFO', '<span class="nocode text-info">INFO</span>') | map(
+    'replace', 'ERROR', '<span class="nocode text-dander">ERROR</span>') | map(
+    'replace', 'CRITICAL', '<span class="nocode text-dander">CRITICAL</span>') | map(
+    'replace', 'WARNING', '<span class="nocode text-warning">WARNING</span>') -%}
+{% endif -%}
 <pre id="filecode" {% if file_content %}class="prettyprint lang-{{file_content}}"{% endif -%}>
-{% set PREFIXES = {
-  "[DEBUG]": "muted",
-  "[FAIL] ": "text-danger",
-  "[INFO] ": "text-info",
-  "[ OK ] ": "text-success",
-  "[WARN] ": "text-warning",
-} -%}
 {% for line in lines -%}
 {% for part in line -%}
-{% if loop.index == 1 and part|length > 7 and part[0:7] in PREFIXES
--%}<span class="{{PREFIXES[part[0:7]]}}">{{part[0:7]}}</span>{{part[7:]}}{%
-else -%}
 {% if loop.index % 2 == 1 -%}{{part}}{% else 
 -%}<span class="highlight">{{part}}</span>{% endif -%}
 {% endif -%}

--- a/lib/html/template/rose-bush/view.html
+++ b/lib/html/template/rose-bush/view.html
@@ -60,16 +60,16 @@
 </pre>
 </div>
 <div class="col-md-11">
-{% if not file_content -%}
-{% set lines = lines | map(
-    'replace', 'DEBUG', '<span class="nocode text-muted">DEBUG</span>') | map(
-    'replace', 'INFO', '<span class="nocode text-info">INFO</span>') | map(
-    'replace', 'ERROR', '<span class="nocode text-dander">ERROR</span>') | map(
-    'replace', 'CRITICAL', '<span class="nocode text-dander">CRITICAL</span>') | map(
-    'replace', 'WARNING', '<span class="nocode text-warning">WARNING</span>') -%}
-{% endif -%}
 <pre id="filecode"{% if file_content %} class="prettyprint lang-{{file_content}}"{% endif %}>
 {% for line in lines -%}
+{% if not file_content -%}
+{% set line = line | replace(
+    'DEBUG', '<span class="nocode text-muted">DEBUG</span>') | replace(
+    'INFO', '<span class="nocode text-info">INFO</span>') | replace(
+    'ERROR', '<span class="nocode text-dander">ERROR</span>') | replace(
+    'CRITICAL', '<span class="nocode text-dander">CRITICAL</span>') | replace(
+    'WARNING', '<span class="nocode text-warning">WARNING</span>') -%}
+{% endif -%}
 {% if mode == "tags" -%}
 {{line}}
 {% else -%}

--- a/lib/html/template/rose-bush/view.html
+++ b/lib/html/template/rose-bush/view.html
@@ -60,23 +60,20 @@
 </pre>
 </div>
 <div class="col-md-11">
-<pre{% if file_content %} class="prettyprint lang-{{file_content}}"{% endif %}>
-{%- set PREFIXES = {
-    "[DEBUG]": "muted",
-    "[FAIL] ": "text-danger",
-    "[INFO] ": "text-info",
-    "[ OK ] ": "text-success",
-    "[WARN] ": "text-warning",
-} -%}
+{% if not file_content -%}
+{% set lines = lines | map(
+    'replace', 'DEBUG', '<span class="nocode text-muted">DEBUG</span>') | map(
+    'replace', 'INFO', '<span class="nocode text-info">INFO</span>') | map(
+    'replace', 'ERROR', '<span class="nocode text-dander">ERROR</span>') | map(
+    'replace', 'CRITICAL', '<span class="nocode text-dander">CRITICAL</span>') | map(
+    'replace', 'WARNING', '<span class="nocode text-warning">WARNING</span>') -%}
+{% endif -%}
+<pre id="filecode"{% if file_content %} class="prettyprint lang-{{file_content}}"{% endif %}>
 {% for line in lines -%}
-{% if line|length > 7 and line[0:7] in PREFIXES -%}
-<span class="{{PREFIXES[line[0:7]]}}">{{line[0:7]}}</span>{{line[7:]}}
-{% else -%}
 {% if mode == "tags" -%}
 {{line}}
 {% else -%}
 {{line|urlise}}
-{% endif -%}
 {% endif -%}
 {% endfor -%}
 </pre>


### PR DESCRIPTION
* When a line number is specified in the URL the line will be highlighted on page load.
* Selecting a line no longer requires a content reload.
* Highlighting of logger level information (i.e. `INFO`, `DEBUG`, ...) is now restored (broken by the new logging system).

@matthewrmshin please assign second review when the time comes.