### PR TITLE
command-format-less rose_bunch

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,6 +39,7 @@ below:
 * Jon Seddon (Met Office, UK)
 * Harry Shepherd (Met Office, UK)
 * Matt Shin (Met Office, UK)
+* Tomasz Trzeciak (Met Office, UK)
 * Stuart Whitehouse (Met Office, UK)
 * Steve Wardle (Met Office, UK)
 * Scott Wales (ARC Centre of Excellence for Climate Systems Science, Australia)

--- a/bin/rose-app-run
+++ b/bin/rose-app-run
@@ -78,6 +78,8 @@
 # ENVIRONMENT VARIABLES
 #     optional ROSE_APP_COMMAND_KEY
 #         Switch to a particular command specified in `[command]KEY`.
+#     optional ROSE_APP_MODE
+#         Specifies a builtin application to run.
 #     optional ROSE_APP_OPT_CONF_KEYS
 #         Each `KEY` in this space delimited list switches on an optional
 #         configuration. The configurations are applied first-to-last.

--- a/etc/rose-meta/rose_bunch/HEAD/rose-meta.conf
+++ b/etc/rose-meta/rose_bunch/HEAD/rose-meta.conf
@@ -12,7 +12,6 @@ help="rose bunch" built-in application used to run multiple commands from a
     =rose task-run invocation.
 
 [bunch=command-format]
-compulsory=true
 description=A Pythonic printf style format string to construct the commands
            =to run.
 help=Insert placeholders %(argname)s for substitution of the arguments

--- a/lib/python/rose/app_run.py
+++ b/lib/python/rose/app_run.py
@@ -349,6 +349,8 @@ class AppRunner(Runner):
         app_mode = conf_tree.node.get_value(["mode"])
         if app_mode is None:
             app_mode = opts.app_mode
+        if app_mode is None:
+            app_mode = os.getenv("ROSE_APP_MODE")
         if app_mode in [None, "command"]:
             return self._command(conf_tree, opts, args)
         else:

--- a/lib/python/rose/apps/rose_bunch.py
+++ b/lib/python/rose/apps/rose_bunch.py
@@ -154,14 +154,6 @@ class RoseBunchApp(BuiltinApp):
         if self.incremental:
             self.incremental = rose.env.env_var_process(self.incremental)
 
-        multi_args = conf_tree.node.get_value([self.ARGS_SECTION], {})
-        bunch_args_names = []
-        bunch_args_values = []
-        for key, val in multi_args.items():
-            bunch_args_names.append(key)
-            bunch_args_values.append(
-                shlex.split(rose.env.env_var_process(val.value)))
-
         self.isformatted = True
         self.command = rose.env.env_var_process(
             conf_tree.node.get_value([self.BUNCH_SECTION, "command-format"]))
@@ -186,6 +178,15 @@ class RoseBunchApp(BuiltinApp):
                                        instances,
                                        "not an integer value")
 
+        # Argument lists
+        multi_args = conf_tree.node.get_value([self.ARGS_SECTION], {})
+        bunch_args_names = []
+        bunch_args_values = []
+        for key, val in multi_args.items():
+            bunch_args_names.append(key)
+            bunch_args_values.append(
+                shlex.split(rose.env.env_var_process(val.value)))
+
         # Validate runlists
         if not self.invocation_names:
             if instances:
@@ -196,11 +197,12 @@ class RoseBunchApp(BuiltinApp):
         else:
             arglength = len(self.invocation_names)
 
-        if any(len(item) != arglength for item in bunch_args_values):
-            raise ConfigValueError([self.ARGS_SECTION, item],
-                                   conf_tree.node.get_value(
-                                   [self.ARGS_SECTION, item]),
-                                   "inconsistent arg lengths")
+        for item, vals in zip(bunch_args_names, bunch_args_values):
+            if len(vals) != arglength:
+                raise ConfigValueError([self.ARGS_SECTION, item],
+                                       conf_tree.node.get_value(
+                                       [self.ARGS_SECTION, item]),
+                                       "inconsistent arg lengths")
 
         if conf_tree.node.get_value([self.ARGS_SECTION, "command-instances"]):
             raise ConfigValueError([self.ARGS_SECTION, "command-instances"],

--- a/sphinx/api/built-in/rose_bunch.rst
+++ b/sphinx/api/built-in/rose_bunch.rst
@@ -49,8 +49,8 @@ Configuration
 
 The application is normally configured in the
 :rose:conf:`rose_bunch[bunch]` and :rose:conf:`rose_bunch[bunch-args]`
-sections of the :rose:file:`rose-app.conf` file, but `rose_bunch[command]`
-can be optionally used too, see below for details.
+sections of the :rose:file:`rose-app.conf` file, but
+:rose:conf:`rose-app.conf[command]` can be used too, see below for details.
 
 .. rose:app:: rose_bunch
 
@@ -75,10 +75,10 @@ can be optionally used too, see below for details.
          instances of a command they want to run. This generates the values
          used by the ``%(command-instances)s`` value in command-format.
          If `[bunch]command-format` is not specified then the command instance
-         is passed as the ``COMMAND_INSTANCES`` environment variable instead.
-         Useful for cases where the only difference between invocations
-         would be an index number e.g. ensemble members. Note indexes
-         start at ``0``.
+         is passed as the :envvar:`COMMAND_INSTANCES` environment variable
+         instead. This is useful for cases where the only difference between
+         invocations would be an index number e.g. ensemble members. Note
+         indexes start at ``0``.
 
       .. rose:conf:: pool-size=N
 
@@ -130,8 +130,8 @@ can be optionally used too, see below for details.
    .. rose:conf:: bunch-args
 
       This section is used to specify the various combinations of args to be
-      passed to the :rose:conf:`rose-app.conf[command]` specified under
-      :rose:conf:`[bunch]command-format`.
+      passed to the command specified under :rose:conf:`[bunch]command-format`,
+      if defined, or :rose:conf:`rose-app.conf[command]` otherwise.
 
       .. rose:conf:: argname=val1 val2 ...
 

--- a/sphinx/api/built-in/rose_bunch.rst
+++ b/sphinx/api/built-in/rose_bunch.rst
@@ -49,7 +49,8 @@ Configuration
 
 The application is normally configured in the
 :rose:conf:`rose_bunch[bunch]` and :rose:conf:`rose_bunch[bunch-args]`
-sections of the :rose:file:`rose-app.conf` file.
+sections of the :rose:file:`rose-app.conf` file, but `rose_bunch[command]`
+can be optionally used too, see below for details.
 
 .. rose:app:: rose_bunch
 
@@ -57,20 +58,24 @@ sections of the :rose:file:`rose-app.conf` file.
 
       .. rose:conf:: command-format=FORMAT
 
-         :compulsory: True
-
          A Pythonic ``printf``-style format string to construct the commands
          to run. Insert placeholders ``%(argname)s`` for substitution of the
          arguments specified under :rose:conf:`[bunch-args]` to the invoked
          command. The placeholder ``%(command-instances)s`` is reserved for
          inserting an automatically generated index for the command
-         invocation when using the command-instances setting.
+         invocation when using the command-instances setting. If not specified
+         then the command to run is determined following the ``mode=command``
+         logic, see :ref:`command-rose-app-run` for details, and arguments
+         are made accessible to the command as environment variables.
+
 
       .. rose:conf:: command-instances=N
 
          Allows the user to specify an integer value for the number of
          instances of a command they want to run. This generates the values
          used by the ``%(command-instances)s`` value in command-format.
+         If `[bunch]command-format` is not specified then the command instance
+         is passed as the ``COMMAND_INSTANCES`` environment variable instead.
          Useful for cases where the only difference between invocations
          would be an index number e.g. ensemble members. Note indexes
          start at ``0``.
@@ -131,9 +136,10 @@ sections of the :rose:file:`rose-app.conf` file.
       .. rose:conf:: argname=val1 val2 ...
 
          Allows defining named lists of argument values to pass to
-         :rose:conf:`[bunch]command-format`. Multiple named sets of
-         arguments can be defined. Each argname can be referenced in the
-         using ``%(argname)s``. The only disallowed name is
-         ``command-instances``, which is reserved for the
-         auto-generated list of instances when the
+         the commands being run. Multiple named sets of arguments can be
+         defined. Each `argname` can be referenced  using ``%(argname)s`` in
+         :rose:conf:`[bunch]command-format`, if specified, or ``${argname}``
+         environment variable otherwise. The only disallowed names are
+         ``command-instances`` and ``COMMAND_INSTANCES``, which are reserved
+         for the auto-generated list of instances when the
          :rose:conf:`[bunch]command-instances=N` option is used.

--- a/sphinx/api/environment-variables.rst
+++ b/sphinx/api/environment-variables.rst
@@ -25,6 +25,14 @@ Rose Environment Variables
       * :ref:`command-rose-app-run`
       * :ref:`command-rose-task-run`
 
+.. envvar:: ROSE_APP_MODE
+
+   Description
+      Can be set to define which built-in app to run.
+   Used By
+      * :ref:`command-rose-app-run`
+      * :ref:`command-rose-task-run`
+
 .. envvar:: ROSE_APP_OPT_CONF_KEYS
 
    Description

--- a/sphinx/api/environment-variables.rst
+++ b/sphinx/api/environment-variables.rst
@@ -2,6 +2,14 @@ Rose Environment Variables
 ==========================
 
 
+.. envvar:: COMMAND_INSTANCES
+
+   Description
+      Environment variable provided to Rose Bunch instances at runtime to
+      identify the command instance being run.
+   Provided At Runtime By
+      * Rose Bunch
+
 .. envvar:: NPROC
 
    Description

--- a/t/rose-task-run/41-app-bunch-default-command.t
+++ b/t/rose-task-run/41-app-bunch-default-command.t
@@ -27,12 +27,11 @@ tests 26
 export ROSE_CONF_PATH=
 TEST_KEY=$TEST_KEY_BASE
 mkdir -p $HOME/cylc-run
-SUITE_RUN_DIR=$(mktemp -d --tmpdir= 'rose-test-battery.XXXXXX')
-SUITE_RUN_DIR=$HOME/cylc-run/rose-test-battery.$TEST_KEY_BASE
+SUITE_RUN_DIR=$(mktemp -d --tmpdir=$HOME/cylc-run 'rose-test-battery.XXXXXX')
 NAME=$(basename $SUITE_RUN_DIR)
 run_pass "$TEST_KEY" \
     rose suite-run -C $TEST_SOURCE_DIR/$TEST_KEY_BASE --name=$NAME \
-    --no-gcontrol --host=localhost --new -- --no-detach --debug
+    --no-gcontrol --host=localhost -- --no-detach --debug
 #-------------------------------------------------------------------------------
 CYCLE=20100101T0000Z
 LOG_DIR="$SUITE_RUN_DIR/log/job/$CYCLE"
@@ -85,6 +84,5 @@ for TASK in buncher_default buncher_import; do
 #-------------------------------------------------------------------------------
 done
 #-------------------------------------------------------------------------------
-
-#rose suite-clean -q -y $NAME
+rose suite-clean -q -y $NAME
 exit 0

--- a/t/rose-task-run/41-app-bunch-default-command.t
+++ b/t/rose-task-run/41-app-bunch-default-command.t
@@ -1,0 +1,90 @@
+#!/bin/bash
+#-------------------------------------------------------------------------------
+# (C) British Crown Copyright 2012-8 Met Office.
+#
+# This file is part of Rose, a framework for meteorological suites.
+#
+# Rose is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Rose is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Rose. If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test rose_bunch built-in application.
+#-------------------------------------------------------------------------------
+. $(dirname $0)/test_header
+#-------------------------------------------------------------------------------
+tests 26
+#-------------------------------------------------------------------------------
+# Run the suite, and wait for it to complete
+export ROSE_CONF_PATH=
+TEST_KEY=$TEST_KEY_BASE
+mkdir -p $HOME/cylc-run
+SUITE_RUN_DIR=$(mktemp -d --tmpdir= 'rose-test-battery.XXXXXX')
+SUITE_RUN_DIR=$HOME/cylc-run/rose-test-battery.$TEST_KEY_BASE
+NAME=$(basename $SUITE_RUN_DIR)
+run_pass "$TEST_KEY" \
+    rose suite-run -C $TEST_SOURCE_DIR/$TEST_KEY_BASE --name=$NAME \
+    --no-gcontrol --host=localhost --new -- --no-detach --debug
+#-------------------------------------------------------------------------------
+CYCLE=20100101T0000Z
+LOG_DIR="$SUITE_RUN_DIR/log/job/$CYCLE"
+#-------------------------------------------------------------------------------
+# Testing successful runs
+#-------------------------------------------------------------------------------
+OFFSET=1
+for TASK in buncher_default buncher_import; do
+#-------------------------------------------------------------------------------
+# Confirm launching set of commands
+    TEST_KEY_PREFIX=launch-ok
+    FILE=$LOG_DIR/$TASK/NN/job.out
+    for INSTANCE in 0 1 2 3; do
+        TEST_KEY=$TEST_KEY_PREFIX-$INSTANCE
+        file_grep $TEST_KEY \
+        "\[INFO\] [-0-9]*T[+:0-9]* $INSTANCE: added to pool"\
+         $FILE
+    done
+#-------------------------------------------------------------------------------
+# Check output to separate files is correct
+    TEST_KEY_PREFIX=check-logs
+    FILE_PREFIX=$LOG_DIR/$TASK/NN
+    for INSTANCE in 0 1 2 3; do
+        TEST_KEY=$TEST_KEY_PREFIX-$INSTANCE
+        file_grep $TEST_KEY \
+            "$TASK: $((INSTANCE + OFFSET))" $FILE_PREFIX/bunch.$INSTANCE.out
+    done
+#-------------------------------------------------------------------------------
+    OFFSET=$((OFFSET+4))
+done
+#-------------------------------------------------------------------------------
+# Run suite a second time
+run_pass "$TEST_KEY" \
+    rose suite-run -C $TEST_SOURCE_DIR/$TEST_KEY_BASE --name=$NAME \
+    --no-gcontrol --host=localhost -- --no-detach --debug
+#-------------------------------------------------------------------------------
+# Testing successful rerun
+#-------------------------------------------------------------------------------
+for TASK in buncher_default buncher_import; do
+#-------------------------------------------------------------------------------
+# Confirm launching set of commands
+    TEST_KEY_PREFIX=launch-ok-2nd-run
+    FILE=$LOG_DIR/$TASK/NN/job.out
+    for INSTANCE in 0 1 2 3; do
+        TEST_KEY=$TEST_KEY_PREFIX-$INSTANCE
+        file_grep $TEST_KEY \
+        "\[INFO\] [-0-9]*T[+:0-9]* $INSTANCE: added to pool"\
+         $FILE
+    done
+#-------------------------------------------------------------------------------
+done
+#-------------------------------------------------------------------------------
+
+#rose suite-clean -q -y $NAME
+exit 0

--- a/t/rose-task-run/41-app-bunch-default-command/app/buncher_default/rose-app.conf
+++ b/t/rose-task-run/41-app-bunch-default-command/app/buncher_default/rose-app.conf
@@ -1,0 +1,12 @@
+mode=rose_bunch
+meta=rose_bunch
+
+[command]
+default=echo $ROSE_TASK_NAME: ${arg1}
+
+[bunch-args]
+arg1=1 2 3 4
+
+[bunch]
+command-instances = 4
+pool-size=1

--- a/t/rose-task-run/41-app-bunch-default-command/app/buncher_import/rose-app.conf
+++ b/t/rose-task-run/41-app-bunch-default-command/app/buncher_import/rose-app.conf
@@ -1,0 +1,7 @@
+import=buncher_default
+
+[env]
+arg1=5 6 7 8
+
+[bunch-args]
+arg1=$arg1

--- a/t/rose-task-run/41-app-bunch-default-command/suite.rc
+++ b/t/rose-task-run/41-app-bunch-default-command/suite.rc
@@ -1,0 +1,19 @@
+#!jinja2
+[cylc]
+    UTC mode=True
+    abort if any task fails=True
+    [[events]]
+        abort on timeout=True
+        timeout=PT1M
+[scheduling]
+    initial cycle point=20100101
+    final cycle point=20100101
+    [[dependencies]]
+        [[[T00]]]
+            graph = buncher_default & buncher_import
+[runtime]
+    [[buncher_default, buncher_import]]
+        script=rose task-run -v -v --debug
+        [[[job]]]
+            execution time limit=PT1M
+


### PR DESCRIPTION
This PR makes rose_bunch compatible with the default command lookup logic.

**Motivation:**

The `[bunch]commad-format` template is sometimes awkward to use. Firstly, it is expanded for environment variables, which makes it inconvenient for writing pieces of shell code. One might need to define variables in more complex commands (e.g.,  `for VAR in ...`), but kludges like `${VAR%}` are necessary to prevent their premature expansion in the command body.

Secondly, it makes factoring out bunching functionality out of the apps harder. One may reasonably want to have, say, a single app for deterministic and ensemble runs with a single `[command]default` for both cases and enable bunching through an optional config or app import on top of the main app config.

**Implementation:**

This PR makes `[bunch]commad-format` setting optional rather than compulsory. If it is not specified then the command to run is determined following the default ``mode=command`` logic. In this case `[bunch-args]` are passed in the environment.