### PR TITLE
rosie disco: Catch attempts to connect to non-existent DB

### DIFF
--- a/lib/python/rosie/db.py
+++ b/lib/python/rosie/db.py
@@ -45,13 +45,18 @@ def _col_keys(table):
     return [c.key for c in table.c]
 
 
-class RosieDatabaseConnectError(Exception):
+class RosieDatabaseConnectError(al.exc.OperationalError):
 
-    """Exception raised when a database cannot be connected to."""
+    """Exception raised when unable to establish a database connection."""
+
+    def __init__(self, bad_db_url, message):
+        self.bad_db_url = bad_db_url
+        self.message = message
+        super(RosieDatabaseConnectError, self).__init__(
+            self.message, "None", self.bad_db_url)
 
     def __str__(self):
-
-        return "%s: failed to connect to DB." % self.args
+        return "Failed to connect to DB '%s'." % self.bad_db_url
 
 
 class DAO(object):
@@ -87,8 +92,8 @@ class DAO(object):
 
         try:
             self.db_connection = self.db_engine.connect()
-        except al.exc.OperationalError:
-            raise RosieDatabaseConnectError(self.db_url)
+        except al.exc.OperationalError as exc:
+            raise RosieDatabaseConnectError(self.db_url, exc)
 
         self.tables = {}
         for name in [LATEST_TABLE_NAME, MAIN_TABLE_NAME, META_TABLE_NAME,

--- a/lib/python/rosie/db.py
+++ b/lib/python/rosie/db.py
@@ -45,14 +45,13 @@ def _col_keys(table):
     return [c.key for c in table.c]
 
 
-class RosieDatabaseCreateError(Exception):
+class RosieDatabaseConnectError(Exception):
 
-    """Exception raised when a database cannot be created and therefore cannot
-       be opened or connected to; attempt to connect to an empty file."""
+    """Exception raised when a database cannot be connected to."""
 
     def __str__(self):
 
-        return "%s: failed to create DB." % self.args
+        return "%s: failed to connect to DB." % self.args
 
 
 class DAO(object):
@@ -88,8 +87,8 @@ class DAO(object):
 
         try:
             self.db_connection = self.db_engine.connect()
-        except al.exc.OperationalError as exc:
-            raise RosieDatabaseCreateError(self.db_url)
+        except al.exc.OperationalError:
+            raise RosieDatabaseConnectError(self.db_url)
 
         self.tables = {}
         for name in [LATEST_TABLE_NAME, MAIN_TABLE_NAME, META_TABLE_NAME,

--- a/lib/python/rosie/ws.py
+++ b/lib/python/rosie/ws.py
@@ -112,6 +112,8 @@ class RosieDiscoService(object):
         except (KeyError, AttributeError, jinja2.exceptions.TemplateError):
             import traceback
             traceback.print_exc()
+        except rosie.db.RosieDatabaseConnectError as exc:
+            raise cherrypy.HTTPError(404, str(exc))
 
     @cherrypy.expose
     def hello(self, format=None):


### PR DESCRIPTION
When the ``.metomi`` 'rose.conf' file does not contain valid information for either or both of 'mot' or 'mi' under the ``[rosie-db]`` setting, attempts to start an ad-hoc rosie disco server via ``rosie disco start`` and then access the 'mi' or 'mot' discovery databases will result in a long & obscure traceback (as below), which could be much improved with a try/except statement.

```
500 Internal Server Error

The server encountered an unexpected condition which prevented it from fulfilling the request.

Traceback (most recent call last):
  File "/usr/lib/python2.6/site-packages/cherrypy/_cprequest.py", line 656, in respond
    response.body = self.handler()
  File "/usr/lib/python2.6/site-packages/cherrypy/lib/encoding.py", line 188, in __call__
    self.body = self.oldhandler(*args, **kwargs)
  File "/usr/lib/python2.6/site-packages/cherrypy/_cpdispatch.py", line 34, in __call__
    return self.callable(*self.args, **self.kwargs)
  File "/net/home/h06/sbarth/rose.git/lib/python/rosie/ws.py", line 111, in index
    return self._render()
  File "/net/home/h06/sbarth/rose.git/lib/python/rosie/ws.py", line 184, in _render
    known_keys=self.dao.get_known_keys(),
  File "/net/home/h06/sbarth/rose.git/lib/python/rosie/db.py", line 152, in get_known_keys
    common_keys = self.get_common_keys()
  File "/net/home/h06/sbarth/rose.git/lib/python/rosie/db.py", line 146, in get_common_keys
    self._connect()
  File "/net/home/h06/sbarth/rose.git/lib/python/rosie/db.py", line 76, in _connect
    self.db_connection = self.db_engine.connect()
  File "/usr/lib64/python2.6/site-packages/sqlalchemy/engine/base.py", line 2471, in connect
    return self._connection_cls(self, **kwargs)
  File "/usr/lib64/python2.6/site-packages/sqlalchemy/engine/base.py", line 878, in __init__
    self.__connection = connection or engine.raw_connection()
  File "/usr/lib64/python2.6/site-packages/sqlalchemy/engine/base.py", line 2557, in raw_connection
    return self.pool.unique_connection()
  File "/usr/lib64/python2.6/site-packages/sqlalchemy/pool.py", line 184, in unique_connection
    return _ConnectionFairy(self).checkout()
  File "/usr/lib64/python2.6/site-packages/sqlalchemy/pool.py", line 401, in __init__
    rec = self._connection_record = pool._do_get()
  File "/usr/lib64/python2.6/site-packages/sqlalchemy/pool.py", line 822, in _do_get
    return self._create_connection()
  File "/usr/lib64/python2.6/site-packages/sqlalchemy/pool.py", line 189, in _create_connection
    return _ConnectionRecord(self)
  File "/usr/lib64/python2.6/site-packages/sqlalchemy/pool.py", line 282, in __init__
    self.connection = self.__connect()
  File "/usr/lib64/python2.6/site-packages/sqlalchemy/pool.py", line 344, in __connect
    connection = self.__pool._creator()
  File "/usr/lib64/python2.6/site-packages/sqlalchemy/engine/strategies.py", line 80, in connect
    return dialect.connect(*cargs, **cparams)
  File "/usr/lib64/python2.6/site-packages/sqlalchemy/engine/default.py", line 281, in connect
    return self.dbapi.connect(*cargs, **cparams)
OperationalError: (OperationalError) unable to open database file None None
```