### PR TITLE
Add coverage to project reports.

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,51 @@
+# Codecov settings
+# After modifying this file, it might be worth to validate it with:
+# `curl --data-binary @.codecov.yml https://codecov.io/validate`
+
+# which branch to monitor and whether wait for ci success
+codecov:
+  branch: master
+  notify:
+    require_ci_to_pass: yes
+
+# define the colour bar limits here
+coverage:
+  precision: 2
+  round: down
+  range: "75...100"
+
+  # diff type
+  status:
+    project:
+      default:
+        # commits below this threshold will be marked as failed
+        target: '84%'
+        # how much we allow the coverage to drop
+        threshold: '1%'
+    patch:
+      default:
+        # basic
+        target: '84%'
+        threshold: '1%'
+        base: auto
+        # advanced
+        branches: null
+        if_no_uploads: error
+        if_not_found: success
+        if_ci_failed: error
+        only_pulls: false
+        flags: null
+        paths: null
+    changes: no
+
+# files to ignore
+ignore:
+  - "demo/**/*.py"
+  - "etc/**/*.py"
+  - "sphinx/**/*.py"
+  - "t/**/*.py"
+  - ".travis/**/*.py"
+  - "lib/python/isodatetime/**/*.py"
+
+# turn off comments to pull requests
+comment: off

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,92 @@
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2012-8 Met Office.
+#
+# This file is part of Rose, a framework for meteorological suites.
+#
+# Rose is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Rose is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Rose. If not, see <http://www.gnu.org/licenses/>.
+# -----------------------------------------------------------------------------
+
+# This is the Coverage.py configuration file. This is used by Travis-CI when running
+# the tests and collecting coverage
+
+[run]
+
+branch=True
+cover_pylib=False
+concurrency=multiprocessing
+data_file=${TRAVIS_BUILD_DIR}/.coverage
+disable_warnings=
+    trace-changed
+    module-not-python
+    module-not-imported
+    no-data-collected
+    module-not-measured
+#    include-ignored
+debug=
+#    callers
+#    dataio
+#    multiprocess
+#    dataio
+#    dataop
+#    pid
+#    plugin
+#    process
+#    sys
+#    trace
+# Include can be used only if source is not used!
+note=
+omit=
+    */lib/python/isodatetime*
+    */lib/python/sitecustomize.py
+parallel = True
+plugins=
+include=
+    *lib/python/rose*
+    *lib/python/rosie*
+timid = False
+
+
+[report]
+
+exclude_lines =
+    pragma: no cover
+    def __repr__
+    raise NotImplementedError
+    if __name__ == .__main__.:
+    def parse_args
+    pass
+fail_under=0
+ignore_errors = False
+include=
+omit=
+    */lib/python/isodatetime*
+    */lib/python/sitecustomize.py
+partial_branches=
+precision=2
+show_missing=False
+skip_covered=False
+sort=Name
+
+
+[html]
+
+directory=htmlcov
+extra_css=
+title=
+
+
+[xml]
+
+output=coverage.xml
+package_depth=99

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,9 @@ etc/opt
 lib/bash/rose_init_site
 doc
 venv
+
+# coverage
+.coverage
+.coverage.*
+coverage.xml
+htmlcov/

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,10 @@ before_install:
     - ssh-keygen -t 'rsa' -f "${HOME}/.ssh/id_rsa" -N '' -q
     - cat "${HOME}/.ssh/id_rsa.pub" >>"${HOME}/.ssh/authorized_keys"
     - ssh-keyscan -t 'rsa' 'localhost' >>"${HOME}/.ssh/known_hosts"
+    # Coverage dependencies
+    - pip install coverage pytest-cov
 
-install: 
+install:
     - >
         sudo apt-get install -y at build-essential gfortran heirloom-mailx
         python-pip python-dev graphviz libgraphviz-dev python-jinja2
@@ -33,14 +35,19 @@ install:
     - sudo apt-get update
     - sudo apt-get install -y subversion
 
-script: skip
+script:
+    - export COVERAGE_PROCESS_START="${TRAVIS_BUILD_DIR}/.coveragerc"
+    # ./bin/rose will change PYTHONPATH, so we cannot rely on that for sitecustomize.py
+    # but instead we can move the sitecustomize.py to the place used as PYTHONPATH
+    - cp "${TRAVIS_BUILD_DIR}/.travis/sitecustomize.py" ./lib/python
+    - export PYTHONPATH="${TRAVIS_BUILD_DIR}/.travis"
+    - coverage run .travis/cover.py
+    - rm ./lib/python/sitecustomize.py
 
-jobs:
-    include:
-        - stage: test
-        - script: >
-            rose test-battery --state=save -j 5 ||
-            (echo -e "\n\nRerunning Failed Tests...\n\n";
-            rose test-battery -v --state=save,failed -j 5)
-        - script: >
-            rose make-docs --venv --dev --strict clean linkcheck doctest html slides latexpdf
+after_script:
+    - rose make-docs --venv --dev --strict clean linkcheck doctest html slides latexpdf
+
+after_success:
+    - coverage combine --append
+    - coverage xml --ignore-errors
+    - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,19 +35,22 @@ install:
     - sudo apt-get update
     - sudo apt-get install -y subversion
 
-script:
-    - export COVERAGE_PROCESS_START="${TRAVIS_BUILD_DIR}/.coveragerc"
-    # ./bin/rose will change PYTHONPATH, so we cannot rely on that for sitecustomize.py
-    # but instead we can move the sitecustomize.py to the place used as PYTHONPATH
-    - cp "${TRAVIS_BUILD_DIR}/.travis/sitecustomize.py" ./lib/python
-    - export PYTHONPATH="${TRAVIS_BUILD_DIR}/.travis"
-    - coverage run .travis/cover.py
-    - rm ./lib/python/sitecustomize.py
-
-after_script:
-    - rose make-docs --venv --dev --strict clean linkcheck doctest html slides latexpdf
-
 after_success:
     - coverage combine --append
     - coverage xml --ignore-errors
     - bash <(curl -s https://codecov.io/bash)
+
+jobs:
+    include:
+    - name: "Test Battery"
+      script:
+      - export COVERAGE_PROCESS_START="${TRAVIS_BUILD_DIR}/.coveragerc"
+      # ./bin/rose will change PYTHONPATH, so we cannot rely on that for sitecustomize.py
+      # but instead we can move the sitecustomize.py to the place used as PYTHONPATH
+      - cp "${TRAVIS_BUILD_DIR}/.travis/sitecustomize.py" ./lib/python
+      - export PYTHONPATH="${TRAVIS_BUILD_DIR}/.travis"
+      - coverage run .travis/cover.py
+      - rm ./lib/python/sitecustomize.py
+    - name: "Documentation"
+      script:
+        - rose make-docs --venv --dev --strict clean linkcheck doctest html slides latexpdf

--- a/.travis/cover.py
+++ b/.travis/cover.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2012-8 Met Office.
+#
+# This file is part of Rose, a framework for meteorological suites.
+#
+# Rose is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Rose is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Rose. If not, see <http://www.gnu.org/licenses/>.
+# -----------------------------------------------------------------------------
+
+import sys
+
+from subprocess import call
+
+
+def main():
+    command = ['rose', 'test-battery', '-j', '5']
+    if call(command + ['--state=save']):
+        # Non-zero return code
+        sys.stderr.write('\n\nRerunning Failed Tests...\n\n')
+        # Exit with final return code
+        sys.exit(call(command + ['--state=save,failed', '-v']))
+
+
+if __name__ == '__main__':
+    main()

--- a/.travis/sitecustomize.py
+++ b/.travis/sitecustomize.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# (C) British Crown Copyright 2012-8 Met Office.
+#
+# This file is part of Rose, a framework for meteorological suites.
+#
+# Rose is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Rose is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Rose. If not, see <http://www.gnu.org/licenses/>.
+# -----------------------------------------------------------------------------
+
+"""This file is used by Travis-CI to start the coverage process. In order to make
+Python aware of it, we export PYTHONPATH when running the tests"""
+
+
+import coverage
+coverage.process_startup()
+


### PR DESCRIPTION
Hi,

This is based on a [pull request submitted for Cylc](https://github.com/cylc/cylc/pull/2766), but with a few enhancements (which will be applied there too now).

The current [coverage reported in Codacy is **3%**](https://app.codacy.com/project/kinow/rose/dashboard), but it could be due to some bug in this pull request. Or maybe not all the code can be covered, and so it would be just a matter of ignoring more files... or maybe it is due to some configuration from Codacy that I forgot to change.

I finished this change yesterday, and have been playing with Codacy and Travis until now, trying to tweak the settings to see if there was anything obvious that I was missing. But perhaps somebody else would be interested in having a look at it? (if you compare my/rose Codacy dashboard, there are a small improvement in the metrics due to myself adding more files to be ignored... right now only lib/python/{rose|rosie} are being analyzed - I think).

Before merging it, someone with admin access to the project's Codacy account would have to [follow the Codacy docs](https://support.codacy.com/hc/en-us/articles/207279819-Coverage) to enable Travis integration, and also customize what files are ignored in the analysis (e.g. isodatetime, demo, etc, and other folders may be analyzed and considered for coverage statistic).

Cheers
Bruno