### PR TITLE
rose-arch: Raise error for duplicate targets.

### DIFF
--- a/lib/python/rose/apps/rose_arch.py
+++ b/lib/python/rose/apps/rose_arch.py
@@ -39,6 +39,13 @@ from tempfile import mkdtemp
 from time import gmtime, strftime, time
 
 
+class RoseArchDuplicateError(ConfigValueError):
+
+    """An exception raised if dupluicate archive targets are provided."""
+
+    ERROR_FORMAT = '%s: duplicate archive target%s: "%s"'
+
+
 class RoseArchValueError(KeyError):
 
     """An error raised on a bad value."""
@@ -144,8 +151,7 @@ class RoseArchApp(BuiltinApp):
 
             # Don't permit duplicate targets.
             if s_key_tail in s_key_tails:
-                raise Exception('%s: Duplicate target "%s".' % (
-                    t_key, s_key_tail))
+                raise RoseArchDuplicateError([t_key], '', s_key_tail)
             else:
                 s_key_tails.add(s_key_tail)
 

--- a/lib/python/rose/apps/rose_arch.py
+++ b/lib/python/rose/apps/rose_arch.py
@@ -118,7 +118,9 @@ class RoseArchApp(BuiltinApp):
             "rose.apps.rose_arch_compressions",
             ["compress_sources"],
             None, app_runner)
+
         # Set up the targets
+        s_key_tails = set()
         targets = []
         for t_key, t_node in sorted(config.value.items()):
             if t_node.is_ignored() or ":" not in t_key:
@@ -126,8 +128,30 @@ class RoseArchApp(BuiltinApp):
             s_key_head, s_key_tail = t_key.split(":", 1)
             if s_key_head != self.SECTION or not s_key_tail:
                 continue
+
+            # Determine target path.
+            s_key_tail = t_key.split(":", 1)[1]
+            try:
+                s_key_tail = env_var_process(s_key_tail)
+            except UnboundEnvironmentVariableError as exc:
+                raise ConfigValueError([t_key, ""], "", exc)
+
+            # If parenthesised target is optional.
+            is_compulsory_target = True
+            if s_key_tail.startswith("(") and s_key_tail.endswith(")"):
+                s_key_tail = s_key_tail[1:-1]
+                is_compulsory_target = False
+
+            # Don't permit duplicate targets.
+            if s_key_tail in s_key_tails:
+                raise Exception('%s: Duplicate target "%s".' % (
+                    t_key, s_key_tail))
+            else:
+                s_key_tails.add(s_key_tail)
+
             target = self._run_target_setup(
-                app_runner, compress_manager, config, t_key, t_node)
+                app_runner, compress_manager, config, t_key, s_key_tail,
+                t_node, is_compulsory_target)
             old_target = dao.select(target.name)
             if old_target is None or old_target != target:
                 dao.delete(target)
@@ -147,19 +171,11 @@ class RoseArchApp(BuiltinApp):
             RoseArchTarget.ST_BAD)
 
     def _run_target_setup(
-            self, app_runner, compress_manager, config, t_key, t_node):
+            self, app_runner, compress_manager, config, t_key, s_key_tail,
+            t_node, is_compulsory_target=True):
         """Helper for _run. Set up a target."""
         target_prefix = self._get_conf(
             config, t_node, "target-prefix", default="")
-        s_key_tail = t_key.split(":", 1)[1]
-        try:
-            s_key_tail = env_var_process(s_key_tail)
-        except UnboundEnvironmentVariableError as exc:
-            raise ConfigValueError([t_key, ""], "", exc)
-        is_compulsory_target = True
-        if s_key_tail.startswith("(") and s_key_tail.endswith(")"):
-            s_key_tail = s_key_tail[1:-1]
-            is_compulsory_target = False
         target = RoseArchTarget(target_prefix + s_key_tail)
         target.command_format = self._get_conf(
             config, t_node, "command-format", compulsory=True)

--- a/t/rose-task-run/40-app-arch-duplicate.t
+++ b/t/rose-task-run/40-app-arch-duplicate.t
@@ -1,0 +1,41 @@
+#!/bin/bash
+#-------------------------------------------------------------------------------
+# (C) British Crown Copyright 2012-8 Met Office.
+#
+# This file is part of Rose, a framework for meteorological suites.
+#
+# Rose is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Rose is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Rose. If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test "rose_arch" built-in application, duplicate targets.
+#-------------------------------------------------------------------------------
+. "$(dirname "$0")/test_header"
+
+#-------------------------------------------------------------------------------
+tests 1
+#-------------------------------------------------------------------------------
+# Run the suite, and wait for it to complete
+export CYLC_CONF_PATH=
+export ROSE_CONF_PATH=
+mkdir -p "${HOME}/cylc-run"
+SUITE_RUN_DIR="$(mktemp -d "${HOME}/cylc-run/rose-test-battery.XXXXXX")"
+NAME="$(basename "${SUITE_RUN_DIR}")"
+rose suite-run -q -C "${TEST_SOURCE_DIR}/${TEST_KEY_BASE}" --name="${NAME}" \
+    --no-gcontrol --host=localhost -- --no-detach --debug
+#-------------------------------------------------------------------------------
+TEST_KEY="${TEST_KEY_BASE}"
+file_grep "${TEST_KEY}" '[arch:foo]: Duplicate' \
+    "${SUITE_RUN_DIR}/log/job/1/archive_fail_duplicate/NN/job.err"
+#-------------------------------------------------------------------------------
+rose suite-clean -q -y "${NAME}"
+exit 0

--- a/t/rose-task-run/40-app-arch-duplicate.t
+++ b/t/rose-task-run/40-app-arch-duplicate.t
@@ -34,7 +34,8 @@ rose suite-run -q -C "${TEST_SOURCE_DIR}/${TEST_KEY_BASE}" --name="${NAME}" \
     --no-gcontrol --host=localhost -- --no-detach --debug
 #-------------------------------------------------------------------------------
 TEST_KEY="${TEST_KEY_BASE}"
-file_grep "${TEST_KEY}" '[arch:foo]: Duplicate' \
+cat "${SUITE_RUN_DIR}/log/job/1/archive_fail_duplicate/NN/job.err" >&2
+file_grep "${TEST_KEY}" 'duplicate archive target: "foo"' \
     "${SUITE_RUN_DIR}/log/job/1/archive_fail_duplicate/NN/job.err"
 #-------------------------------------------------------------------------------
 rose suite-clean -q -y "${NAME}"

--- a/t/rose-task-run/40-app-arch-duplicate/app/archive/rose-app.conf
+++ b/t/rose-task-run/40-app-arch-duplicate/app/archive/rose-app.conf
@@ -1,0 +1,11 @@
+mode=rose_arch
+
+[arch]
+command-format=cp %(sources)s %(target)s
+target-prefix=$ROSE_SUITE_DIR/share
+
+[arch:foo]
+source=$CYLC_TASK_WORK_DIR/foo
+
+[arch:(foo)]
+source=$CYLC_TASK_WORK_DIR/bar

--- a/t/rose-task-run/40-app-arch-duplicate/suite.rc
+++ b/t/rose-task-run/40-app-arch-duplicate/suite.rc
@@ -1,0 +1,19 @@
+#!jinja2
+[cylc]
+    UTC mode = True
+    [[events]]
+        timeout = PT1M
+        abort on timeout = True
+[scheduling]
+    [[dependencies]]
+        graph = archive_fail_duplicate
+
+[runtime]
+    [[archive_fail_duplicate]]
+        script = """
+            touch foo
+            touch bar
+            rose task-run || true
+        """
+        [[[environment]]]
+            ROSE_TASK_APP = archive


### PR DESCRIPTION
It is possible to pass rose arch a pair of duplicate targets using the `[arch:(target)]` syntax e.g:

```
[arch:foo]

[arch:(foo)]
```

This PR catches the configuration error before it surfaces from sqlite to provide a more helpful error.