### PR TITLE
env vars in quoted types

### DIFF
--- a/demo/rose-config-edit/demo_meta/app/01-types/meta/rose-meta.conf
+++ b/demo/rose-config-edit/demo_meta/app/01-types/meta/rose-meta.conf
@@ -18,6 +18,11 @@ description=A logical array of any length
 length=:
 type=boolean
 
+[namelist:nl1=my_python_boolean_array]
+description=A boolean array of length 3
+length=3
+type=python_boolean
+
 [namelist:nl1=my_char]
 description=A character variable
 type=character

--- a/demo/rose-config-edit/demo_meta/app/01-types/rose-app.conf
+++ b/demo/rose-config-edit/demo_meta/app/01-types/rose-app.conf
@@ -14,6 +14,7 @@ source=namelist:nl1
 my_boolean=false
 my_boolean_array=false,true,false
 my_boolean_array_varying=true,false,false,true
+my_python_boolean_array=False,True,False
 my_char='Character string'
 my_char_array='a','b','c'
 my_derived='Char',1.0,2,.false.

--- a/lib/python/rose/config_editor/valuewidget/array/logical.py
+++ b/lib/python/rose/config_editor/valuewidget/array/logical.py
@@ -43,11 +43,19 @@ class LogicalArrayValueWidget(gtk.HBox):
         self.max_length = metadata[rose.META_PROP_LENGTH]
         value_array = rose.variable.array_split(value)
         if metadata.get(rose.META_PROP_TYPE) == "boolean":
+            # boolean -> true/false
             self.allowed_values = [rose.TYPE_BOOLEAN_VALUE_FALSE,
                                    rose.TYPE_BOOLEAN_VALUE_TRUE]
             self.label_dict = dict(zip(self.allowed_values,
                                        self.allowed_values))
+        elif metadata.get(rose.META_PROP_TYPE) == "python_boolean":
+            # python_boolean -> True/False
+            self.allowed_values = [rose.TYPE_PYTHON_BOOLEAN_VALUE_FALSE,
+                                   rose.TYPE_PYTHON_BOOLEAN_VALUE_TRUE]
+            self.label_dict = dict(zip(self.allowed_values,
+                                       self.allowed_values))
         else:
+            # logical -> .true./.false.
             self.allowed_values = [rose.TYPE_LOGICAL_VALUE_FALSE,
                                    rose.TYPE_LOGICAL_VALUE_TRUE]
             self.label_dict = {
@@ -55,6 +63,7 @@ class LogicalArrayValueWidget(gtk.HBox):
                 rose.TYPE_LOGICAL_FALSE_TITLE,
                 rose.TYPE_LOGICAL_VALUE_TRUE:
                 rose.TYPE_LOGICAL_TRUE_TITLE}
+
 
         imgs = [(gtk.STOCK_MEDIA_STOP, gtk.ICON_SIZE_MENU),
                 (gtk.STOCK_APPLY, gtk.ICON_SIZE_MENU)]

--- a/sphinx/api/configuration/metadata.rst
+++ b/sphinx/api/configuration/metadata.rst
@@ -297,6 +297,11 @@ The metadata options for a configuration fall into four categories:
 
            *usage*: only in derived types
 
+         str_multi
+           *description*: for strings containing newline characters.
+
+           *usage*: plain text strings
+
          spaced_list
            *description*: used to signify a space separated list such as
            ``"Foo" 50 False``.


### PR DESCRIPTION
Partly addresses #2206

When environment variables are present in values `rose edit` safely falls back to `raw`. Unfortunately this isn't actually safe with quoted data types (#2206).

To solve don't fall back to the `raw` entry widget if the metadata type is a text type e.g. `quoted`. This does not solve #2206 as one could still edit the field from a raw widget (i.e. with metadata turned off) but this should prevent the overwhelming majority of users encountering the problem.

Also two bolt-on fixes:

* Document the multi line string data type.
* Add `python_boolean` support to `LogicalArrayValueWidget` (seems strange not to support it).