### PR TITLE
Rose user guide rose stem

### DIFF
--- a/etc/rose.conf.example
+++ b/etc/rose.conf.example
@@ -318,6 +318,11 @@ path-prepend.PYTHONPATH=
 [rose-ana]
 # Items to prepend to the search path for user methods.
 method-path=/path/1 /path2
+# :default: .false.
+#
+# Turns on the :ref:`Rose Ana Comparison Database
+# <The Rose Ana Comparison Database>`.
+kgo-database=.true.
 
 
 # Configuration related to the database of the Rosie web service server.

--- a/etc/rose.conf.example
+++ b/etc/rose.conf.example
@@ -323,6 +323,12 @@ method-path=/path/1 /path2
 # Turns on the :ref:`Rose Ana Comparison Database
 # <The Rose Ana Comparison Database>`.
 kgo-database=.true.
+# Limits the number of lines printed when using the
+# :py:mod:`rose.apps.ana_builtin.grepper` analysis class.
+grepper-report-limit=42
+# Causes the :py:mod:`rose.apps.ana_builtin.grepper` class to pass
+# if all files to be compared are missing.
+skip-if-all-files-missing=.true.
 
 
 # Configuration related to the database of the Rosie web service server.

--- a/lib/python/rose/apps/ana_builtin/grepper.py
+++ b/lib/python/rose/apps/ana_builtin/grepper.py
@@ -20,7 +20,7 @@
 """The following options can be specified in:
 
 * :rose:conf:`rose.conf[rose-ana]`
-* :rose:conf:`rose_ana[ana:ANALYSIS_CLASS]`
+* :rose:conf:`rose_ana[ana:config]`
 
 .. describe:: Options
 

--- a/lib/python/rose/apps/ana_builtin/grepper.py
+++ b/lib/python/rose/apps/ana_builtin/grepper.py
@@ -17,6 +17,29 @@
 # You should have received a copy of the GNU General Public License
 # along with Rose. If not, see <http://www.gnu.org/licenses/>.
 # -----------------------------------------------------------------------------
+"""The following options can be specified in the
+:rose:conf:`rose_ana[ana:ANALYSIS_CLASS]` section a :rose:app:`rose_ana`
+application or in the :rose:conf:`rose.conf[rose-ana]` section of the site/user
+configuration:
+
+.. describe:: Options
+
+    grepper-report-limit:
+        A numerical value giving the maximum number of informational output
+        lines to print for each comparison. This is intended for cases where
+        for example a pattern-matching comparison is expected to match many
+        thousands of occurences in the given files; it may not be desirable
+        to print the results of every comparison. After the given number of
+        lines are printed a special message indicating that the rest of the
+        output is truncated will be produced.
+    skip-if-all-files-missing:
+        Can be set to ``.true.`` or ``.false.``; if active, any comparison
+        done on files by ``grepper`` will be skipped if all of those files
+        are non-existent. In this case the task will return as "skipped"
+        rather than passed/failed.
+
+"""
+
 import os
 import re
 from rose import TYPE_LOGICAL_VALUE_TRUE
@@ -24,7 +47,23 @@ from rose.apps.rose_ana import AnalysisTask
 
 
 class SingleCommandStatus(AnalysisTask):
-    """Run a single command and pass/fail based on its exit status."""
+    """Run a shell command, passing or failing depending on the exit
+       status of that command.
+
+       Options:
+           files (optional):
+               A newline-separated list of filenames which may appear
+               in the command.
+           command:
+               The command to run; if it contains Python style
+               format specifiers these will be expanded using the list of
+               files above (if provided).
+           kgo_file:
+               If the list of files above was provided gives the
+               (0-based) index of the file holding the "kgo" or "control"
+               output for use with the comparisons database (if active).
+    """
+
     def run_analysis(self):
         """Main analysis routine called from rose_ana."""
         self.process_opt_files()
@@ -180,11 +219,19 @@ class SingleCommandStatus(AnalysisTask):
 
 
 class SingleCommandPattern(SingleCommandStatus):
-    """
-    Run a single command and then pass/fail depending on the presence of a
+    """Run a single command and then pass/fail depending on the presence of a
     particular expression in that command's standard output.
 
+    Options:
+        files (optional):
+            Same as previous task. command - same as previous task.
+        kgo_file:
+            Same as previous task.
+        pattern:
+            The regular expression to search for in the stdout from the command.
+
     """
+
     def run_analysis(self):
         """Main analysis routine called from rose_ana."""
         # Note that this is identical to the above class, only it has the
@@ -233,11 +280,28 @@ class SingleCommandPattern(SingleCommandStatus):
 
 
 class FilePattern(SingleCommandPattern):
-    """
-    Check for occurences of a particular expression or value within the
+    """Check for occurences of a particular expression or value within the
     contents of two or more files.
 
+    Options:
+        files (optional):
+            Same as previous tasks.
+        kgo_file:
+            Same as previous tasks.
+        pattern:
+            The regular expression to search for in the files. The
+            expression should include one or more capture groups; each
+            of these will be compared between the files any time the
+            pattern occurs.
+        tolerance (optional):
+            By default the above comparisons will be compared exactly,
+            but if this argument is specified they will be converted to
+            float values and compared according to the given tolerance.
+            If this tolerance ends in % it will be interpreted as a
+            relative tolerance (otherwise absolute).
+
     """
+
     def run_analysis(self):
         """Main analysis routine called from rose_ana."""
         self.process_opt_files()
@@ -400,11 +464,24 @@ class FilePattern(SingleCommandPattern):
 
 
 class FileCommandPattern(FilePattern):
-    """
-    Check for occurences of a particular expression or value in the standard
+    """Check for occurences of a particular expression or value in the standard
     output from a command applied to two or more files.
 
+    Options:
+        files (optional):
+            Same as previous tasks.
+        kgo_file:
+            Same as previous tasks.
+        pattern:
+            Same as previous tasks.
+        tolerance (optional):
+            Same as previous tasks.
+        command:
+            The command to run; it should contain a Python style format
+            specifier to be expanded using the list of files above.
+
     """
+
     def run_analysis(self):
         """Main analysis routine called from rose_ana."""
         # Note that this is identical to the above class, only it has the

--- a/lib/python/rose/apps/ana_builtin/grepper.py
+++ b/lib/python/rose/apps/ana_builtin/grepper.py
@@ -17,10 +17,10 @@
 # You should have received a copy of the GNU General Public License
 # along with Rose. If not, see <http://www.gnu.org/licenses/>.
 # -----------------------------------------------------------------------------
-"""The following options can be specified in the
-:rose:conf:`rose_ana[ana:ANALYSIS_CLASS]` section a :rose:app:`rose_ana`
-application or in the :rose:conf:`rose.conf[rose-ana]` section of the site/user
-configuration:
+"""The following options can be specified in:
+
+* :rose:conf:`rose.conf[rose-ana]`
+* :rose:conf:`rose_ana[ana:ANALYSIS_CLASS]`
 
 .. describe:: Options
 

--- a/lib/python/rose/apps/rose_ana.py
+++ b/lib/python/rose/apps/rose_ana.py
@@ -152,10 +152,25 @@ class KGODatabase(object):
 
 
 class AnalysisTask(object):
-    """
-    Base class for an analysis task; all custom user tasks should inherit
-    from this class and override the "run_analysis" method to perform
-    whatever analysis is required.
+    """Base class for an analysis task.
+
+    All custom user tasks should inherit from this class and override
+    the ``run_analysis`` method to perform whatever analysis is required.
+
+    This class provides the following attributes:
+
+    Attributes:
+        self.config:
+            A dictionary containing any Rose Ana configuration options.
+        self.reporter:
+            A reference to the :py:class:`rose.reporter.Reporter` instance used
+            by the parent app (for printing to stderr/stdout).
+        self.kgo_db:
+            A reference to the KGO database object created by the parent app
+            (for adding entries to the database).
+        self.popen:
+            A reference to the :py:class:`rose.popen.RosePopener` instance
+            used by the parent app (for spawning subprocesses).
 
     """
     __metaclass__ = abc.ABCMeta

--- a/sphinx/api/built-in/rose_ana.rst
+++ b/sphinx/api/built-in/rose_ana.rst
@@ -25,7 +25,7 @@ load firstly in the ``ana`` subdirectory of the ``rose-ana`` app, then in
 the ``ana`` subdirectory of the top-most suite directory. Any
 additional directories to search (for example a site-wide central
 directory) may be specified by setting the
-:rose:conf:`rose_ana[rose-ana]method-path` variable. Finally the
+:rose:conf:`rose.conf[rose-ana]method-path` variable. Finally the
 ``ana_builtins`` subdirectory of the Rose installation itself contains
 any built-in comparisons.
 
@@ -78,11 +78,22 @@ details.
 
 .. rose:app:: rose_ana
 
-   .. rose:conf:: rose-ana
+   .. rose:conf:: ana:config
 
-      .. rose:conf:: method-path
+      .. rose:conf:: grepper-report-limit
 
-         Specify additional search paths for analysis modules.
+         Limits the number of lines printed when using the
+         :py:mod:`rose.apps.ana_builtin.grepper` analysis class.
+
+      .. rose:conf:: skip-if-all-files-missing
+
+         Causes the :py:mod:`rose.apps.ana_builtin.grepper` class to pass
+         if all files to be compared are missing.
+
+      .. rose:conf:: kgo-database
+
+         Turns on the :ref:`Rose Ana Comparison Database
+         <The Rose Ana Comparison Database>`.
 
    .. rose:conf:: ana:ANALYSIS_CLASS
 

--- a/sphinx/ext/rose_domain.py
+++ b/sphinx/ext/rose_domain.py
@@ -829,6 +829,7 @@ class RoseAutoDirective(Directive):
         except config.ConfigSyntaxError:
             LOGGER.error(
                 'Syntax error in Rose configuration file "%s".' % filename)
+            raise
 
         nodes = []
         nodes.append(addnodes.highlightlang(lang='rose', linenothreshold=20))

--- a/sphinx/tutorial/rose/furthertopics/rose-stem.rst
+++ b/sphinx/tutorial/rose/furthertopics/rose-stem.rst
@@ -1,310 +1,376 @@
 .. include:: ../../../hyperlinks.rst
    :start-line: 1
 
+.. _Rose Stem:
+
 Rose Stem
 =========
 
+Rose Stem is a testing system for use with Rose. It provides a user-friendly
+way of defining source trees and tasks on the command line which are then
+passed by Rose Stem to the suite as Jinja2 variables.
+
 .. warning::
 
-   Before proceeding you should already be familiar with the Rose Stem
-   part of the user guide.
-
-   .. TODO - link in the rose user guide page when translated.
-
-.. image:: http://upload.wikimedia.org/wikipedia/commons/thumb/b/b2/Cassini_Saturn_Orbit_Insertion.jpg/320px-Cassini_Saturn_Orbit_Insertion.jpg
-   :align: right
-   :alt: Artist's Impression of Cassini entering Saturn orbit
-   :width: 300px
-
-This tutorial will walk you through creating a simple example of the
-Rose Stem testing system which will involve piloting a spaceship
-through space.
+   Rose Stem requires the use of `FCM`_ as it requires some of the version
+   control information.
 
 
-Getting Started
----------------
+Motivation
+----------
 
-We will start the Rose Stem tutorial by setting up an `FCM`_ repository
-called ``SPACESHIP`` to store the code and test suite in.
+Why do we test code?
 
-.. _keyword: https://metomi.github.io/fcm/doc/user_guide/code_management.html#svn_basic_keywords
+Most people would answer something along the lines of "so we know it works".
 
-Usually you would add a Rose Stem suite to an existing repository with
-the `keyword`_ already set up to test the accompanying source code. For the
-purposes of this tutorial we will create a new one.
+However, this is really asking two related but separate questions.
 
-Type the follow to create a temporary repository (you can safely delete
-it after finishing this tutorial)::
+#. Does the code do what I meant it to do?
+#. Does the code do anything I didn't mean it to do?
 
-   mkdir -p ~/rose-tutorial
-   svnadmin create ~/rose-tutorial/spaceship_repos
-   (cd $(mktemp -d); mkdir -p trunk/src; svn import -m "" . file://$HOME/rose-tutorial/spaceship_repos)
+Answering the first question may involve writing a bespoke test and checking
+the results. The second question can at least partially be answered by using
+an automated testing system which runs predefined tasks and presents the
+answers. Rose Stem is a system for doing this.
 
-We then need to link the project name ``SPACESHIP`` with this project.
-Creating the file and directory if they do not exist
-add the following line to the file ``$HOME/.metomi/fcm/keyword.cfg``:
-
-.. code-block:: rose
-
-   location{primary}[spaceship] = file:///home/user/rose-tutorial/spaceship_repos
-
-Make sure the path on the right-hand side matches the location you
-specified in the ``svnadmin`` command.
-
-Now you can checkout a working copy of your repository by typing::
-
-   mkdir -p ~/rose-tutorial/spaceship_working_copy
-   cd ~/rose-tutorial/spaceship_working_copy
-   fcm checkout fcm:spaceship_tr .
-
-Finally populate your working copy by running (answering ``y`` to the prompt)::
-
-   rose tutorial rose-stem .
+N.B. When writing tests for new code, they should be added to the testing
+system so that future developers can be confident that they haven't broken
+the new functionality.
 
 
-``spaceship_command.f90``
+Rose Stem
+---------
+
+There are two components in Rose Stem:
+
+:ref:`command-rose-stem`
+   The command line tool which executes an appropriate suite.
+:rose:app:`rose_ana`
+   A Rose built-in application which can compare the result of a task against
+   a control.
+
+We will describe each in turn. It is intended that a test suite lives
+alongside the code in the same version-controlled project, which should
+encourage developers to update the test suite when they update the code.
+This means that the test suite will always be a valid test of the code
+it is accompanying.
+
+
+Running A Suite With :ref:`command-rose-stem`
+---------------------------------------------
+
+The ``rose stem`` command is essentially a wrapper to
+:ref:`command-rose-suite-run`, which accepts some additional arguments
+and converts them to Jinja2 variables which the suite can interpret.
+
+These arguments are:
+
+``--source``
+   Specifies a source tree to include in a suite.
+``--group``
+   Specifies a group of tasks to run.
+
+A group is a set of Rose tasks which together test a certain configuration
+of a program.
+
+
+The ``--source`` Argument
 -------------------------
 
-Our Fortran program is ``spaceship_command.f90``, which reads in an
-initial position and spaceship mass from one namelist, and a series
-of commands to apply thrust in three-dimensional space. It then uses
-Newtonian mechanics to calculate a final position.
+The source argument provides a set of Jinja2 variables which can then be
+included in any compilation tasks in a suite. You can specify multiple
+``--source`` arguments on the command line. For example::
 
-You will find it in the ``src`` directory. Have a look at it and see
-what it does.
+   rose stem --source=/path/to/workingcopy --source=fcm:other_project_tr@head
 
+Each source tree is associated with a project (via an ``fcm`` command) when
+:ref:`command-rose-stem` is run on the command line. This project name
+is then used in the construction of the Jinja2 variable names.
 
-The ``spaceship`` app
----------------------
+Each project has a Jinja2 variable ``SOURCE_FOO`` where ``FOO`` is the
+project name. This contains a space-separated list of all sourcetrees
+belonging to that project, which can then be given to an appropriate
+build task in the suite so it builds those source trees.
 
-.. TODO - outline what this app does.
+Similarly, a ``HOST_SOURCE_FOO`` variable is also provided. This is
+identical to ``SOURCE_FOO`` except any working copies have the local
+hostname prepended. This is to assist building on remote machines.
 
-Create a new Rose app called ``spaceship``::
+The first source specified must be a working copy which contains the
+Rose Stem suite. The suite is expected to be in a
+subdirectory named ``rose-stem`` off the top of the working copy. This
+source is used to generate three additional variables:
 
-   mkdir -p rose-stem/app/spaceship
+``SOURCE_FOO_BASE``
+   The base directory of the project
+``HOST_SOURCE_FOO_BASE``
+   The base directory of the project with the hostname prepended if it is a
+   working copy
+``SOURCE_FOO_REV``
+   The revision of the project (if any)
 
-Paste the following configuration into a :rose:file:`rose-app.conf` file within
-that directory:
+These settings override the variables in the :rose:file:`rose-suite.conf` file.
 
-.. code-block:: rose
+These should allow the use of configuration files which control the build
+process inside the working copy, e.g. you can refer to::
 
-   [command]
-   default=spaceship_command.exe
+   {{HOST_SOURCE_FOO_BASE}}/fcm-make/configs/machine.cfg{{SOURCE_FOO_REV}}
 
-   [file:spaceship.NL]
-   source=namelist:spaceship
+If you omit the source argument, Rose Stem defaults to assuming that the
+current directory is part of the working copy which should be added as a
+source tree::
 
-   [file:command.NL]
-   source=namelist:command
+   rose stem --source=.
 
-   [namelist:spaceship]
-   mass=2.0
-   position=0.0,0.0,0.0
+The project to which a source tree belongs is normally automatically
+determined using `FCM`_ commands. However, in the case where the source tree
+is not a valid FCM URL, or where you wish to assign it to another project,
+you can specify this using the ``--source`` argument::
 
-   [namelist:command]
-   thrust(1,:) =  1.0,  0.0, 0.0, 1.0,  0.0, -1.0, -1.0, 0.0, 0.0,  0.0
-   thrust(2,:) =  0.0, -2.0, 0.0, 1.0,  1.0,  0.5, -1.0, 1.5, 0.0, -1.0
-   thrust(3,:) =  0.0,  1.0, 0.0, 1.0, -1.0,  1.0, -1.5, 0.0, 0.0, -0.5
+   rose stem --source=foo=/path/to/source
 
-
-The ``fcm-make`` app
---------------------
-
-We now need to provide the instructions for :rose:app:`fcm_make` to build the
-Fortran executable.
-
-Create a new app called ``fcm_make_spaceship`` with an empty
-:rose:file:`rose-app.conf` file.
-
-Inside this app create a subdirectory called ``file`` and paste the following
-into the ``fcm-make.cfg`` file within that directory:
-
-.. code-block:: ini
-
-   steps = build
-   build.source = $SOURCE_SPACESHIP/src
-   build.target{task} = link
-
-The ``$SOURCE_SPACESHIP`` environment variable will be set using the
-Jinja2 variable of the same name which is provided by Rose Stem.
+assigns the URL ``/path/to/source`` to the foo project, so the variables
+``SOURCE_FOO`` and ``SOURCE_FOO_BASE`` will be set to ``/path/to/source``.
 
 
-The ``suite.rc`` file
----------------------
+The ``--group`` Argument
+------------------------
 
-Next we will look at the ``rose-stem/suite.rc`` file.
+The group argument is used to provide a Pythonic list of groups in the
+variable ``RUN_NAMES`` which can then be looped over in a suite to switch
+sets of tasks on and off.
 
-The ``suite.rc`` file starts off with ``UTC mode = True``, which you
-should already be :ref:`familiar with <tutorial-cylc-datetime-utc>`.
-The next part is a Jinja2 block which links the group names the user
-can specify with the :term:`graph <graph>` for that group. In this
-case, the group ``command_spaceship`` gives you the graph:
+Each ``--group`` argument adds another group to the list. For example::
 
-.. digraph:: Example
-   :align: center
+   rose stem --group=mygroup --group=myothergroup
 
-   fcm_make_spaceship -> spaceship -> rose_ana_position
-
-This variable ``name_graphs`` is used later to generate the graph when
-the suite is run. The Jinja2 variable ``groups`` is next. This enables you
-to set shortcuts to a list of groups, in this case specifying ``all`` on the
-command line will run the tasks associated with both ``command_spaceship``
-and ``fire_lasers``.
-
-The scheduling section contains the Jinja2 code to use the information we
-have already set to generate the graph based on what the user
-requested on the command line.
-
-The runtime section should be familiar. Note, however, that the
-``fcm_make_spaceship`` task sets the environment variable
-``SOURCE_SPACESHIP`` from the Jinja2 variable of the same name. This
-is how the variables passed with ``--source`` on the command line are
-passed to ``fcm-make``, which then uses these environment variables in
-its own configuration files.
+runs two groups named ``mygroup`` and ``myothergroup`` with the current
+working copy. The suite will then interpret these into a set of tasks which
+build with the given source tree(s), run the program, and compare the output.
 
 
-The ``rose-suite.conf`` file
-----------------------------
+The ``--task`` Argument
+-----------------------
 
-The suites associated with Rose Stem require a version number
-indicating the version of the ``rose stem`` command with which they
-are compatible. This is specified in the :rose:file:`rose-suite.conf` file,
-together with the default values of ``RUN_NAMES`` and ``SOURCE_SPACESHIP``.
-Paste the following into your :rose:file:`rose-suite.conf` file:
+The task argument is provided as a synonym for ``--group``. Depending on how
+exactly the Rose Stem suite works users may find one of these arguments more
+intuitive to use than the other.
+
+
+Comparing Output With :rose:app:`rose_ana`
+------------------------------------------
+
+Any task beginning with ``rose_ana_`` will be interpreted by Rose as a Rose Ana
+task, and run through the :rose:app:`rose_ana` built-in application.
+
+A Rose Ana :rose:file:`rose-app.conf` file contains a series of blocks;
+each one describing a different analysis task to perform. A common
+task which Rose Ana is used for is to compare output contained in different
+files (e.g. from a new test versus previous output from a control).
+The analysis modules which provide these tasks are flexible and able to be
+provided by the user; however there is one built-in module inside Rose Ana
+itself.
+
+An example based on the built-in ``grepper`` module:
 
 .. code-block:: rose
 
-   ROSE_STEM_VERSION=1
+   [ana:grepper.FilePattern(Compare data from myfile)]
+   pattern='data value:(\d+)'
+   files=/data/kgo/myfile
+        =../run.1/myfile
 
-   [jinja2:suite.rc]
-   RUN_NAMES=[]
-   SOURCE_SPACESHIP='fcm:spaceship_tr@head'
+This tells Rose Ana to scan the contents of the file ``../run.1/myfile``
+(which is relative to the Rose Ana task's work directory) and the contents of
+``/data/kgo/myfile`` for the specified regular expression. Since the
+pattern contains a group (in parentheses) so it is the contents of this
+group which will be compared between the two files. The ``grepper.FilePattern``
+analysis task can optionally be given a "tolerance" option for matching
+numeric values, but without it the matching is expected to be exact.
+If the pattern or group contents do not match the task will return a failure.
 
-Both of the Jinja2 variables will be overridden by the user when they
-execute ``rose stem`` on the command line.
+As well as sections defining analysis tasks, Rose Ana apps allow for one
+additional section for storing global configuration settings for the app.
+Just like the tasks themselves these options and their effects are
+dependent on which analysis tasks are used by the app.
 
-
-The ``rose_ana_position`` app
------------------------------
-
-The final component is a :rose:app:`rose_ana` app to test whether the position
-of our spaceship matches the correct output.
-
-Create an app named ``rose_ana_position`` and paste the following into its
-:rose:file:`rose-app.conf` file.
+Therefore we will here present an example using the built-in ``grepper``
+class. An app may begin with a section like this:
 
 .. code-block:: rose
 
-   [ana:grepper.FilePattern(Check X position at each timestep)]
-   pattern='^\s*Position:\s*(.*?)\s*,'
-   files=/home/user/spaceship/kgo.txt
-        =../spaceship/output.txt
+   [ana:config]
+   grepper-report-limit=5
+   skip-if-all-files-missing=.true.
 
-   [ana:grepper.FilePattern(Check Y position at each timestep)]
-   pattern='^\s*Position:.*?,\s*(.*?)\s*,'
-   files=/home/user/spaceship/kgo.txt
-        =../spaceship/output.txt
-
-   [ana:grepper.FilePattern(Check Z position at each timestep)]
-   pattern='^\s*Position:.*,\s*(.*)\s*$'
-   files=/home/user/spaceship/kgo.txt
-        =../spaceship/output.txt
-
-This will check that the positions reported by the program match those
-within the known good output file.
-
-
-Known Good Output
------------------
-
-In the root of the working copy is a file called ``kgo.txt``.
-
-The known good output should be the result of a control run. ``rose ana``
-will compare the answers from this file (obtained using the extract and
-comparison methods in the :rose:file:`rose-app.conf` file) with the results
-from the user's code change.
-
-Replace the ``/home/user/spaceship`` paths in the ``rose_ana_position``
-app with the path to this file.
-
-
-Adding the suite to version control
------------------------------------
-
-Before running the suite we need to make sure that all the files and
-directories we have created are known to the version control system.
-
-Add all the new files you've created using ``fcm add -c`` *(answer yes
-to the prompts)*.
-
-
-Running the test suite
-----------------------
-
-We should now be able to run the test suite. Simply type::
-
-   rose stem --group=command_spaceship
-
-anywhere in your working copy (the ``--source`` argument defaults to ``.``
-so it should automatically pick up your working copy as the source).
+Each of these modifies the behaviour of ``grepper``. The first option
+suppresses printed output for each analysis task once the specified number
+of lines have been printed (in this case 5 lines). The second option
+causes Rose Ana to skip any ``grepper`` tasks which compare files in the
+case that both files do not exist.
 
 .. note::
 
-   If your site uses a Cylc server, and your home directory is not shared
-   with the Cylc server, you will need to add the option::
+   Any options given to this section may instead be specified in the
+   :rose:conf:`rose.conf[rose-ana]` section of the user or site configuration.
+   In the case that the same configuration option appears in both locations
+   the one contained in the app file will take precedence.
 
-      --host=localhost
+It is possible to add additional analysis modules to Rose Ana by placing an
+appropriately formatted python file in one of the following places (in order
+of precedence):
 
-We use ``--group`` in preference to ``--task`` in this suite (both are
-synonymous) as we specify a group of tasks set up in the Jinja2 variable
-``name_graphs``.
+#. The ``ana`` sub-directory of the Rose Ana application.
+#. The ``ana`` sub-directory of the suite.
+#. Any other directory which is accessible to the process running Rose Ana
+   and is specified in the :rose:conf:`rose.conf[rose-ana]method-path`
+   variable.
 
+The only analysis module provided with Rose is
+:py:mod:`rose.apps.ana_builtin.grepper`, it provides the following analysis
+tasks and options:
 
-A failing test
---------------
+.. autoclass:: rose.apps.ana_builtin.grepper.SingleCommandStatus
+   :noindex:
 
-Now edit the file::
+.. autoclass:: rose.apps.ana_builtin.grepper.SingleCommandPattern
+   :noindex:
 
-   rose-stem/app/spaceship/rose-app.conf
+.. autoclass:: rose.apps.ana_builtin.grepper.FilePattern
+   :noindex:
 
-and change one of the thrusts, then rerun ``rose stem``. You will find the
-``rose_ana_position`` task fails, as the results have changed.
+.. autoclass:: rose.apps.ana_builtin.grepper.FileCommandPattern
+   :noindex:
 
-.. TODO - Do we need to reset previous changes?!
+.. automodule:: rose.apps.ana_builtin.grepper
+   :noindex:
 
-Try modifying the Fortran source code - for example, changing the direction
-in which thrust is applied (by changing the acceleration to be subtracted
-from the velocity rather than added). Again, rerun ``rose stem``, and see
-the failure.
+The format for analysis modules themselves is relatively simple; the easiest
+route to understanding how they should be arranged is likely to look at the
+built-in ``grepper`` module. But the key concepts are as follows. To be
+recognised as a valid analysis module, the Python file must contain at
+least one class which inherits and extends
+:py:mod:`rose.apps.rose_ana.AnalysisTask`:
 
-In this way, you can monitor whether the behaviour of code is changed by
-any of the code alterations you have made.
+.. autoclass:: rose.apps.rose_ana.AnalysisTask
 
+For example:
 
-Further Exercises
------------------
+.. code-block:: python
 
-If you wish, you can try extending the suite to include the ``fire_lasers``
-group of tasks which was in the list of groups in the ``suite.rc`` file.
-Using the same technique as we've just demonstrated for piloting the
-spaceship, you should be able to aim and fire the ship's weapons.
+   from rose.apps.rose_ana import AnalysisTask
 
+   class CustomAnalysisTask(AnalysisTask):
+       """My new custom analysis task."""
+       def run_analysis(self):
+           print self.options  # Dictionary of options (see next slide)
+           if self.options["option1"] == "5":
+               self.passed = True
 
-Automatic Options
------------------
-
-It is possible to automatically add options to ``rose stem`` using the
-:rose:conf:`rose.conf[rose-stem]automatic-options` variable in the
-:ref:`Site And User Configuration` file.
-This takes the syntax of key-value pairs on a single
-line, and is functionally equivalent to adding them using the ``-S``
-option on the ``rose stem`` command line. For example:
+Assuming the above was saved in a file called ``custom.py`` and placed
+into a folder suitable for analysis modules this would allow a Rose Ana
+application to specify:
 
 .. code-block:: rose
 
-   [rose-stem]
-   automatic-options=GRAVITY=newtonian PLANET=jupiter
+   [ana:custom.CustomAnalysisTask(Example rose-ana test)]
+   option1 = 5
+   option2 = test of Rose Ana
+   option3 = .true.
 
-sets the variable ``GRAVITY`` to have the value ``newtonian``, and
-``PLANET`` to be ``jupiter``. These can then be used in the ``suite.rc``
-file as Jinja2 variables.
+.. note::
+
+   The custom part of the filename appears at the start of the
+   ``ana`` entry, followed by the name of the desired class (in the style
+   of Python's own namespacing). All options specified by the app-task
+   will be processed by Rose Ana into a dictionary and attached to the
+   running analysis class instance as the options attribute. Hopefully you
+   can see that in this case the task would pass because ``option1`` is set
+   to 5 as required by the class.
+
+
+.. _The Rose Ana Comparison Database:
+
+The Rose Ana Comparison Database
+--------------------------------
+
+In addition to performing the comparisons each of the Rose Ana tasks in the
+suite can be configured to append some key details about any comparisons
+performed to an sqlite database kept in the suite's log directory (at
+``log/rose-ana-comparisons.db``).
+
+This is intended to provide a quick means to interrogate the suite for
+information about the status of any comparisons it has performed. There are
+2 tables present in the suite which contain the following:
+
+.. TODO - migrate this documentation into the codebase?
+
+tasks (TABLE)
+   The intention of this table is to detect if any Rose Ana tasks have
+   failed unexpectedly (or are still running).
+
+   Contains an entry for each Rose Ana task, using the following columns:
+
+   task_name (TEXT)
+      The exact name of the Rose Ana task.
+   completed (INT)
+      Set to 1 when the task starts performing its comparisons then updated
+      to 0 when the task has completed
+
+      .. note::
+
+         Task success is not related to the success/failed state of the
+         comparisons).
+
+comparisons (TABLE)
+   The intention of this table is to provide a record of which files
+   were compared by which tasks, how they were compared and what the
+   result of the comparison was.
+
+   Contains an entry for each individual comparison from every
+   Rose Ana task, using the following columns:
+
+   comp_task (TEXT)
+      The comparison task name - by convention this is usually the
+      comparison section name from the app defintion (including the
+      part inside the brackets).
+   kgo_file (TEXT)
+      The full path to the file specified as the KGO file in
+      the app definition.
+   suite_file (TEXT)
+      The full path to the file specified as the
+      active test output in the app definition.
+   status (TEXT)
+      The status of the task (one of " OK ", "FAIL" or "WARN").
+      comparison (TEXT) Additional details which may be provided
+      about the comparison.
+
+The database is entirely optional; by default is will not be produced; if
+it is required it can be activated by setting
+:rose:conf:`rose.conf[rose-ana]kgo-database=.true.`.
+
+.. note::
+
+   The system does not provide any direct methods for working with or
+   interrogating the database - since there could be various reasons for
+   doing so, and there may be other suite-design factors to consider.
+   Users are therefore expected to provide this functionality separately
+   based on their specific needs.
+
+
+Summary
+-------
+
+From within a working copy, running ``rose stem`` is simple. Just run::
+
+   rose stem --group=groupname
+
+replacing the groupname with the desired task. Rose Stem should then
+automatically pick up the working copy and run the requested tests on it.
+
+Next see the :ref:`Rose Stem Tutorial`
+
+.. toctree::
+   :hidden:
+
+   rose-stem/tutorial.rst

--- a/sphinx/tutorial/rose/furthertopics/rose-stem/tutorial.rst
+++ b/sphinx/tutorial/rose/furthertopics/rose-stem/tutorial.rst
@@ -1,0 +1,311 @@
+.. include:: ../../../../hyperlinks.rst
+   :start-line: 1
+
+
+.. _Rose Stem Tutorial:
+
+Rose Stem Tutorial
+==================
+
+.. warning::
+
+   Before proceeding you should already be familiar with the :ref:`Rose Stem`
+   section.
+
+.. image:: http://upload.wikimedia.org/wikipedia/commons/thumb/b/b2/Cassini_Saturn_Orbit_Insertion.jpg/320px-Cassini_Saturn_Orbit_Insertion.jpg
+   :align: right
+   :alt: Artist's Impression of Cassini entering Saturn orbit
+   :width: 300px
+
+This tutorial will walk you through creating a simple example of the
+Rose Stem testing system which will involve piloting a spaceship
+through space.
+
+
+Getting Started
+---------------
+
+We will start the Rose Stem tutorial by setting up an `FCM`_ repository
+called ``SPACESHIP`` to store the code and test suite in.
+
+.. _keyword: https://metomi.github.io/fcm/doc/user_guide/code_management.html#svn_basic_keywords
+
+Usually you would add a Rose Stem suite to an existing repository with
+the `keyword`_ already set up to test the accompanying source code. For the
+purposes of this tutorial we will create a new one.
+
+Type the follow to create a temporary repository (you can safely delete
+it after finishing this tutorial)::
+
+   mkdir -p ~/rose-tutorial
+   svnadmin create ~/rose-tutorial/spaceship_repos
+   (cd $(mktemp -d); mkdir -p trunk/src; svn import -m "" . file://$HOME/rose-tutorial/spaceship_repos)
+
+We then need to link the project name ``SPACESHIP`` with this project.
+Creating the file and directory if they do not exist
+add the following line to the file ``$HOME/.metomi/fcm/keyword.cfg``:
+
+.. code-block:: rose
+
+   location{primary}[spaceship] = file:///home/user/rose-tutorial/spaceship_repos
+
+Make sure the path on the right-hand side matches the location you
+specified in the ``svnadmin`` command.
+
+Now you can checkout a working copy of your repository by typing::
+
+   mkdir -p ~/rose-tutorial/spaceship_working_copy
+   cd ~/rose-tutorial/spaceship_working_copy
+   fcm checkout fcm:spaceship_tr .
+
+Finally populate your working copy by running (answering ``y`` to the prompt)::
+
+   rose tutorial rose-stem .
+
+
+``spaceship_command.f90``
+-------------------------
+
+Our Fortran program is ``spaceship_command.f90``, which reads in an
+initial position and spaceship mass from one namelist, and a series
+of commands to apply thrust in three-dimensional space. It then uses
+Newtonian mechanics to calculate a final position.
+
+You will find it in the ``src`` directory. Have a look at it and see
+what it does.
+
+
+The ``spaceship`` app
+---------------------
+
+.. TODO - outline what this app does.
+
+Create a new Rose app called ``spaceship``::
+
+   mkdir -p rose-stem/app/spaceship
+
+Paste the following configuration into a :rose:file:`rose-app.conf` file within
+that directory:
+
+.. code-block:: rose
+
+   [command]
+   default=spaceship_command.exe
+
+   [file:spaceship.NL]
+   source=namelist:spaceship
+
+   [file:command.NL]
+   source=namelist:command
+
+   [namelist:spaceship]
+   mass=2.0
+   position=0.0,0.0,0.0
+
+   [namelist:command]
+   thrust(1,:) =  1.0,  0.0, 0.0, 1.0,  0.0, -1.0, -1.0, 0.0, 0.0,  0.0
+   thrust(2,:) =  0.0, -2.0, 0.0, 1.0,  1.0,  0.5, -1.0, 1.5, 0.0, -1.0
+   thrust(3,:) =  0.0,  1.0, 0.0, 1.0, -1.0,  1.0, -1.5, 0.0, 0.0, -0.5
+
+
+The ``fcm-make`` app
+--------------------
+
+We now need to provide the instructions for :rose:app:`fcm_make` to build the
+Fortran executable.
+
+Create a new app called ``fcm_make_spaceship`` with an empty
+:rose:file:`rose-app.conf` file.
+
+Inside this app create a subdirectory called ``file`` and paste the following
+into the ``fcm-make.cfg`` file within that directory:
+
+.. code-block:: ini
+
+   steps = build
+   build.source = $SOURCE_SPACESHIP/src
+   build.target{task} = link
+
+The ``$SOURCE_SPACESHIP`` environment variable will be set using the
+Jinja2 variable of the same name which is provided by Rose Stem.
+
+
+The ``suite.rc`` file
+---------------------
+
+Next we will look at the ``rose-stem/suite.rc`` file.
+
+The ``suite.rc`` file starts off with ``UTC mode = True``, which you
+should already be :ref:`familiar with <tutorial-cylc-datetime-utc>`.
+The next part is a Jinja2 block which links the group names the user
+can specify with the :term:`graph <graph>` for that group. In this
+case, the group ``command_spaceship`` gives you the graph:
+
+.. digraph:: Example
+   :align: center
+
+   fcm_make_spaceship -> spaceship -> rose_ana_position
+
+This variable ``name_graphs`` is used later to generate the graph when
+the suite is run. The Jinja2 variable ``groups`` is next. This enables you
+to set shortcuts to a list of groups, in this case specifying ``all`` on the
+command line will run the tasks associated with both ``command_spaceship``
+and ``fire_lasers``.
+
+The scheduling section contains the Jinja2 code to use the information we
+have already set to generate the graph based on what the user
+requested on the command line.
+
+The runtime section should be familiar. Note, however, that the
+``fcm_make_spaceship`` task sets the environment variable
+``SOURCE_SPACESHIP`` from the Jinja2 variable of the same name. This
+is how the variables passed with ``--source`` on the command line are
+passed to ``fcm-make``, which then uses these environment variables in
+its own configuration files.
+
+
+The ``rose-suite.conf`` file
+----------------------------
+
+The suites associated with Rose Stem require a version number
+indicating the version of the ``rose stem`` command with which they
+are compatible. This is specified in the :rose:file:`rose-suite.conf` file,
+together with the default values of ``RUN_NAMES`` and ``SOURCE_SPACESHIP``.
+Paste the following into your :rose:file:`rose-suite.conf` file:
+
+.. code-block:: rose
+
+   ROSE_STEM_VERSION=1
+
+   [jinja2:suite.rc]
+   RUN_NAMES=[]
+   SOURCE_SPACESHIP='fcm:spaceship_tr@head'
+
+Both of the Jinja2 variables will be overridden by the user when they
+execute ``rose stem`` on the command line.
+
+
+The ``rose_ana_position`` app
+-----------------------------
+
+The final component is a :rose:app:`rose_ana` app to test whether the position
+of our spaceship matches the correct output.
+
+Create an app named ``rose_ana_position`` and paste the following into its
+:rose:file:`rose-app.conf` file.
+
+.. code-block:: rose
+
+   [ana:grepper.FilePattern(Check X position at each timestep)]
+   pattern='^\s*Position:\s*(.*?)\s*,'
+   files=/home/user/spaceship/kgo.txt
+        =../spaceship/output.txt
+
+   [ana:grepper.FilePattern(Check Y position at each timestep)]
+   pattern='^\s*Position:.*?,\s*(.*?)\s*,'
+   files=/home/user/spaceship/kgo.txt
+        =../spaceship/output.txt
+
+   [ana:grepper.FilePattern(Check Z position at each timestep)]
+   pattern='^\s*Position:.*,\s*(.*)\s*$'
+   files=/home/user/spaceship/kgo.txt
+        =../spaceship/output.txt
+
+This will check that the positions reported by the program match those
+within the known good output file.
+
+
+Known Good Output
+-----------------
+
+In the root of the working copy is a file called ``kgo.txt``.
+
+The known good output should be the result of a control run. Rose Ana
+will compare the answers from this file (obtained using the extract and
+comparison methods in the :rose:file:`rose-app.conf` file) with the results
+from the user's code change.
+
+Replace the ``/home/user/spaceship`` paths in the ``rose_ana_position``
+app with the path to this file.
+
+
+Adding the suite to version control
+-----------------------------------
+
+Before running the suite we need to make sure that all the files and
+directories we have created are known to the version control system.
+
+Add all the new files you've created using ``fcm add -c`` *(answer yes
+to the prompts)*.
+
+
+Running the test suite
+----------------------
+
+We should now be able to run the test suite. Simply type::
+
+   rose stem --group=command_spaceship
+
+anywhere in your working copy (the ``--source`` argument defaults to ``.``
+so it should automatically pick up your working copy as the source).
+
+.. note::
+
+   If your site uses a Cylc server, and your home directory is not shared
+   with the Cylc server, you will need to add the option::
+
+      --host=localhost
+
+We use ``--group`` in preference to ``--task`` in this suite (both are
+synonymous) as we specify a group of tasks set up in the Jinja2 variable
+``name_graphs``.
+
+
+A failing test
+--------------
+
+Now edit the file::
+
+   rose-stem/app/spaceship/rose-app.conf
+
+and change one of the thrusts, then rerun ``rose stem``. You will find the
+``rose_ana_position`` task fails, as the results have changed.
+
+.. TODO - Do we need to reset previous changes?!
+
+Try modifying the Fortran source code - for example, changing the direction
+in which thrust is applied (by changing the acceleration to be subtracted
+from the velocity rather than added). Again, rerun ``rose stem``, and see
+the failure.
+
+In this way, you can monitor whether the behaviour of code is changed by
+any of the code alterations you have made.
+
+
+Further Exercises
+-----------------
+
+If you wish, you can try extending the suite to include the ``fire_lasers``
+group of tasks which was in the list of groups in the ``suite.rc`` file.
+Using the same technique as we've just demonstrated for piloting the
+spaceship, you should be able to aim and fire the ship's weapons.
+
+
+Automatic Options
+-----------------
+
+It is possible to automatically add options to ``rose stem`` using the
+:rose:conf:`rose.conf[rose-stem]automatic-options` variable in the
+:ref:`Site And User Configuration` file.
+This takes the syntax of key-value pairs on a single
+line, and is functionally equivalent to adding them using the ``-S``
+option on the ``rose stem`` command line. For example:
+
+.. code-block:: rose
+
+   [rose-stem]
+   automatic-options=GRAVITY=newtonian PLANET=jupiter
+
+sets the variable ``GRAVITY`` to have the value ``newtonian``, and
+``PLANET`` to be ``jupiter``. These can then be used in the ``suite.rc``
+file as Jinja2 variables.


### PR DESCRIPTION
**Built on #2170, merge after**

Migrate the rose stem user guide into the new rose documentation. Some documentation moved into the codebase, otherwise a direct translation.