### PR TITLE
rose bush: fix template: hierarchical suite names

### DIFF
--- a/lib/html/template/rose-bush/broadcast-events.html
+++ b/lib/html/template/rose-bush/broadcast-events.html
@@ -6,7 +6,7 @@
 
 <div class="row"><div class="col-md-12">
 <ul class="list-inline pull-right">
-  <li><a href="{{script}}/broadcast_states/{{user}}/{{suite|replace("/", "%2F")}}">states</a></li>
+  <li><a href="{{script}}/broadcast_states/{{user}}/?&amp;suite={{suite|replace("/", "%2F")}}">states</a></li>
   <li>events</li>
 </ul>
 

--- a/lib/html/template/rose-bush/broadcast-states.html
+++ b/lib/html/template/rose-bush/broadcast-states.html
@@ -7,7 +7,7 @@
 <div class="row"><div class="col-md-12">
 <ul class="list-inline pull-right">
   <li>states</li>
-  <li><a href="{{script}}/broadcast_events/{{user}}/{{suite|replace("/", "%2F")}}">events</a></li>
+  <li><a href="{{script}}/broadcast_events/{{user}}/?&amp;suite={{suite|replace("/", "%2F")}}">events</a></li>
 </ul>
 
 {% if broadcast_states %}

--- a/lib/html/template/rose-bush/suite-base.html
+++ b/lib/html/template/rose-bush/suite-base.html
@@ -53,7 +53,7 @@ rel="stylesheet" media="screen" />
         </li>
         {% else %}
         <li>
-          <a href="{{script}}/{{method}}/{{user}}/{{suite|replace("/", "%2F")}}">
+          <a href="{{script}}/{{method}}/{{user}}?&amp;suite={{suite|replace("/", "%2F")}}">
             <i class="glyphicon {{icon}}" title="{{name}}"></i>
             {{name}}
           </a>
@@ -75,7 +75,7 @@ rel="stylesheet" media="screen" />
               <ul class="dropdown-menu">
         {% for log_path in log.paths -%}
                 <li>
-                  <a href="{{script}}/view/{{user}}/{{suite|replace("/", "%2F")}}?path={{log_path}}&amp;no_fuzzy_time={{no_fuzzy_time}}"
+                  <a href="{{script}}/view/{{user}}?&amp;suite={{suite|replace("/", "%2F")}}&amp;path={{log_path}}&amp;no_fuzzy_time={{no_fuzzy_time}}"
                   title="{{log.size}} bytes">{{log_path}}</a>
                 </li>
         {% endfor -%}
@@ -83,7 +83,7 @@ rel="stylesheet" media="screen" />
             </li>
         {% else -%}
             <li>
-              <a href="{{script}}/view/{{user}}/{{suite|replace("/", "%2F")}}?path={{log.path}}&amp;no_fuzzy_time={{no_fuzzy_time}}"
+              <a href="{{script}}/view/{{user}}?&amp;suite={{suite|replace("/", "%2F")}}&amp;path={{log.path}}&amp;no_fuzzy_time={{no_fuzzy_time}}"
               title="{{log.size}} bytes">{{key}}</a></li>
         {% endif -%}
         {% endfor -%}

--- a/lib/html/template/rose-bush/view-mode.html
+++ b/lib/html/template/rose-bush/view-mode.html
@@ -1,10 +1,10 @@
 <ul class="nav navbar-nav pull-right">
 {% if mode == "tags" -%}
-<li><a href="{{script}}/view/{{user}}/{{suite|replace("/", "%2F")}}?path={{path}}{%- if path_in_tar -%}&amp;path_in_tar={{path_in_tar}}{%- endif -%}&amp;mode=text">Text</a></li>
+<li><a href="{{script}}/view/{{user}}/?&amp;suite={{suite|replace("/", "%2F")}}&amp;path={{path}}{%- if path_in_tar -%}&amp;path_in_tar={{path_in_tar}}{%- endif -%}&amp;mode=text">Text</a></li>
 <li class="active"><a>Tags</a></li>
 {% else -%}
 <li class="active"><a>Text</a></li>
-<li><a href="{{script}}/view/{{user}}/{{suite|replace("/", "%2F")}}?path={{path}}{%- if path_in_tar -%}&amp;path_in_tar={{path_in_tar}}{%- endif -%}&amp;mode=tags">Tags</a></li>
+<li><a href="{{script}}/view/{{user}}/?&amp;suite={{suite|replace("/", "%2F")}}&amp;path={{path}}{%- if path_in_tar -%}&amp;path_in_tar={{path_in_tar}}{%- endif -%}&amp;mode=tags">Tags</a></li>
 {% endif -%}
-<li><a href="{{script}}/view/{{user}}/{{suite|replace("/", "%2F")}}?path={{path}}{%- if path_in_tar -%}&amp;path_in_tar={{path_in_tar}}{%- endif -%}&amp;mode=download">Raw</a></li>
+<li><a href="{{script}}/view/{{user}}/?&amp;suite={{suite|replace("/", "%2F")}}&amp;path={{path}}{%- if path_in_tar -%}&amp;path_in_tar={{path_in_tar}}{%- endif -%}&amp;mode=download">Raw</a></li>
 </ul>

--- a/lib/html/template/rose-bush/view.html
+++ b/lib/html/template/rose-bush/view.html
@@ -16,7 +16,7 @@
   </div>
   <div>
     <small>
-      <a href="{{script}}/view/{{user}}/{{suite|replace("/", "%2F")}}?path={{path}}">{{f_name}}</a>
+      <a href="{{script}}/view/{{user}}/?&amp;suite={{suite|replace("/", "%2F")}}&amp;path={{path}}">{{f_name}}</a>
       <span class="label label-default">Content loaded
       <abbr class="livestamp" title="{{time}}">{{time}}</abbr></span>
     </small>


### PR DESCRIPTION
Use `?&suite=SUITE` instead of `/SUITE` in links.

Fix #2133.