### PR TITLE
fix ., .. versions and ensure .html url endings

### DIFF
--- a/bin/rose-make-docs
+++ b/bin/rose-make-docs
@@ -85,7 +85,6 @@ SPHINX_PATH=sphinx
 DOCS_DIR="${ROSE_HOME}/doc"
 # documentation output directory for this version
 BUILD_DIR="${DOCS_DIR}/${ROSE_VERSION}"
-# glob for documented rose versions
 # glob for documentation formats within a rose version
 DOC_FORMATS=!(*.html|doctrees)
 
@@ -141,6 +140,7 @@ done
 if [[ -z "${BUILDS}" ]]; then
     BUILDS='html'
 fi
+# glob for documented rose versions
 DOC_VERSIONS=!(*.html|doc|versions.json|"${DEFAULT_ALIAS}"|CHANGES.md|404.md|_config.yml)
 
 

--- a/bin/rose-make-docs
+++ b/bin/rose-make-docs
@@ -86,7 +86,6 @@ DOCS_DIR="${ROSE_HOME}/doc"
 # documentation output directory for this version
 BUILD_DIR="${DOCS_DIR}/${ROSE_VERSION}"
 # glob for documented rose versions
-DOC_VERSIONS=!(*.html|.git|doc|versions.json|"${DEFAULT_ALIAS}"|CHANGES.md|404.md|_config.yml)
 # glob for documentation formats within a rose version
 DOC_FORMATS=!(*.html|doctrees)
 
@@ -142,6 +141,7 @@ done
 if [[ -z "${BUILDS}" ]]; then
     BUILDS='html'
 fi
+DOC_VERSIONS=!(*.html|doc|versions.json|"${DEFAULT_ALIAS}"|CHANGES.md|404.md|_config.yml)
 
 
 venv-activate () {

--- a/sphinx/_static/js/versioning.js
+++ b/sphinx/_static/js/versioning.js
@@ -16,7 +16,7 @@ $(document).ready(function() {
                     .append($('<a />')
                         .attr({'href': root_dir + version + '/' +
                                        current_builder + '/' +
-                                       current_page_name})
+                                       current_page_name + '.html'})
                         .append(version)
                     )
                 );


### PR DESCRIPTION
Apparently extglob behaviour with dot-files is not completely standard across bash versions. Solve by removing `.git` from the the `DOC_VERSIONS` pattern as it is not needed there anyway.