### PR TITLE
fix doctests

### DIFF
--- a/t/docs/01-doctest.t
+++ b/t/docs/01-doctest.t
@@ -21,7 +21,7 @@
 #-------------------------------------------------------------------------------
 . "$(dirname "$0")/test_header"
 #-------------------------------------------------------------------------------
-if ! rose check-software-docs 2>'/dev/null'; then
+if ! rose check-software --docs 2>'/dev/null'; then
     skip_all "Software dependencies for documentation not met."
 fi
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
Command was not updated after it was renamed causing the doctests to always get skipped.