### PR TITLE
docs: permit documenting rose objects via intersphinx

### DIFF
--- a/sphinx/ext/rose_domain.py
+++ b/sphinx/ext/rose_domain.py
@@ -102,6 +102,22 @@ Example:
 
                    ..            ^ relative reference
 
+Referencing Objects Via Intersphinx:
+    Reference Rose objects as you would any other e.g:
+
+    .. code-block:: rst
+
+       :rose:file:`intersphinx-mapping:rose-app.conf`
+
+    A quick way to get the object reference is to extract if from the URL.
+    For example in the following URL:
+
+    .. code-block:: none
+
+        doc-root/api/configuration/application.html#rose:file:rose-app.conf
+
+    The reference is ``rose:file:rose-app.conf``.
+
 """
 
 import re


### PR DESCRIPTION
This PR allows rose objects to be referenced from other Sphinx projects (i.e. Cylc).

Invalid references to rose objects from other projects will result in warnings which will cause a build failure if run in strict mode (same behaviour as referencing rose objects locally).

Unfortunately this is rather hard to test without creating a dummy sphinx project to reference from. Once we start using this in the Cylc documentation (and vice versa) it will be tested (by virtue of being used and failing on error).

Minimal example sphinx project to demonstrate intersphinx referencing.

*conf.py*
```python
import os
import sys

# add extensions directory to python path
sys.path.append(os.path.abspath('ext'))

# register sphinx extensions
extensions = [
    'sphinx.ext.intersphinx',
    'rose_domain'
]

# mapping of project name: project url
intersphinx_mapping = {'myrosedoc': ('http:/<url path to>/rose/doc/html', None)}

# name of the index file
master_doc = 'index'
```
*index.rst*
```rst
Check out the :rose:file:`myrosedoc:rose-app.conf` file!
```

*ext/*

* *rose_domain.py*