### PR TITLE
Fix root-dir settings for remote machine.

### DIFF
--- a/lib/python/rose/suite_run.py
+++ b/lib/python/rose/suite_run.py
@@ -24,6 +24,7 @@ from datetime import datetime
 from fnmatch import fnmatchcase
 from glob import glob
 import os
+import pipes
 from rose.config import ConfigDumper, ConfigLoader, ConfigNode
 from rose.env import env_var_process
 from rose.host_select import HostSelector
@@ -398,7 +399,7 @@ class SuiteRunner(Runner):
                 value = self._run_conf(key, host=host, conf_tree=conf_tree)
                 if value is not None:
                     val = self.popen.list_to_shell_str([str(value)])
-                    shcommand += ",%s=%s" % (key, val)
+                    shcommand += ",%s=%s" % (key, pipes.quote(val))
                     locs_conf.set([auth, key], value)
             command.append(shcommand)
             proc = self.popen.run_bg(*command)


### PR DESCRIPTION
This relates to #2103, which causes a similar issue for us. 

To repeat, we set: `root-dir=login*.archer.ac.uk=$DATADIR`. But in the submission command `$DATADIR` is interpreted on the rose/cylc server machine, which has no knowledge of what `$DATADIR` should be on the HPC. And so the suite directory is not created in the correct place. This doesn't seem to be an issue with the shell (as in #2103), as I use bash on both machines. 

Adding quotes around the value of the `root-dir` settings fixes it for us. 