### PR TITLE
metadata-check: ignore GTK widgets if no display

### DIFF
--- a/lib/python/rose/metadata_check.py
+++ b/lib/python/rose/metadata_check.py
@@ -217,13 +217,11 @@ def _check_widget(value, module_files=None, meta_dir=None):
     try:
         widget = rose.resource.import_object(
             widget_name, module_files, _import_err_handler)
-    except RuntimeError as exc:
+    except Exception as exc:
         # Ignore if there is no display for GTK widget
-        if (not os.getenv('DISPLAY') and
+        if (isinstance(exc, RuntimeError) and not os.getenv('DISPLAY') and
                 exc.args == ('could not open display',)):
             return
-        return INVALID_IMPORT.format(widget_name, type(exc).__name__, exc)
-    except Exception as exc:
         return INVALID_IMPORT.format(widget_name, type(exc).__name__, exc)
     if widget is None:
         return INVALID_OBJECT.format(value)

--- a/t/rosie.db/00-query.t
+++ b/t/rosie.db/00-query.t
@@ -52,10 +52,11 @@ run_pass "$TEST_KEY" $TEST_PARSER \
     '[["and", "description", "eq", "shiny"],
       ["or", "title", "eq", "Something"],
       ["and", "simulation", "contains", "Matrix"]]'
+sed -i 's/%%/%/g' "${TEST_KEY}.out"
 file_cmp_any "$TEST_KEY.out" "$TEST_KEY.out" <<'__CONTENT__'
-optional.name = :name_1 AND optional.value = :value_1 OR main.title = :title_1 AND optional.name = :name_2 AND optional.value LIKE '%%' || :value_2 || '%%'
+optional.name = :name_1 AND optional.value = :value_1 OR main.title = :title_1 AND optional.name = :name_2 AND optional.value LIKE '%' || :value_2 || '%'
 __filesep__
-optional.name = :name_1 AND optional.value = :value_1 OR main.title = :title_1 AND optional.name = :name_2 AND (optional.value LIKE '%%' || :value_2 || '%%')
+optional.name = :name_1 AND optional.value = :value_1 OR main.title = :title_1 AND optional.name = :name_2 AND (optional.value LIKE '%' || :value_2 || '%')
 __CONTENT__
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
 #-------------------------------------------------------------------------------
@@ -76,10 +77,11 @@ run_pass "$TEST_KEY" $TEST_PARSER \
     '[["and", "(", "description", "eq", "shiny"],
       ["or", "title", "eq", "Something", ")"],
       ["and", "simulation", "contains", "Matrix"]]'
+sed -i 's/%%/%/g' "${TEST_KEY}.out"
 file_cmp_any "$TEST_KEY.out" "$TEST_KEY.out" <<'__CONTENT__'
-(optional.name = :name_1 AND optional.value = :value_1 OR main.title = :title_1) AND optional.name = :name_2 AND optional.value LIKE '%%' || :value_2 || '%%'
+(optional.name = :name_1 AND optional.value = :value_1 OR main.title = :title_1) AND optional.name = :name_2 AND optional.value LIKE '%' || :value_2 || '%'
 __filesep__
-(optional.name = :name_1 AND optional.value = :value_1 OR main.title = :title_1) AND optional.name = :name_2 AND (optional.value LIKE '%%' || :value_2 || '%%')
+(optional.name = :name_1 AND optional.value = :value_1 OR main.title = :title_1) AND optional.name = :name_2 AND (optional.value LIKE '%' || :value_2 || '%')
 __CONTENT__
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
 #-------------------------------------------------------------------------------
@@ -94,10 +96,11 @@ run_pass "$TEST_KEY" $TEST_PARSER \
       ["or", "((", "author", "contains", "fr"],
       ["or", "revision", "lt", "100", ")"],
       ["or", "title", "contains", "x", ")"]]'
+sed -i 's/%%/%/g' "${TEST_KEY}.out"
 file_cmp_any "$TEST_KEY.out" "$TEST_KEY.out" <<'__CONTENT__'
-optional.name = :name_1 AND optional.value = :value_1 OR main.title = :title_1 AND (main.owner = :owner_1 OR main.owner = :owner_2) OR main.author LIKE '%%' || :author_1 || '%%' OR latest.revision < :revision_1 OR main.title LIKE '%%' || :title_2 || '%%'
+optional.name = :name_1 AND optional.value = :value_1 OR main.title = :title_1 AND (main.owner = :owner_1 OR main.owner = :owner_2) OR main.author LIKE '%' || :author_1 || '%' OR latest.revision < :revision_1 OR main.title LIKE '%' || :title_2 || '%'
 __filesep__
-optional.name = :name_1 AND optional.value = :value_1 OR main.title = :title_1 AND (main.owner = :owner_1 OR main.owner = :owner_2) OR (main.author LIKE '%%' || :author_1 || '%%') OR latest.revision < :revision_1 OR (main.title LIKE '%%' || :title_2 || '%%')
+optional.name = :name_1 AND optional.value = :value_1 OR main.title = :title_1 AND (main.owner = :owner_1 OR main.owner = :owner_2) OR (main.author LIKE '%' || :author_1 || '%') OR latest.revision < :revision_1 OR (main.title LIKE '%' || :title_2 || '%')
 __CONTENT__
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
 #-------------------------------------------------------------------------------
@@ -113,10 +116,11 @@ run_pass "$TEST_KEY" $TEST_PARSER \
       ["or", "((", "author", "contains", "fr"],
       ["or", "revision", "lt", "100", ")"],
       ["and", "title", "eq", "x", ")"]]'
+sed -i 's/%%/%/g' "${TEST_KEY}.out"
 file_cmp_any "$TEST_KEY.out" "$TEST_KEY.out" <<'__CONTENT__'
-(optional.name = :name_1 AND optional.value = :value_1 OR main.title = :title_1 OR main.title = :title_2) AND (main.owner = :owner_1 OR main.owner = :owner_2) OR (main.author LIKE '%%' || :author_1 || '%%' OR latest.revision < :revision_1) AND main.title = :title_3
+(optional.name = :name_1 AND optional.value = :value_1 OR main.title = :title_1 OR main.title = :title_2) AND (main.owner = :owner_1 OR main.owner = :owner_2) OR (main.author LIKE '%' || :author_1 || '%' OR latest.revision < :revision_1) AND main.title = :title_3
 __filesep__
-(optional.name = :name_1 AND optional.value = :value_1 OR main.title = :title_1 OR main.title = :title_2) AND (main.owner = :owner_1 OR main.owner = :owner_2) OR ((main.author LIKE '%%' || :author_1 || '%%') OR latest.revision < :revision_1) AND main.title = :title_3
+(optional.name = :name_1 AND optional.value = :value_1 OR main.title = :title_1 OR main.title = :title_2) AND (main.owner = :owner_1 OR main.owner = :owner_2) OR ((main.author LIKE '%' || :author_1 || '%') OR latest.revision < :revision_1) AND main.title = :title_3
 __CONTENT__
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
Allow check to pass for GTK widgets if there is no display in the environment.

Problem reported by @scwhitehouse.