### PR TITLE
docs: change confusing rose-stem documentation structure

### DIFF
--- a/sphinx/tutorial/rose/furthertopics/index.rst
+++ b/sphinx/tutorial/rose/furthertopics/index.rst
@@ -18,6 +18,7 @@ This section goes into detail in additional Rose topics.
    rose-arch
    rose-bunch
    rose-stem
+   rose-stem-tutorial
    trigger
    upgrading
    upgrading-macro-development

--- a/sphinx/tutorial/rose/furthertopics/rose-stem-tutorial.rst
+++ b/sphinx/tutorial/rose/furthertopics/rose-stem-tutorial.rst
@@ -1,6 +1,5 @@
-.. include:: ../../../../hyperlinks.rst
+.. include:: ../../../hyperlinks.rst
    :start-line: 1
-
 
 .. _Rose Stem Tutorial:
 

--- a/sphinx/tutorial/rose/furthertopics/rose-stem.rst
+++ b/sphinx/tutorial/rose/furthertopics/rose-stem.rst
@@ -369,8 +369,3 @@ replacing the groupname with the desired task. Rose Stem should then
 automatically pick up the working copy and run the requested tests on it.
 
 Next see the :ref:`Rose Stem Tutorial`
-
-.. toctree::
-   :hidden:
-
-   rose-stem/tutorial.rst


### PR DESCRIPTION
Does this make sense?

| old url                               | new url |
| ----------------------------          | ---------------------------- |
| furthertopics/rose-stem.html          | furthertopics/rose-stem.html |
|furthertopics/rose-stem/tutorial.html | furthertopics/rose-stem-tutorial.html |