### PR TITLE
Rose user guide: versioning

### DIFF
--- a/404.md
+++ b/404.md
@@ -1,5 +1,5 @@
 [comment]: <> (This is the 404 page as used on the Github Pages site.)
 
-## The Rose Documentation Has Moved
+## 404 Page Not Found - The Rose Documentation Has Moved
 
 Please update your bookmarks to: http://metomi.github.io/rose

--- a/404.md
+++ b/404.md
@@ -1,0 +1,5 @@
+[comment]: <> (This is the 404 page as used on the Github Pages site.)
+
+## The Rose Documentation Has Moved
+
+Please update your bookmarks to: http://metomi.github.io/rose

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,15 @@
+# This file configures the Jekyll static web builder (https://jekyllrb.com/) as
+# used by Github Pages.
+
+# Jekyll treats directories beginning with underscores as having special meaning
+# and omits them from the build. This can be overridden by manually including
+# directories using "include".
+# https://help.github.com/articles/files-that-start-with-an-underscore-are-missing/
+# NOTE: Only the directory name should be specified not the full path.
+include: [
+    "_downloads",
+    "_images",
+    "_modules",
+    "_sources",
+    "_static"
+]

--- a/bin/rose-make-docs
+++ b/bin/rose-make-docs
@@ -37,6 +37,9 @@
 #         errors.
 #     --debug
 #         Run `make` with the --debug option.
+#     --default-version=VERSION
+#         By default the current version is symlinked as the default version,
+#         provide an alternative version to override this.
 #
 # BUILD
 #     The format(s) to build the documentation in - default html.
@@ -51,8 +54,8 @@
 #     `latexpdf`
 #         For building PDF documentation.
 #     `clean`
-#         Removes all builds (rose make-docs clean <build> will force a
-#         complete re-build).
+#         Removes all built documentation for the current rose version.
+#         (use `rm -rf doc` to remove all documentation).
 #
 # DEVELOPMENT BUILDS
 #     For development purposes use the following BUILDs:
@@ -65,13 +68,81 @@
 #-----------------------------------------------------------------------------
 set -e
 set -o pipefail
+shopt -s extglob
 
 # Move into rose directory
-cd "$(dirname $0)/../"
+cd "$(dirname "$0")/../"
 
-VENV_PATH='venv'  # Path for virtualenv.
-USING_VENV=false  # Set to `true` when the virtualenv is being used.
-SPHINX_PATH=sphinx  # Path to the sphinx directory.
+# Path for virtualenv.
+VENV_PATH='venv'
+# Set to `true` when the virtualenv is being used.
+USING_VENV=false
+# Path to the sphinx directory.
+SPHINX_PATH=sphinx
+# pick up official rose version
+. "${ROSE_HOME}/rose-version"
+# documentation root output directory
+DOCS_DIR="${ROSE_HOME}/doc"
+# documentation output directory for this version
+BUILD_DIR="${DOCS_DIR}/${ROSE_VERSION}"
+# glob for documented rose versions
+DOC_VERSIONS=!(*.html|.git|doc|versions.json|"${DEFAULT_ALIAS}")
+# glob for documentation formats within a rose version
+DOC_FORMATS=!(*.html|doctrees)
+
+# is the virtualenv command available
+if which virtualenv >/dev/null 2>&1; then
+    VENV_COMPLIANT=true
+else
+    VENV_COMPLIANT=false
+fi
+
+# Parse command line args.
+VENV_MODE=false
+FORCE=false
+DEV_MODE=false
+DEBUG=''
+BUILDS=''
+SPHINX_OPTS=''
+DEFAULT_ALIAS='doc'
+DEFAULT_VERSION=
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --venv)
+            VENV_MODE=true
+            shift
+            ;;
+        --dev)
+            DEV_MODE=true
+            shift
+            ;;
+        --force)
+            FORCE=true
+            shift
+            ;;
+        --strict)
+            SPHINX_OPTS='SPHINX_OPTS=-aEW'
+            shift
+            ;;
+        --debug)
+            DEBUG='--debug'
+            shift
+            ;;
+        --default-version)
+            DEFAULT_VERSION="$2"
+            shift
+            shift
+            ;;
+        *)
+            BUILDS="${BUILDS} $1"
+            shift
+            ;;
+    esac
+done
+if [[ -z "${BUILDS}" ]]; then
+    BUILDS='html'
+fi
+
 
 venv-activate () {
     USING_VENV=true
@@ -97,50 +168,53 @@ venv-destroy () {
     rm -rf "${VENV_PATH}"
 }
 
-if which virtualenv >/dev/null 2>&1; then
-    VENV_COMPLIANT=true
-else
-    VENV_COMPLIANT=false
-fi
+json_list () {
+    # write out a bash array as a JSON list
+    echo -n "[\"$(local IFS=','; echo "$*" | sed 's/,/", "/g';)\"]"
+}
 
-# Parse command line args.
-VENV_MODE=false
-FORCE=false
-DEV_MODE=false
-DEBUG=''
-BUILDS=''
-SPHINXOPTS=''
-while [[ $# -gt 0 ]]; do
-    case $1 in
-        --venv)
-            VENV_MODE=true
-            shift
-            ;;
-        --dev)
-            DEV_MODE=true
-            shift
-            ;;
-        --force)
-            FORCE=true
-            shift
-            ;;
-        --strict)
-            SPHINXOPTS='SPHINXOPTS=-aEW'
-            shift
-            ;;
-        --debug)
-            DEBUG='--debug'
-            shift
-            ;;
-        *)
-            BUILDS="${BUILDS} $1"
-            shift
-            ;;
-    esac
-done
-if [[ -z "${BUILDS}" ]]; then
-    BUILDS='html'
-fi
+version_file () {
+    # output the dictionary {"version": ["build", ...]} in JSON format
+    DOCS_DIR="$1"
+    DEFAULT_ALIAS="$2"
+
+    echo '{'
+    # scrape filesystem for list of rose versions which have built docs
+    VERSIONS=( $(cd "${DOCS_DIR}"; echo $DOC_VERSIONS) )
+    for version in "${VERSIONS[@]}"; do
+        # scrape filesystem to get list of formats this version is available in
+        formats=( $(cd "${DOCS_DIR}/${version}"; echo $DOC_FORMATS) )
+        list="    \"${version}\": $(json_list ${formats})"
+        if [[ $version == "${VERSIONS[$(( ${#VERSIONS[@]} - 1 ))]}" ]]; then
+            # JSON doesn't permit a comma after the last item in a collection
+            echo "${list}"
+        else
+            echo "${list},"
+        fi
+    done
+    echo '}'
+}
+
+html_redirect () {
+    # write an html file to $2 which auto-redirects to the relative path $1
+    SRC="$1"
+    DEST="$2"
+
+    cat >"$2" << __HTML__
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Rose Documentation</title>
+        <meta http-equiv="REFRESH" content="0;url=$1">
+    </head>
+    <body>
+        <p>If not automatically redirected, please click
+        <a href="$1">Rose Documentation</a>.</p>
+    </body>
+</html>
+__HTML__
+}
+
 
 # Use virtualenv if present and requested or if we are in development mode.
 if "${DEV_MODE}" || "${VENV_MODE}"; then
@@ -174,7 +248,7 @@ if ! rose-check-software --doc >/dev/null; then
 
         echo
         echo 'The documentation can still be built by installing dependencies'
-        echo 'in a python virtual enironment (virtualenv). This environment'
+        echo 'in a python virtual environment (virtualenv). This environment'
         echo "will be created in rose/${VENV_PATH} and will be removed after"
         echo 'use. To keep the virtualenv for future builds run this command'
         echo 'with the "--dev" option.'
@@ -198,9 +272,25 @@ if ! rose-check-software --doc >/dev/null; then
     fi
 fi
 
-# Run sphinx make.
-if make ${DEBUG} -C "${SPHINX_PATH}" ${BUILDS} ${SPHINXOPTS}; then
+# makefile argument to set the output directory for this build
+SPHINX_OPTS="${SPHINX_OPTS} BUILDDIR=${DOCS_DIR}/${ROSE_VERSION}"
+
+# run sphinx-build
+if make ${DEBUG} -C "${SPHINX_PATH}" ${BUILDS} ${SPHINX_OPTS}; then
     RET=0
+    # output file containing details of all versions and formats the
+    # documentation has been built in (locally) for the version / format
+    # switching pane
+    version_file "${DOCS_DIR}" "${DEFAULT_ALIAS}" > "${DOCS_DIR}/versions.json"
+    # symlink this version as the default
+    (
+        cd "${DOCS_DIR}"
+        rm "${DEFAULT_ALIAS}" 2>/dev/null || true
+        ln -s "${DEFAULT_VERSION:-$ROSE_VERSION}" "${DEFAULT_ALIAS}"
+    )
+    # symlink landing pages
+    html_redirect "${DEFAULT_ALIAS}/html/index.html" 'doc/index.html'
+    html_redirect "html/index.html" "doc/${ROSE_VERSION}/index.html"
 else
     RET=1
 fi

--- a/bin/rose-make-docs
+++ b/bin/rose-make-docs
@@ -86,7 +86,7 @@ DOCS_DIR="${ROSE_HOME}/doc"
 # documentation output directory for this version
 BUILD_DIR="${DOCS_DIR}/${ROSE_VERSION}"
 # glob for documented rose versions
-DOC_VERSIONS=!(*.html|.git|doc|versions.json|"${DEFAULT_ALIAS}")
+DOC_VERSIONS=!(*.html|.git|doc|versions.json|"${DEFAULT_ALIAS}"|CHANGES.md|404.md|_config.yml)
 # glob for documentation formats within a rose version
 DOC_FORMATS=!(*.html|doctrees)
 
@@ -183,7 +183,7 @@ version_file () {
     for version in "${VERSIONS[@]}"; do
         # scrape filesystem to get list of formats this version is available in
         formats=( $(cd "${DOCS_DIR}/${version}"; echo $DOC_FORMATS) )
-        list="    \"${version}\": $(json_list ${formats})"
+        list="    \"${version}\": $(json_list ${formats[@]})"
         if [[ $version == "${VERSIONS[$(( ${#VERSIONS[@]} - 1 ))]}" ]]; then
             # JSON doesn't permit a comma after the last item in a collection
             echo "${list}"
@@ -291,8 +291,8 @@ if make ${DEBUG} -C "${SPHINX_PATH}" ${BUILDS} ${SPHINX_OPTS}; then
     html_redirect "${DEFAULT_ALIAS}/html/index.html" 'doc/index.html'
     html_redirect "html/index.html" "doc/${ROSE_VERSION}/index.html"
     # support legacy doc/rose.html url
-    mkdir 'doc/doc' || true
-    html_redirect "doc/${DEFAULT_ALIAS}/index.html" "doc/doc/rose.html"
+    mkdir 'doc/doc' 2>/dev/null || true
+    html_redirect "html/index.html" "doc/${ROSE_VERSION}/rose.html"
 else
     RET=1
 fi

--- a/bin/rose-make-docs
+++ b/bin/rose-make-docs
@@ -176,7 +176,6 @@ json_list () {
 version_file () {
     # output the dictionary {"version": ["build", ...]} in JSON format
     DOCS_DIR="$1"
-    DEFAULT_ALIAS="$2"
 
     echo '{'
     # scrape filesystem for list of rose versions which have built docs
@@ -281,7 +280,7 @@ if make ${DEBUG} -C "${SPHINX_PATH}" ${BUILDS} ${SPHINX_OPTS}; then
     # output file containing details of all versions and formats the
     # documentation has been built in (locally) for the version / format
     # switching pane
-    version_file "${DOCS_DIR}" "${DEFAULT_ALIAS}" > "${DOCS_DIR}/versions.json"
+    version_file "${DOCS_DIR}" > "${DOCS_DIR}/versions.json"
     # symlink this version as the default
     (
         cd "${DOCS_DIR}"
@@ -291,6 +290,9 @@ if make ${DEBUG} -C "${SPHINX_PATH}" ${BUILDS} ${SPHINX_OPTS}; then
     # symlink landing pages
     html_redirect "${DEFAULT_ALIAS}/html/index.html" 'doc/index.html'
     html_redirect "html/index.html" "doc/${ROSE_VERSION}/index.html"
+    # support legacy doc/rose.html url
+    mkdir 'doc/doc' || true
+    html_redirect "doc/${DEFAULT_ALIAS}/index.html" "doc/doc/rose.html"
 else
     RET=1
 fi

--- a/bin/rose-make-docs
+++ b/bin/rose-make-docs
@@ -121,7 +121,7 @@ while [[ $# -gt 0 ]]; do
             shift
             ;;
         --strict)
-            SPHINX_OPTS='SPHINX_OPTS=-aEW'
+            SPHINX_OPTS='SPHINXOPTS=-aEW'
             shift
             ;;
         --debug)

--- a/etc/deploy-docs
+++ b/etc/deploy-docs
@@ -1,0 +1,81 @@
+#!/bin/bash
+#-----------------------------------------------------------------------------
+# (C) British Crown Copyright 2012-8 Met Office.
+#
+# This file is part of Rose, a framework for meteorological suites.
+#
+# Rose is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Rose is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Rose. If not, see <http://www.gnu.org/licenses/>.
+#-----------------------------------------------------------------------------
+set -eu
+shopt -s extglob
+
+cd "$(dirname "$BASH_SOURCE")/../"
+
+REMOTE='origin'
+TEMP_DOCS_LABEL='doc-build-dir'
+DOCUMENTATION_FILES=!(doc|404.md|CHANGES.md|"$TEMP_DOCS_LABEL"|_config.yml)
+
+. ./rose-version
+if [[ -z $ROSE_VERSION ]]; then
+    exit 1
+fi
+
+initial_deployment () {  # Create a new gh-pages branch from scratch.
+    # start with a blank doc directory
+    git clean -xf doc
+
+    # build the documentation
+    rose make-docs html slides
+
+    # create the gh-pages branch
+    git branch -D gh-pages || true
+    git checkout --orphan gh-pages
+
+    # move docs to the top level and delete everything else
+    git rm -rf $DOCUMENTATION_FILES     # remove tracked files
+    git clean -xf $DOCUMENTATION_FILES  # remove untracked files
+    mv doc "$TEMP_DOCS_LABEL"  # permit the alias "doc"
+    mv "$TEMP_DOCS_LABEL"/* .
+    git clean -xf "$TEMP_DOCS_LABEL"
+    git add * -f
+
+    # commit and push
+    git commit -m "${ROSE_VERSION}"
+    # git push "${REMOTE}" gh-pages
+}
+
+
+subsequent_deployment () {  # Add new version to documentation.
+    # update gh-pages branch
+    git pull "${REMOTE}" gh-pages -f
+    git clean -xf doc
+
+    # copy gh-pahes branch to a temporary directory
+    TMP_DOCS_DIR="$(mktemp -d)"
+    git archive 'gh-pages' | (cd "${TMP_DOCS_DIR}" && tar -xf -)
+
+    # append new documentation to the temporary directory
+    ln -s "$TMP_DOCS_DIR" doc
+    rose make-docs html slides
+
+    # apply changes to gh-pages branch
+    git checkout gh-pages
+    rsync -av "${TMP_DOCS_DIR}/" .  # NOTE: the trailing slash is required
+    rm -rf "${TMP_DOCS_DIR}"
+    git add * -f
+
+    # commit and push
+    git commit -m "${ROSE_VERSION}"
+    # git push "${REMOTE}" gh-pages
+}

--- a/index.html
+++ b/index.html
@@ -1,13 +1,1 @@
-<!DOCTYPE html>
-
-<html>
-<head>
-  <title>Rose Documentation</title>
-  <meta http-equiv="REFRESH" content="0;url=doc/html/index.html">
-</head>
-
-<body>
-<p>If not automatically redirected,
-please click <a href="doc/html/index.html">Rose Documentation</a>.</p>
-</body>
-</html>
+doc/current/html/index.html

--- a/index.html
+++ b/index.html
@@ -1,1 +1,0 @@
-doc/current/html/index.html

--- a/lib/python/rose/resource.py
+++ b/lib/python/rose/resource.py
@@ -148,11 +148,14 @@ class ResourceLocator(object):
             return os.path.basename(sys.argv[0])
 
     def get_version(self, ignore_environment=False):
-        """Return ROSE_VERSION.
+        """return the current rose_version number.
+
+        By default pass through the value of the ``ROSE_VERSION`` environment
+        variable.
 
         Args:
-            ignore_environment (bool): Ignore the value of the ROSE_VERSION
-                environment variable if present.
+            ignore_environment (bool): Return the value extracted from the
+                ``rose-version`` file.
         """
         version = None
         if not ignore_environment:

--- a/lib/python/rose/resource.py
+++ b/lib/python/rose/resource.py
@@ -147,10 +147,17 @@ class ResourceLocator(object):
         except KeyError:
             return os.path.basename(sys.argv[0])
 
-    def get_version(self):
-        """Return ROSE_VERSION."""
-        version = os.getenv("ROSE_VERSION")
-        if version is None:
+    def get_version(self, ignore_environment=False):
+        """Return ROSE_VERSION.
+
+        Args:
+            ignore_environment (bool): Ignore the value of the ROSE_VERSION
+                environment variable if present.
+        """
+        version = None
+        if not ignore_environment:
+            version = os.getenv("ROSE_VERSION")
+        if not version:
             for line in open(self.get_util_home("rose-version")):
                 if line.startswith("ROSE_VERSION="):
                     value = line.replace("ROSE_VERSION=", "")

--- a/rose.html
+++ b/rose.html
@@ -1,13 +1,1 @@
-<!DOCTYPE html>
-
-<html>
-<head>
-  <title>Rose Documentation</title>
-  <meta http-equiv="REFRESH" content="0;url=doc/html/index.html">
-</head>
-
-<body>
-<p>If not automatically redirected,
-please click <a href="doc/html/index.html">Rose Documentation</a>.</p>
-</body>
-</html>
+doc/current/html/index.html

--- a/rose.html
+++ b/rose.html
@@ -1,1 +1,0 @@
-doc/current/html/index.html

--- a/sphinx/_static/js/versioning.js
+++ b/sphinx/_static/js/versioning.js
@@ -1,0 +1,40 @@
+$(document).ready(function() {
+    $.ajax({
+        'async': false,
+        'type': 'GET',
+        'url': root_dir + 'versions.json',
+        dataType: 'json',
+        success: function (versions) {
+            // the DOM element to append version and format selectors to
+            var ele = $('#version-selector');
+
+            // construct version selector
+            var ver = ele.append($('<dl />'));
+            $(ver).append($('<dt />').append('Versions'));
+            for (let version of Object.keys(versions).sort().reverse()) {
+                $(ver).append($('<dd />')
+                    .append($('<a />')
+                        .attr({'href': root_dir + version + '/' +
+                                       current_builder + '/' +
+                                       current_page_name})
+                        .append(version)
+                    )
+                );
+            }
+
+            // construct format selector
+            var bui = ele.append($('<dl />'));
+            $(bui).append($('<dt />').append('Formats'));
+            for (let builder_for_version of versions[current_version].sort()) {
+                $(bui).append($('<dd />')
+                    .append($('<a />')
+                        .attr({'href': root_dir + current_version + '/' +
+                                       builder_for_version + '/' +
+                                       current_page_name})
+                        .append(builder_for_version)
+                    )
+                );
+            }
+        }
+    });
+});

--- a/sphinx/_templates/layout.html
+++ b/sphinx/_templates/layout.html
@@ -2,5 +2,11 @@
 
 {% extends "!layout.html" %}
 
-{% set css_files = css_files + ['_static/css/rtd-theme-fix.css', '_static/pygments.css'] %}
-{% set script_files = script_files + ['_static/js/rtd-theme-extensions.js'] %}
+{% set css_files = css_files + [
+    '_static/css/rtd-theme-fix.css',
+    '_static/pygments.css']
+%}
+{% set script_files = script_files + [
+    '_static/js/rtd-theme-extensions.js',
+    '_static/js/versioning.js']
+%}

--- a/sphinx/_templates/versions.html
+++ b/sphinx/_templates/versions.html
@@ -1,0 +1,39 @@
+{# Add rst-badge after rst-versions for small badge style. #}
+<div class="rst-versions" data-toggle="rst-versions" role="note"
+     aria-label="versions">
+  <span class="rst-current-version" data-toggle="rst-current-version">
+    <span class="fa fa-book"> Read the Docs</span>
+    v: {{ version }}
+    <span class="fa fa-caret-down"></span>
+  </span>
+  <div class="rst-other-versions" id="version-selector">
+    <script type="text/javascript">
+        // NOTE: temporary variables not initiated so that they can be deleted
+
+        // path to a root file in the current version of the documentation
+        version_path = "{{ pathto('') }}".split('/');
+        // dirname of the root dir
+        version_dir = version_path
+            .splice(0, version_path.length - 1)
+            .join('/');
+        delete version_path;
+        // relative path from the current version to the documentation root
+        rel_path = '../../';
+        // relative path from the current document to the documentation root
+        var root_dir;
+        if (version_dir) {
+            root_dir = version_dir + '/' + rel_path;
+        } else {
+            root_dir = rel_path;
+        }
+        delete version_dir;
+        delete rel_path;
+        // the name of the current version of the documentation
+        const current_version = "{{ version }}";
+        // the name of the builder (i.e. html)
+        const current_builder = "{{ builder }}";
+        // the name of the current page
+        const current_page_name = "{{ current_page_name }}";
+    </script>
+  </div>
+</div>

--- a/sphinx/conf.py
+++ b/sphinx/conf.py
@@ -31,23 +31,26 @@ sys.path.append(os.path.abspath('ext'))
 
 # Register extensions.
 extensions = [
+    # sphinx built-in extensions
     'sphinx.ext.autodoc',
-    'sphinx.ext.doctest',
-    'sphinx.ext.viewcode',
-    'sphinx.ext.napoleon',
     'sphinx.ext.autosummary',
+    'sphinx.ext.doctest',
     'sphinx.ext.graphviz',
     'sphinx.ext.mathjax',
-    'minicylc',
+    'sphinx.ext.napoleon',
+    'sphinx.ext.viewcode',
+    # sphinx user community extensions
+    'hieroglyph',
+    'sphinxcontrib.httpdomain',
+    # custom project extensions (located in ext/)
+    'auto_cli_doc',
     'cylc_lang',
+    'minicylc',
+    'practical',
     'rose_lang',
     'rose_domain',
-    'sub_lang',
-    'practical',
-    'auto_cli_doc',
     'script_include',
-    'sphinxcontrib.httpdomain',
-    'hieroglyph'
+    'sub_lang'
 ]
 
 # Slide (hieroglyph) settings.
@@ -78,9 +81,9 @@ copyright = (': British Crown Copyright 2012-8 Met Office. See Terms of Use. '
 
 # The full version for the project you're documenting, acts as replacement for
 # |version|.
-release = ResourceLocator().get_version()
+release = ResourceLocator().get_version(ignore_environment=True)
 # The short X.Y version, acts as replacement for |release|.
-version = release.split('-')[0]
+version = release
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/t/syntax/01-eslint.t
+++ b/t/syntax/01-eslint.t
@@ -27,7 +27,7 @@ tests 3
 
 TEST_KEY="${TEST_KEY_BASE}-docs"
 run_pass "${TEST_KEY}" eslint --env browser --env jquery --env es6 \
-    --parser-options=ecmaVersion:6 sphinx/_static/
+    --parser-options=ecmaVersion:6 sphinx/_static/js
 file_cmp "${TEST_KEY}.out" "${TEST_KEY}.out" <'/dev/null'
 file_cmp "${TEST_KEY}.err" "${TEST_KEY}.err" <'/dev/null'
 


### PR DESCRIPTION
Add functionality to `rose make-docs` to build versioned documentation.

Documentation is built incrementally so new versions can be added without having to rebuild old ones i.e:

```console
$ git checkout 2018.05.0
$ rose make-docs
$ tree doc -L 1
doc
|-- 2018.05.0
|-- doc -> 2018.05.0
|-- index.html
`-- versions.json
$ git checkout some-future-version
$ rose make-docs
$ tree doc -L 1
doc
|-- 2018.05.0
|-- checkout some-future-version
|-- doc -> checkout some-future-version
|-- index.html
`-- versions.json
```

As the documentation is built incrementally it is non-destructive in version control terms meaning we can do:

```console
$ git push upstream gh-pages  # no need to -f force
```

This would make auto-deployment of documentation much nicer.

Static HTML redirects are created by `rose make-docs` including a legacy re-direct for `doc/rose.html`.

The version switcher AJAXes the versions.json file to get a dictionary of available versions and formats, this AJAX means that the version selector will only work when served from behind a web server (or very permissive browser - cross site scripting).