### PR TITLE
Fix libsecret password manager (#2171) version check

### DIFF
--- a/lib/python/rosie/ws_client_auth.py
+++ b/lib/python/rosie/ws_client_auth.py
@@ -41,7 +41,7 @@ try:
     require_version('Secret', '1')
     from gi.repository import Secret
     GI_FLAG = True
-except ImportError:
+except (ImportError, ValueError):
     GI_FLAG = False
 try:
     if GI_FLAG:


### PR DESCRIPTION
``require_version()`` raises a ValueError 'if module/version is already loaded, already required, or unavailable' which was missing as an exception for the gi imports block.