### PR TITLE
rose make-docs: add --strict option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,5 +41,4 @@ jobs:
             (echo -e "\n\nRerunning Failed Tests...\n\n";
             rose test-battery -v --state=save,failed -j 5)
         - script: >
-            rose make-docs --venv --dev clean strict linkcheck doctest &&
-            rose make-docs --venv --dev html slides
+            rose make-docs --venv --dev --strict clean linkcheck doctest html slides

--- a/bin/rose-make-docs
+++ b/bin/rose-make-docs
@@ -32,6 +32,9 @@
 #         if necessary.
 #     --dev
 #         Development mode, don't remove virtualenv after build.
+#     --strict
+#         Disable cashe forcing a complete re-build and turn warnings into
+#         errors.
 #
 # BUILD
 #     The format(s) to build the documentation in - default html.
@@ -54,9 +57,6 @@
 #
 #     `doctest`
 #         Runs any doctest examples present in documented python modules.
-#     `strict`
-#         Runs sphinx-build in a "strict" mode where caching is turned off and
-#         warnings are turned into errors.
 #     `linkcheck`
 #         Checks external links.
 #
@@ -106,6 +106,7 @@ VENV_MODE=false
 FORCE=false
 DEV_MODE=false
 BUILDS=''
+SPHINXOPTS=''
 while [[ $# -gt 0 ]]; do
     case $1 in
         --venv)
@@ -118,6 +119,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         --force)
             FORCE=true
+            shift
+            ;;
+        --strict)
+            SPHINXOPTS='SPHINXOPTS=-aEW'
             shift
             ;;
         *)
@@ -187,7 +192,7 @@ if ! rose-check-software --doc >/dev/null; then
 fi
 
 # Run sphinx make.
-make -C "${SPHINX_PATH}" ${BUILDS}
+make -C "${SPHINX_PATH}" ${BUILDS} "${SPHINXOPTS}"
 
 # Remove virtualenv if used and if we are not in development mode.
 if "${USING_VENV}"; then

--- a/lib/python/rose/apps/ana_builtin/grepper.py
+++ b/lib/python/rose/apps/ana_builtin/grepper.py
@@ -228,7 +228,8 @@ class SingleCommandPattern(SingleCommandStatus):
         kgo_file:
             Same as previous task.
         pattern:
-            The regular expression to search for in the stdout from the command.
+            The regular expression to search for in the stdout from the
+            command.
 
     """
 

--- a/sphinx/Makefile
+++ b/sphinx/Makefile
@@ -180,8 +180,3 @@ pseudoxml:
 	$(SPHINXBUILD) -b pseudoxml $(ALLSPHINXOPTS) $(BUILDDIR)/pseudoxml
 	@echo
 	@echo "Build finished. The pseudo-XML files are in $(BUILDDIR)/pseudoxml."
-
-strict:
-	$(SPHINXBUILD) -aEW -b dummy $(ALLSPHINXOPTS) $(BUILDDIR)
-	@echo
-	@echo "Dummy build finished."

--- a/sphinx/developing/building.rst
+++ b/sphinx/developing/building.rst
@@ -8,6 +8,9 @@ Building & Testing
 The documentation is built by the :ref:`command-rose-make-docs` command. Its
 arguments are provided to the sphinx makefile in order.
 
+Build using the ``--strict`` argument before committing changes, this forces a
+re-build and will fail if any warnings are raised.
+
 Whenever making changes to the sphinx infrastructure use a clean build e.g:
 
 .. code-block:: bash
@@ -16,8 +19,6 @@ Whenever making changes to the sphinx infrastructure use a clean build e.g:
 
 The following builders are useful for development:
 
-``strict``
-   Perform a dummy build - fail if any warnings are raised.
 ``linkcheck``
    Check external links (internal links are checked by a regular build).
 ``doctest``

--- a/sphinx/tutorial/rose/summary.rst
+++ b/sphinx/tutorial/rose/summary.rst
@@ -34,22 +34,28 @@ So far we have covered:
 
     subgraph cluster_1 {
         label = "Cylc Suite"
-        fontsize="20"
-        fontcolor="#5050aa"
-        labelloc="r"
-        "suite.rc" [fontsize="18", fontname="mono", fontcolor"black"]
+        fontsize = "20"
+        fontcolor = "#5050aa"
+        labelloc = "r"
+        "suite.rc" [fontsize="18",
+                    fontname="mono",
+                    fontcolor="black"]
         "rcinfo" [label="Defines the workflow\nin terms of tasks\nand dependencies"]
         "suite.rc" -- "rcinfo"
 
         subgraph cluster_2 {
             label = "Rose Suite Configuration"
-            "rose-suite.conf" [fontsize="18", fontname="mono", fontcolor"black"]
+            "rose-suite.conf" [fontsize="18",
+                               fontname="mono",
+                               fontcolor="black"]
             "confinfo" [label="Defines Jinja2 variables for\nthe suite.rc and environment\nvariables for use throughout\nthe suite"]
             "rose-suite.conf" -- "confinfo"
 
             subgraph cluster_3 {
                 label = "Rosie Suite"
-                "rose-suite.info" [fontsize="18", fontname="mono", fontcolor"black"]
+                "rose-suite.info" [fontsize="18",
+                                   fontname="mono",
+                                   fontcolor="black"]
                 "infoinfo" [label="Contains basic information\nabout the suite used\nby Rosie for searching\nand version control purposes"]
                 "rose-suite.info" -- "infoinfo"
             }


### PR DESCRIPTION
~**Built on #2170, review after it is merged**~

It is possible for ``rose make-docs strict`` to pass but ``rose make-docs html`` to fail as some things, e.g. graphviz are only done as required. To pick up these errors TravisCI now runs *all* builds in "strict" mode.