### PR TITLE
docs: fix typo breaking example code

### DIFF
--- a/sphinx/tutorial/cylc/runtime/configuration-consolidation/jinja2.rst
+++ b/sphinx/tutorial/cylc/runtime/configuration-consolidation/jinja2.rst
@@ -132,7 +132,7 @@ This would result in:
 
    #!Jinja2
 
-   {% set stations = {'belmullet: 3976,
+   {% set stations = {'belmullet': 3976,
                       'camborne': 3808,
                       'heathrow': 3772,
                       'shetland': 3005} %}


### PR DESCRIPTION
Fix typo in a Jinja2 multi-line statement example. Trivial hence a single reviewer sufficient.

(I don't have time to trawl through docs to check for typos, but will try to report as & when I spot them.)