### PR TITLE
Avoid declaring variable twice in nested for loops

### DIFF
--- a/lib/python/rose/apps/rose_prune.py
+++ b/lib/python/rose/apps/rose_prune.py
@@ -252,13 +252,13 @@ class RosePruneApp(BuiltinApp):
                 cycle_set.add(cycle)
                 if cycle_args:
                     cycle_strs = {"cycle": cycle}
-                    for key, cycle_format in cycle_formats.items():
+                    for cycle_key, cycle_format in cycle_formats.items():
                         if self._get_cycling_mode() == "integer":
-                            cycle_strs[key] = cycle_format % int(cycle)
+                            cycle_strs[cycle_key] = cycle_format % int(cycle)
                         else:  # date time cycling
                             cycle_point = (
                                 app_runner.date_time_oper.date_parse(cycle)[0])
-                            cycle_strs[key] = (
+                            cycle_strs[cycle_key] = (
                                 app_runner.date_time_oper.date_format(
                                     cycle_format, cycle_point))
                     for tail_glob in shlex.split(cycle_args.pop()):

--- a/lib/python/rose/config_editor/data_helper.py
+++ b/lib/python/rose/config_editor/data_helper.py
@@ -433,9 +433,9 @@ class ConfigDataHelper(object):
                     var_id = var.metadata["id"]
                     section = self.util.get_section_option_from_id(var_id)[0]
                     sect_data = config_data.sections.get_sect(section)
-                    for key in sect_data.ignored_reason:
-                        variable_statuses.setdefault(key, 0)
-                        variable_statuses[key] += 1
+                    for key2 in sect_data.ignored_reason:
+                        variable_statuses.setdefault(key2, 0)
+                        variable_statuses[key2] += 1
                 else:
                     variable_statuses.setdefault(key, 0)
                     variable_statuses[key] += 1

--- a/lib/python/rosie/db.py
+++ b/lib/python/rosie/db.py
@@ -281,8 +281,8 @@ class DAO(object):
                 if level > len(levels) - 1:
                     levels.append([])
                 levels[level].append([])
-            for i in range(level + 1):
-                levels[i][-1].append(item)
+            for j in range(level + 1):
+                levels[j][-1].append(item)
             if item == ")":
                 level -= 1
         for i in range(len(levels) - 1, -1, -1):


### PR DESCRIPTION
Preventing a variable of being declared twice in nested for loops. Hoping the build server will confirm that it doesn't break any tests (haven't learned how to run the tests locally yet :-) )