### PR TITLE
Minor fixes for list removal

### DIFF
--- a/lib/python/rose/config_editor/valuewidget/array/entry.py
+++ b/lib/python/rose/config_editor/valuewidget/array/entry.py
@@ -378,7 +378,7 @@ class EntryArrayValueWidget(gtk.HBox):
         """Remove the last selected or the last entry."""
         if (self.last_selected_src is not None and
                 self.last_selected_src in self.entries):
-            entry = self.entries.remove(self.last_selected_src)
+            entry = self.entries.pop(self.last_selected_src)
             self.last_selected_src = None
         else:
             entry = self.entries.pop()

--- a/lib/python/rose/config_editor/valuewidget/array/python_list.py
+++ b/lib/python/rose/config_editor/valuewidget/array/python_list.py
@@ -348,7 +348,7 @@ class PythonListValueWidget(gtk.HBox):
         if (self.last_selected_src is not None and
                 self.last_selected_src in self.entries):
             text = self.last_selected_src.get_text()
-            widget = self.entries.remove(self.last_selected_src)
+            widget = self.entries.pop(self.last_selected_src)
             self.last_selected_src = None
         else:
             text = self.entries[-1].get_text()

--- a/lib/python/rose/config_editor/valuewidget/array/spaced_list.py
+++ b/lib/python/rose/config_editor/valuewidget/array/spaced_list.py
@@ -343,7 +343,7 @@ class SpacedListValueWidget(gtk.HBox):
         if (self.last_selected_src is not None and
                 self.last_selected_src in self.entries):
             text = self.last_selected_src.get_text()
-            entry = self.entries.remove(self.last_selected_src)
+            entry = self.entries.pop(self.last_selected_src)
             self.last_selected_src = None
         else:
             text = self.entries[-1].get_text()


### PR DESCRIPTION
Hi,

~Small change to compare the `list` using `not`, instead of comparing against another empty list.~

And also removes the part of the code that was trying to store the value of `list.remove`, which happens in place (but in Java if I remember well, `ArrayList#remove()` would return the element...).

Waited for Travis-CI to build my branch (https://travis-ci.org/kinow/rose) before submitting the pull request.

Happy to squash commits, rebase, or even add more unit tests if necessary :tada: 

Cheers
Bruno