### PR TITLE
docs: auto-deploy documentation from the Travis-CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,44 +2,27 @@
 # See https://travis-ci.org/ for more info.
 
 ---
+sudo: required
 language: python
-python:
-    - 2.7
-
-before_install:
-    - wget 'https://github.com/cylc/cylc/archive/master.tar.gz' -O '/tmp/cylc-master.tar.gz'
-    - tar -xvf '/tmp/cylc-master.tar.gz' -C "${HOME}"
-    - make -C "${HOME}/cylc-master" 'version'
-    - wget 'https://github.com/metomi/fcm/archive/master.tar.gz' -O '/tmp/fcm-master.tar.gz'
-    - tar -xvf '/tmp/fcm-master.tar.gz' -C "${HOME}"
-    - cat >"${HOME}/.bashrc" <<<"export PATH=${PWD}/bin:${HOME}/fcm-master/bin:${HOME}/cylc-master/bin:\$PATH"
-    - source "${HOME}/.bashrc"
-    - ssh-keygen -t 'rsa' -f "${HOME}/.ssh/id_rsa" -N '' -q
-    - cat "${HOME}/.ssh/id_rsa.pub" >>"${HOME}/.ssh/authorized_keys"
-    - ssh-keyscan -t 'rsa' 'localhost' >>"${HOME}/.ssh/known_hosts"
-
-install: 
-    - >
-        sudo apt-get install -y at build-essential gfortran heirloom-mailx
-        python-pip python-dev graphviz libgraphviz-dev python-jinja2
-        python-sqlalchemy libxml-parser-perl libconfig-inifiles-perl
-        libdbi-perl libdbd-sqlite3-perl latexmk texlive
-        texlive-generic-extra texlive-latex-extra texlive-fonts-recommended
-    - pip install cherrypy EmPy Jinja2 requests sqlalchemy pyopenssl pycodestyle
-    - pip install pygraphviz --install-option="--include-path=/usr/include/graphviz" --install-option="--library-path=/usr/lib/graphviz/"
-    - sudo sh -c 'echo "deb http://opensource.wandisco.com/ubuntu `lsb_release -cs` svn19" >> /etc/apt/sources.list.d/subversion19.list'
-    - sudo wget -q http://opensource.wandisco.com/wandisco-debian.gpg -O- | sudo apt-key add -
-    - sudo apt-get update
-    - sudo apt-get install -y subversion
-
-script: skip
 
 jobs:
     include:
-        - stage: test
-        - script: >
-            rose test-battery --state=save -j 5 ||
-            (echo -e "\n\nRerunning Failed Tests...\n\n";
-            rose test-battery -v --state=save,failed -j 5)
-        - script: >
-            rose make-docs --venv --dev --strict clean linkcheck doctest html slides latexpdf
+    - name: "Test Battery"
+      python:
+        - 2.7
+      install:
+        - etc/travis-scripts install cylc fcm rose
+      script:
+        - etc/travis-scripts test-battery
+
+    - name: "Documentation"
+      python:
+        - 2.7
+      install:
+        - etc/travis-scripts install docs
+      script:
+        - etc/travis-scripts test-docs
+        - if [[ "${TRAVIS_TAG}" ]]; then etc/travis-scripts prepare-docs-branch; fi
+        - etc/travis-scripts build-docs
+      after_success:
+        - if [[ "${TRAVIS_TAG}" ]]; then etc/travis-scripts deploy-docs; fi

--- a/bin/rose-make-docs
+++ b/bin/rose-make-docs
@@ -37,7 +37,7 @@
 #         errors.
 #     --debug
 #         Run `make` with the --debug option.
-#     --default-version=VERSION
+#     --default-version VERSION
 #         By default the current version is symlinked as the default version,
 #         provide an alternative version to override this.
 #         If set to 'none' then the default version will remain unchanged.

--- a/bin/rose-make-docs
+++ b/bin/rose-make-docs
@@ -40,6 +40,7 @@
 #     --default-version=VERSION
 #         By default the current version is symlinked as the default version,
 #         provide an alternative version to override this.
+#         If set to 'none' then the default version will remain unchanged.
 #
 # BUILD
 #     The format(s) to build the documentation in - default html.
@@ -278,11 +279,13 @@ if make ${DEBUG} -C "${SPHINX_PATH}" ${BUILDS} ${SPHINX_OPTS}; then
     # switching pane
     version_file "${DOCS_DIR}" > "${DOCS_DIR}/versions.json"
     # symlink this version as the default
-    (
-        cd "${DOCS_DIR}"
-        rm "${DEFAULT_ALIAS}" 2>/dev/null || true
-        ln -s "${DEFAULT_VERSION:-$ROSE_VERSION}" "${DEFAULT_ALIAS}"
-    )
+    if [[ "${DEFAULT_VERSION}" != 'none' ]]; then
+        (
+            cd "${DOCS_DIR}"
+            rm -f "${DEFAULT_ALIAS}" 2>/dev/null
+            ln -s "${DEFAULT_VERSION:-$ROSE_VERSION}" "${DEFAULT_ALIAS}"
+        )
+    fi
     # symlink landing pages
     html_redirect "${DEFAULT_ALIAS}/html/index.html" 'doc/index.html'
     html_redirect "html/index.html" "doc/${ROSE_VERSION}/index.html"

--- a/etc/deploy-docs
+++ b/etc/deploy-docs
@@ -36,7 +36,7 @@ initial_deployment () {  # Create a new gh-pages branch from scratch.
     git clean -xf doc
 
     # build the documentation
-    rose make-docs html slides
+    rose make-docs html slides pdf
 
     # create the gh-pages branch
     git branch -D gh-pages || true
@@ -58,19 +58,20 @@ initial_deployment () {  # Create a new gh-pages branch from scratch.
 
 subsequent_deployment () {  # Add new version to documentation.
     # update gh-pages branch
-    git pull "${REMOTE}" gh-pages -f
+    git fetch "${REMOTE}" gh-pages -f
+
     git clean -xf doc
 
     # copy gh-pahes branch to a temporary directory
     TMP_DOCS_DIR="$(mktemp -d)"
-    git archive 'gh-pages' | (cd "${TMP_DOCS_DIR}" && tar -xf -)
+    git archive 'upstream/gh-pages' | (cd "${TMP_DOCS_DIR}" && tar -xf -)
 
     # append new documentation to the temporary directory
     ln -s "$TMP_DOCS_DIR" doc
-    rose make-docs html slides
+    rose make-docs html slides pdf
 
     # apply changes to gh-pages branch
-    git checkout gh-pages
+    git checkout -B gh-pages upstream/gh-pages
     rsync -av "${TMP_DOCS_DIR}/" .  # NOTE: the trailing slash is required
     rm -rf "${TMP_DOCS_DIR}"
     git add * -f

--- a/etc/travis-scripts
+++ b/etc/travis-scripts
@@ -143,7 +143,7 @@ build-docs () {
     if ! rose make-docs --venv --dev --strict clean html slides pdf \
             ${DEFAULT_VERSION:-} >out 2>&1; then
         # output is a bit long, only output it if the docs fail to build
-        cat out >2
+        cat out >&2
         exit 1
     fi
 

--- a/etc/travis-scripts
+++ b/etc/travis-scripts
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+#-------------------------------------------------------------------------------
+# (C) British Crown Copyright 2012-8 Met Office.
+#
+# This file is part of Rose, a framework for meteorological suites.
+#
+# Rose is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Rose is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Rose. If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+set -eu
+set -o xtrace  # for ease of debugging travis builds
+shopt -s extglob
+
+
+export PATH="${PWD}/bin:${HOME}/fcm-master/bin:${HOME}/cylc-master/bin:$PATH"
+
+TMP_DOCS_DIR="${TMPDIR:-/var/tmp}/temp-docs-dir"
+DOCUMENTATION_FILES=!(doc|404*|CHANGES.md|_config.yml)
+GITHUB_REPO="https://github.com/${TRAVIS_REPO_SLUG}"
+
+
+install() {
+    args=("$@")
+
+    # package managers
+    sudo apt-get -q update
+    sudo apt-get install -qy python-pip
+
+    # Cylc
+    if grep 'cylc' <<< "${args[@]}"; then
+        # install Cylc
+        wget 'https://github.com/cylc/cylc/archive/master.tar.gz' -O \
+            '/tmp/cylc-master.tar.gz'
+        tar -xvf '/tmp/cylc-master.tar.gz' -C "${HOME}"
+        make -C "${HOME}/cylc-master" 'version'
+
+        # install Cylc dependencies
+        sudo apt-get -qy install at python-jinja2 heirloom-mailx
+        pip install -q pyopenssl cherrypy requests Jinja2 EmPy
+
+        # configure SSH
+        ssh-keygen -t 'rsa' -f "${HOME}/.ssh/id_rsa" -N '' -q
+        cat "${HOME}/.ssh/id_rsa.pub" >>"${HOME}/.ssh/authorized_keys"
+        ssh-keyscan -t 'rsa' 'localhost' >>"${HOME}/.ssh/known_hosts"
+    fi
+
+    # FCM
+    if grep 'fcm' <<< "${args[@]}"; then
+        # install Subversion
+        sudo sh -c 'echo "deb http://opensource.wandisco.com/ubuntu \
+            `lsb_release -cs` \
+            svn19" >> /etc/apt/sources.list.d/subversion19.list'
+        sudo wget -q http://opensource.wandisco.com/wandisco-debian.gpg -O- | \
+            sudo apt-key add -
+        sudo apt-get -qy install subversion
+
+        # install FCM
+        wget 'https://github.com/metomi/fcm/archive/master.tar.gz' -O \
+            '/tmp/fcm-master.tar.gz'
+        tar -xvf '/tmp/fcm-master.tar.gz' -C "${HOME}"
+
+        # install FCM dependencies
+        sudo apt-get -qy install build-essential gfortran libxml-parser-perl \
+            libconfig-inifiles-perl libdbi-perl libdbd-sqlite3-perl
+    fi
+
+    # Rose - full installation + testing dependencies
+    if grep 'rose' <<< "${args[@]}"; then
+        sudo apt-get -qy install python-jinja2 python-sqlalchemy
+        pip install -q cherrypy requests sqlalchemy pycodestyle Jinja2 EmPy
+    fi
+
+    # Graphviz
+    if grep -E '(rose|cylc|docs)' <<< "${args[@]}"; then
+        sudo apt-get install -qy python-dev graphviz libgraphviz-dev
+        pip install -q pygraphviz \
+            --install-option="--include-path=/usr/include/graphviz" \
+            --install-option="--library-path=/usr/lib/graphviz/"
+    fi
+
+    # LaTeX
+    if grep 'docs' <<< "${args[@]}"; then
+        # NOTE: Rose installs its own Python dependencies in a virtualenv via
+        # the `rose make-docs` command.
+
+        # non-Python dependencies for building PDF documentation
+        sudo apt-get -qy install latexmk texlive texlive-generic-extra \
+            texlive-latex-extra texlive-fonts-recommended
+    fi
+}
+
+test-battery () {
+    # run the standard rose test battery
+    rose test-battery --state=save -j 5 || (
+        echo -e "\n\nRerunning Failed Tests...\n\n"
+        rose test-battery -v --state=save,failed -j 5
+    )
+}
+
+test-docs () {
+    # run rose documentation tests
+    rose make-docs --venv --dev --strict clean linkcheck doctest \
+        --default-version none
+    git clean -xf .
+}
+
+prepare-docs-branch () {
+    # prepare to build documentation on top of the upstream/gh-pages branch
+
+    # symlink doc/ to a temporary directory to build the docs in
+    mkdir "$TMP_DOCS_DIR"
+    rm -rf 'doc' || true
+    ln -s "$TMP_DOCS_DIR" 'doc'
+
+    # archive the upstream/gh-pages branch to the temporary directory
+    git remote add upstream "${GITHUB_REPO}.git"
+    git fetch upstream gh-pages
+    git archive 'upstream/gh-pages' | (cd "${TMP_DOCS_DIR}"; tar -xf '-')
+}
+
+build-docs () {
+    # build the rose documentation in the standard output formats
+
+    # if we are not building the most recent tag then leave the default
+    # docs version (symlinked from the web root) unchanged
+    LATEST_TAG="$(git ls-remote --tags --refs 'http://github.com/metomi/rose' \
+        | sed 's/.*refs\/tags\/\(.*\)/\1/' | sort | tail -n 1)"
+    if [[ "${LATEST_TAG}" != "${TRAVIS_TAG}" ]]; then
+        DEFAULT_VERSION="--default-version none"
+    fi
+
+    # build the documentation
+    if ! rose make-docs --venv --dev --strict clean html slides pdf \
+            ${DEFAULT_VERSION:-} >out 2>&1; then
+        # output is a bit long, only output it if the docs fail to build
+        cat out >2
+        exit 1
+    fi
+
+    # remove left-overs including any doctrees created by Sphinx
+    rm -rf 'doc/'*'/doctrees'
+    git clean -xf $DOCUMENTATION_FILES
+}
+
+deploy-docs () {
+    # produce a gh-pages branch ready for docs deployment
+    git checkout -B 'gh-pages' 'upstream/gh-pages'
+    rsync -aqv "${TMP_DOCS_DIR}/" .
+    git add -f ./*
+    git commit -q -m "${TRAVIS_TAG}"
+
+    # push gh-pages branch to GitHub where it will be auto-deployed to ghpages
+    set +o xtrace  # prevent leakage of the GH_TOKEN env var
+    git push "https://${GH_TOKEN}@github.com/${TRAVIS_REPO_SLUG}.git" \
+        'gh-pages' 2>&1 | sed "s/$GH_TOKEN/\$GH_TOKEN/g"
+}
+
+
+"$@"


### PR DESCRIPTION
#### If building a git tag (as opposed to a branch) then append the built docs to the current gh-pages branch and push back the result, GitHub will take care of the rest.

Documentation is built incrementally atop what has gone before so changes are not destructive, i.e we don't need to do a force push.

Every now and again we will want to remove older versions from the documentation, this can be done manually:
* Check out the `gh-pages` branch and delete the relevant commit.
* If the relevant commit is the first one, delete the relevant directory and squash the commit with the next one.

Example in motion:

* Example of Travis building a regular branch
   * TB output: https://travis-ci.org/oliver-sanders/rose/builds/416776038
* Example of Travis building a tag (release)
    * TB output: https://travis-ci.org/oliver-sanders/rose/builds/416776730
    * gh-pages branch: http://oliver-sanders.github.io/rose/doc/html/index.html

#### Before this can work on metomi/rose

We need a GitHub o-auth token with the permission "public_repo". This then has to be provided to Travis-Ci (via the dashboard) as the environment variable `GH_TOKEN`.