### PR TITLE
rose.config: python 3 compatibility

### DIFF
--- a/lib/python/rose/namelist_dump.py
+++ b/lib/python/rose/namelist_dump.py
@@ -49,17 +49,6 @@ def tr_case(string, case_mode=None):
         return string
 
 
-def _sort_config_key(key_1, key_2):
-    match_1 = RE_NAME_INDEX.match(key_1)
-    match_2 = RE_NAME_INDEX.match(key_2)
-    if match_1 and match_2:
-        name_1, index_1 = match_1.groups()
-        name_2, index_2 = match_2.groups()
-        if name_1.lower() == name_2.lower():
-            return cmp(int(index_1), int(index_2))
-    return cmp(key_1.lower(), key_2.lower())
-
-
 def namelist_dump(args=None, output_file=None, case_mode=None):
     """Convert Fortran namelist file to a Rose configuration."""
     # Input and output options
@@ -123,10 +112,7 @@ def namelist_dump(args=None, output_file=None, case_mode=None):
                 config.set([section, lhs], obj.get_rhs_as_string())
 
     # Config: write results
-    rose.config.dump(config, output_file,
-                     sort_sections=_sort_config_key,
-                     sort_option_items=_sort_config_key,
-                     env_escape_ok=True)
+    rose.config.dump(config, output_file, env_escape_ok=True)
     output_file.close()
 
 

--- a/lib/python/rose/reporter.py
+++ b/lib/python/rose/reporter.py
@@ -19,7 +19,13 @@
 # -----------------------------------------------------------------------------
 """Reporter for diagnostic messages."""
 
-import Queue
+try:
+    # Python 3
+    import queue as Queue
+    unicode = str
+except ImportError:
+    # Python 2
+    import Queue
 
 import multiprocessing
 import sys
@@ -153,7 +159,7 @@ class Reporter(object):
         if level is None:
             level = self.DEFAULT
         msg = None
-        for key, context in self.contexts.items():
+        for key, context in list(self.contexts.items()):
             if context.is_closed():
                 self.contexts.pop(key)  # remove contexts with closed handles
                 continue

--- a/t/rose-app-upgrade/01-upgrade-basic.t
+++ b/t/rose-app-upgrade/01-upgrade-basic.t
@@ -749,11 +749,11 @@ file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<'__OUTPUT__'
         Added with value 'eggs'
     env=A=4
         Removed
-    namelist:something=foo=bar
-        Removed
     namelist:qwerty=uiop=asdf
         Removed
     namelist:qwerty=None=
+        Removed
+    namelist:something=foo=bar
         Removed
     =meta=test-app-upgrade/0.2
         Upgraded from 0.1 to 0.2

--- a/t/rose-app-upgrade/02-downgrade-basic.t
+++ b/t/rose-app-upgrade/02-downgrade-basic.t
@@ -629,10 +629,10 @@ file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<'__OUTPUT__'
 [D] Downgrade_0.2-0.1: changes: 6
     env=A=5
         Added with value '5'
-    namelist:something=foo=bar
-        Added with value 'bar'
     namelist:qwerty=None=None
         Added
+    namelist:something=foo=bar
+        Added with value 'bar'
     env=B=5
         Removed
     namelist:new=spam=eggs

--- a/t/rose-app-upgrade/03-complex.t
+++ b/t/rose-app-upgrade/03-complex.t
@@ -441,17 +441,17 @@ file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<'__OUTPUT__'
 [T] UpgradeTriggerFixing: changes: 7
     namelist:change_opt=trig_ignore_opt_has_changed=.true.
         trig-ignored -> enabled     
-    namelist:trig_ignore_sect_trig_ignored=None=None
-        trig-ignored -> enabled     
-    namelist:trig_ignore_opt_trig_ignored=starts_off_trig_ignored=.true.
+    namelist:trig_ignore_opt_enabled=starts_off_enabled=.true.
         trig-ignored -> enabled     
     namelist:trig_ignore_opt_ignored=already_ignored=.true.
         trig-ignored -> enabled     
-    namelist:trig_ignore_opt_enabled=starts_off_enabled=.true.
+    namelist:trig_ignore_opt_trig_ignored=starts_off_trig_ignored=.true.
+        trig-ignored -> enabled     
+    namelist:trig_ignore_sect_enabled=None=None
         trig-ignored -> enabled     
     namelist:trig_ignore_sect_ignored=None=None
         trig-ignored -> enabled     
-    namelist:trig_ignore_sect_enabled=None=None
+    namelist:trig_ignore_sect_trig_ignored=None=None
         trig-ignored -> enabled     
 __OUTPUT__
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
@@ -910,19 +910,19 @@ file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<'__OUTPUT__'
     =meta=test-app-upgrade/fig
         Upgraded from apple to fig
 [T] UpgradeTriggerFixing: changes: 7
-    namelist:trig_ignore_sect_trig_ignored=None=None
-        trig-ignored -> enabled     
     namelist:change_opt=trig_ignore_opt_has_changed=.true.
-        trig-ignored -> enabled     
-    namelist:trig_ignore_opt_trig_ignored=starts_off_trig_ignored=.true.
-        trig-ignored -> enabled     
-    namelist:trig_ignore_opt_ignored=already_ignored=.true.
         trig-ignored -> enabled     
     namelist:trig_ignore_opt_enabled=starts_off_enabled=.true.
         trig-ignored -> enabled     
-    namelist:trig_ignore_sect_ignored=None=None
+    namelist:trig_ignore_opt_ignored=already_ignored=.true.
+        trig-ignored -> enabled     
+    namelist:trig_ignore_opt_trig_ignored=starts_off_trig_ignored=.true.
         trig-ignored -> enabled     
     namelist:trig_ignore_sect_enabled=None=None
+        trig-ignored -> enabled     
+    namelist:trig_ignore_sect_ignored=None=None
+        trig-ignored -> enabled     
+    namelist:trig_ignore_sect_trig_ignored=None=None
         trig-ignored -> enabled     
 __OUTPUT__
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null

--- a/t/rose-app-upgrade/11-upgrade-basic-tree.t
+++ b/t/rose-app-upgrade/11-upgrade-basic-tree.t
@@ -749,11 +749,11 @@ file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<'__OUTPUT__'
         Added with value 'eggs'
     env=A=4
         Removed
-    namelist:something=foo=bar
-        Removed
     namelist:qwerty=uiop=asdf
         Removed
     namelist:qwerty=None=
+        Removed
+    namelist:something=foo=bar
         Removed
     =meta=test_tree/test-app-upgrade/0.2
         Upgraded from 0.1 to 0.2

--- a/t/rose-app-upgrade/12-downgrade-basic-tree.t
+++ b/t/rose-app-upgrade/12-downgrade-basic-tree.t
@@ -629,10 +629,10 @@ file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<'__OUTPUT__'
 [D] Downgrade_0.2-0.1: changes: 6
     env=A=5
         Added with value '5'
-    namelist:something=foo=bar
-        Added with value 'bar'
     namelist:qwerty=None=None
         Added
+    namelist:something=foo=bar
+        Added with value 'bar'
     env=B=5
         Removed
     namelist:new=spam=eggs

--- a/t/rose-config/06-doctest.t
+++ b/t/rose-config/06-doctest.t
@@ -1,0 +1,47 @@
+#!/bin/bash
+#-------------------------------------------------------------------------------
+# (C) British Crown Copyright 2012-8 Met Office.
+#
+# This file is part of Rose, a framework for meteorological suites.
+#
+# Rose is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Rose is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Rose. If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+. $(dirname $0)/test_header
+tests 4
+#-------------------------------------------------------------------------------
+# Run doctests for the `rose.config` module.
+# NOTE: Doctests of code included in the sphinx documentation are automatically
+#       run by `rose make-docs doctest`.
+# TODO: In the long run we should auto-detect and run doctests and unittests
+#       rather than explicitly running them in this manner.
+#-------------------------------------------------------------------------------
+# Python 2
+if ! which python2 2>/dev/null; then
+    skip 2
+else
+    TEST_KEY="${TEST_KEY_BASE}-python2"
+    run_pass "$TEST_KEY" python2 "${ROSE_HOME}/lib/python/rose/config.py"
+    sed -i /1034h/d "${TEST_KEY}.out"  # Remove nasty unicode output.
+    file_cmp "${TEST_KEY}.out" "${TEST_KEY}.out" </dev/null
+fi
+#-------------------------------------------------------------------------------
+# Python 3
+if ! which python3 2>/dev/null; then
+    skip 2
+else
+    TEST_KEY="${TEST_KEY_BASE}-python3"
+    run_pass "$TEST_KEY" python3 "${ROSE_HOME}/lib/python/rose/config.py"
+    sed -i /1034h/d "${TEST_KEY}.out"  # Remove nasty unicode output.
+    file_cmp "${TEST_KEY}.out" "${TEST_KEY}.out" </dev/null
+fi

--- a/t/rose-namelist-dump/02-type.t
+++ b/t/rose-namelist-dump/02-type.t
@@ -66,11 +66,11 @@ file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<'__CONTENT__'
 source=namelist:name
 
 [namelist:name]
+array_element(-100:-10,-2:10,6:720)=1
+array_element(-10,-2)=1
+array_element(-2:)=1
 array_element(-1)=1
 array_element(-1,0)=1
-array_element(-10,-2)=1
-array_element(-100:-10,-2:10,6:720)=1
-array_element(-2:)=1
 array_element(0,0)=1
 array_element(0:)=1
 array_element(1)=1


### PR DESCRIPTION
For the most part Rose is a standalone system utility, however, the `rose.config` module is occasionally imported. In order to support the continued use of this ahead of the planned Python3 migration (to follow GUI replacement) the `rose.conf` module and its Rose dependencies have been upgraded to support both Python 2 & 3.

#### Tripwire

Old-style `cmp` functions have now been retired, unfortunately Rose makes heavy use of them for sorting configurations. The sorting algorithm currently used in rose contains branched logic which changes the sorting algorithm based on comparisons of both elements being compared, ...

https://github.com/metomi/rose/blob/ec78ddffc59ae21335e2f33c5431c225f8942215/lib/python/rose/config.py#L1550-L1573

... because of this **the old sorting algorithm cannot be ported to Python 3**.

*Ok, cannot is probably a little strong, perhaps more like should not*

#### Solution?

I've implemented a new-style rich comparison algorithm, this is not a direct replacement for the old sorting system, there are differences in results. I think the new system yields better results but the diffs could potentially cause issues for users (see the diff in t/rose-namelist-dump/02-type.t)?

We will have to take the pain of this one with the Python3 upgrade?.

#### Going Forward

In this branch I've done the bare minimum required for `rose.config` to run under Python 3, hence I have left the old sorting algorithm in-place where it is still used by other parts of rose (e.g. the Rose Edit GUI). Should we:

1) Delay this until we are ready to upgrade the entire codebase into Python 3 and take the pain then.
2) Push ahead with a mixed system (not actually as bad as it sounds?).
3) Upgrade all old style comparisons and take the pain now.

@metomi/core 