### PR TITLE
Fix for path functions in grepper

### DIFF
--- a/lib/python/rose/apps/ana_builtin/grepper.py
+++ b/lib/python/rose/apps/ana_builtin/grepper.py
@@ -142,7 +142,7 @@ class SingleCommandStatus(AnalysisTask):
         for ifile, fname in enumerate(files):
             self.reporter(
                 "File {0}: {1}".format(ifile + 1,
-                                       os.path.realpath(files[ifile])))
+                                       os.path.abspath(files[ifile])))
         self.files = files
 
     def process_opt_kgo(self):
@@ -213,8 +213,8 @@ class SingleCommandStatus(AnalysisTask):
                     continue
                 self.kgo_db.enter_comparison(
                     self.options["full_task_name"],
-                    os.path.realpath(kgo_file),
-                    os.path.realpath(suite_file),
+                    os.path.abspath(kgo_file),
+                    os.path.abspath(suite_file),
                     ["FAIL", " OK "][self.passed], "Compared using grepper")
 
 


### PR DESCRIPTION
We recently made an adjustment to the way we interpret the KGO database entries produced by `rose_ana` tasks.  As a result sometimes the compared files include sym-links, and unfortunately the code in the current analysis functions calls `os.path.realpath` on the files.  The causes the sym-links to be followed and causes problems for our updating processes.  On closer inspection there's no reason why this needs to be `realpath`, so we change it here to use `abspath` instead (which is essentially the same, save for the sym-link following part)