### PR TITLE
more reliable check for display capability

### DIFF
--- a/lib/python/rose/gtk/__init__.py
+++ b/lib/python/rose/gtk/__init__.py
@@ -1,0 +1,8 @@
+try:
+    import pygtk
+    pygtk.require('2.0')
+    import gtk
+except (ImportError, RuntimeError):
+    INTERACTIVE_ENABLED = False
+else:
+    INTERACTIVE_ENABLED = True

--- a/lib/python/rose/gtk/__init__.py
+++ b/lib/python/rose/gtk/__init__.py
@@ -2,7 +2,7 @@ try:
     import pygtk
     pygtk.require('2.0')
     import gtk
-except (ImportError, RuntimeError):
+except (ImportError, RuntimeError, AssertionError):
     INTERACTIVE_ENABLED = False
 else:
     INTERACTIVE_ENABLED = True

--- a/lib/python/rose/metadata_check.py
+++ b/lib/python/rose/metadata_check.py
@@ -26,6 +26,7 @@ import sys
 import rose.config
 import rose.config_tree
 import rose.formats.namelist
+from rose.gtk import INTERACTIVE_ENABLED
 import rose.macro
 import rose.macros
 import rose.opt_parse
@@ -208,25 +209,19 @@ def _check_widget(value, module_files=None, meta_dir=None):
 
     Ignore if no DISPLAY in environment and GTK widget requires display.
     """
+    if not INTERACTIVE_ENABLED:
+        # gtk 2.0 not available, skip check.
+        return
+
     if module_files is None:
         module_files = _get_module_files(meta_dir)
     if not module_files:
         return
     widget_name = value.split()[0]
     try:
-        import pygtk
-        pygtk.require('2.0')
-    except ImportError:
-        # gtk 2.0 not available, skip check.
-        return
-    try:
         widget = rose.resource.import_object(
             widget_name, module_files, _import_err_handler)
     except Exception as exc:
-        # Ignore if there is no display for GTK widget
-        if (isinstance(exc, RuntimeError) and not os.getenv('DISPLAY') and
-                exc.args == ('could not open display',)):
-            return
         return INVALID_IMPORT.format(widget_name, type(exc).__name__, exc)
     if widget is None:
         return INVALID_OBJECT.format(value)


### PR DESCRIPTION
Further to #2141, #2169 

It would appear that the measures put in place still do not cover all cases. Note that `import gtk` in `rose.metadata_check` is equivalent to `import rose.gtk`.

For reference the offending function in `gtk` is `set_interactive` which is called on import in `gtk`: https://developer.gnome.org/pygtk/stable/gtk-functions.html#function-gtk--set-interactive