### PR TITLE
rose macro: fix transform opt with arg

### DIFF
--- a/lib/python/rose/macro.py
+++ b/lib/python/rose/macro.py
@@ -889,6 +889,7 @@ def update_optional_values(res, optionals, optional_values,
         res["optional_config_name"] = optional_config_name
         del optionals["optional_config_name"]
     for key in set(optionals) & set(optional_values):
+        optionals[key] = optional_values[key]
         res[key] = optional_values[key]
     res.update(get_user_values(optionals, res.keys()))
     optional_values.update(res)

--- a/t/rose-macro/26-optional-config-name-2.t
+++ b/t/rose-macro/26-optional-config-name-2.t
@@ -1,0 +1,51 @@
+#!/bin/bash
+#-------------------------------------------------------------------------------
+# (C) British Crown Copyright 2012-8 Met Office.
+#
+# This file is part of Rose, a framework for meteorological suites.
+#
+# Rose is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Rose is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Rose. If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test that custom parameter is prompted once for transformer macro.
+#-------------------------------------------------------------------------------
+. "$(dirname "$0")/test_header"
+
+tests 2
+
+setup
+init <<'__CONFIG__'
+[env]
+MY_VALUE=who cares
+__CONFIG__
+init_meta <'/dev/null'
+init_opt 'baseeight' <<'__OPT_CONFIG__'
+[env]
+HELLO=world
+__OPT_CONFIG__
+
+init_macro 'custom_macro_change_arg.py' \
+    <"${TEST_SOURCE_DIR}/lib/custom_macro_change_arg.py"
+
+TEST_KEY="${TEST_KEY_BASE}"
+run_pass "${TEST_KEY}" \
+    rose macro --config='../config' \
+    'custom_macro_change_arg.ArgumentTransformer' < <(echo '"whatever"'; yes)
+sed -i '$d' "${TEST_KEY}.out"
+file_cmp "${TEST_KEY}.out" "${TEST_KEY}.out" <<'__OUT__'
+Value for myvalue (default None): [T] custom_macro_change_arg.ArgumentTransformer: changes: 1
+    env=MY_VALUE=who cares
+        who cares -> whatever
+__OUT__
+teardown
+exit

--- a/t/rose-macro/lib/custom_macro_change_arg.py
+++ b/t/rose-macro/lib/custom_macro_change_arg.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2012-8 Met Office.
+#
+# This file is part of Rose, a framework for meteorological suites.
+#
+# Rose is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Rose is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Rose. If not, see <http://www.gnu.org/licenses/>.
+# -----------------------------------------------------------------------------
+
+from rose.macro import MacroBase
+
+
+class ArgumentTransformer(MacroBase):
+
+    """Test class to change a setting to a user defined value."""
+
+    def transform(self, config, meta_config=None, myvalue=None):
+        """Perform the transform operation on the env switch."""
+        keys = ["env", "MY_VALUE"]
+        if config.get(keys) is not None:
+            value = config.get(keys).value
+            if value != myvalue:
+                config.set(keys, myvalue)
+                self.add_report(
+                    "env", "MY_VALUE", value, '%s -> %s' % (value, myvalue))
+        return config, self.reports


### PR DESCRIPTION
Reported by @r-sharp. New test (which fails on current master) demonstrates the issue. The transform dies on an optional configuration that does not have the custom argument.