### PR TITLE
docs: add tip regarding nature of script setting

### DIFF
--- a/sphinx/tutorial/cylc/runtime/introduction.rst
+++ b/sphinx/tutorial/cylc/runtime/introduction.rst
@@ -95,6 +95,14 @@ We can also call other scripts or executables in this way, e.g:
        [[hello_world]]
            script = hello_world
 
+.. tip::
+
+   In the above example we run our custom executable by supplying just its
+   name to the ``script`` setting. This only works because we set up
+   the file so it can be executed in this way on the command line.
+
+   This is not the case in general. The ``script`` setting is for
+   *bash instructions*, not the name of a file to run.
 
 .. _tutorial-tasks-and-jobs:
 


### PR DESCRIPTION
A user required clarification about the ``script`` task runtime setting, as used in the simple case of running a custom script under ``bin/``. They were unable to get a very basic suite running because the ``script`` setting for their tasks was set-up incorrectly & they could not see why.

They pointed out that the example provided in the Cylc Tutorial docs (Runtime -> Introduction -> 'The ``script`` Setting' & then the Runtime practicals) made it seem like this setting was for providing **just a script name** that would be run for the task in question, as one could easily assume from the setting name ``script``.

I've had a look & the tutorial would greatly benefit from clarification in this regard.