### PR TITLE
rose bush now auto refreshes some pages

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,6 +41,7 @@ below:
 * Stuart Whitehouse (Met Office, UK)
 * Steve Wardle (Met Office, UK)
 * Scott Wales (ARC Centre of Excellence for Climate Systems Science, Australia)
+* Thomas Coleman (Bureau of Meteorology, Australia)
 
 (All contributors are identifiable with email addresses in the version control
 logs or otherwise.)

--- a/lib/html/template/rose-bush/broadcast-events.html
+++ b/lib/html/template/rose-bush/broadcast-events.html
@@ -1,6 +1,6 @@
 {% extends "suite-base.html" %}
 {% block title_name %}broadcasts list{% endblock %}
-
+{% block auto_refresh %}<meta http-equiv="refresh" content="120">{% endblock %}
 {% block content %}
 <div class="container-fluid">
 

--- a/lib/html/template/rose-bush/broadcast-states.html
+++ b/lib/html/template/rose-bush/broadcast-states.html
@@ -1,6 +1,6 @@
 {% extends "suite-base.html" %}
 {% block title_name %}broadcasts list{% endblock %}
-
+{% block auto_refresh %}<meta http-equiv="refresh" content="120">{% endblock %}
 {% block content %}
 <div class="container-fluid">
 

--- a/lib/html/template/rose-bush/cycles.html
+++ b/lib/html/template/rose-bush/cycles.html
@@ -1,6 +1,6 @@
 {% extends "suite-base.html" %}
 {% block title_name %}cycles list{% endblock %}
-
+{% block auto_refresh %}<meta http-equiv="refresh" content="120">{% endblock %}
 {% block content %}
 <div class="page-header">
   <div class="panel-group" id="accordion-0">

--- a/lib/html/template/rose-bush/suite-base.html
+++ b/lib/html/template/rose-bush/suite-base.html
@@ -3,6 +3,7 @@
 <head>
 <title>{% if path is defined %}{{path}} {% endif %}{{suite}}~{{user}}:
 {{title}} @ {{host}} - {% block title_name %}{% endblock %}</title>
+{% block auto_refresh %}{% endblock %}
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <link rel="icon" href="{{script}}/favicon.ico" />
 <link rel="shortcut icon" href="{{script}}/favicon.ico" />

--- a/lib/html/template/rose-bush/suites.html
+++ b/lib/html/template/rose-bush/suites.html
@@ -3,6 +3,7 @@
 <head>
 <title>{{user}}: {{title}}</title>
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta http-equiv="refresh" content="120">
 <link rel="icon" href="{{script}}/favicon.ico" />
 <link rel="shortcut icon" href="{{script}}/favicon.ico" />
 <link type="text/css" href="{{script}}/css/bootstrap.min.css"

--- a/lib/html/template/rose-bush/taskjobs.html
+++ b/lib/html/template/rose-bush/taskjobs.html
@@ -1,5 +1,6 @@
 {% extends "suite-base.html" %}
 {% block title_name %}task jobs list{% endblock %}
+{% block auto_refresh %}<meta http-equiv="refresh" content="120">{% endblock %}
 {% block content %}
 <div class="page-header">
 


### PR DESCRIPTION
Pages include:
* broadcast-events and broadcast-states
* cycles
* suites
* taskjobs

These pages are reasonably expected to update on a semi-frequent basis. For monitoring,
having them auto-refresh will ensure you will probably have the most likely data
at your fingertips if you have your browser open on rose-bush.