### PR TITLE
Fix documentation build error

### DIFF
--- a/bin/rose-check-software
+++ b/bin/rose-check-software
@@ -317,7 +317,9 @@ def docs(check=check):
                version_template='graphviz version ([^\s]+)', outfile=2),
         check('tex', version_template=r'TeX ([^\s]+)'),
         check('pdflatex', version_template=r'pdfTeX .*-.*-([^\s]+)'),
-        check('py:sphinx', (1, 5, 3)),
+        # TODO remove Sphinx version dependency
+        # https://github.com/nyergler/hieroglyph/issues/148
+        check('py:sphinx', (1, 5, 3), (1, 8)),
         check('py:sphinx_rtd_theme', (0, 2, 4)),
         check('py:sphinxcontrib.httpdomain'),
         check('py:hieroglyph')

--- a/bin/rose-make-docs
+++ b/bin/rose-make-docs
@@ -153,7 +153,9 @@ venv-install () {
     venv-destroy
     virtualenv --python=python2.7 "${VENV_PATH}"
     venv-activate
-    pip install sphinx
+    # TODO remove Sphinx version dependency
+    # https://github.com/nyergler/hieroglyph/issues/148
+    pip install 'sphinx==1.7.9'
     pip install sphinx_rtd_theme
     pip install sphinxcontrib-httpdomain
     pip install hieroglyph


### PR DESCRIPTION
The system we use to generate slides in the documentation (hieroglyph) is currently generating traceback for the latest Sphinx.

See: https://github.com/nyergler/hieroglyph/issues/148

HTML and PDF builds are unaffected.

Hardcode the sphinx version to the last working combination (1.7.9) until this issue is resolved.