### PR TITLE
WIP - Support non-standard remote run directories.

### DIFF
--- a/lib/python/rose/opt_parse.py
+++ b/lib/python/rose/opt_parse.py
@@ -333,6 +333,11 @@ class RoseOptionParser(OptionParser):
             {"action": "store",
              "metavar": "DIR",
              "help": "Suite run directory."}],
+        "work_dir": [
+            ["--work-dir"],
+            {"action": "store",
+             "metavar": "DIR",
+             "help": "Suite work and share directory."}],
         "new_mode": [
             ["--new", "-N"],
             {"action": "store_true",

--- a/lib/python/rose/opt_parse.py
+++ b/lib/python/rose/opt_parse.py
@@ -328,6 +328,11 @@ class RoseOptionParser(OptionParser):
             {"action": "store",
              "metavar": "NAME",
              "help": "Specify the suite name."}],
+        "run_dir": [
+            ["--run-dir"],
+            {"action": "store",
+             "metavar": "DIR",
+             "help": "Suite run directory."}],
         "new_mode": [
             ["--new", "-N"],
             {"action": "store_true",

--- a/lib/python/rose/suite_engine_procs/cylc.py
+++ b/lib/python/rose/suite_engine_procs/cylc.py
@@ -67,43 +67,20 @@ class CylcProcessor(SuiteEngineProcessor):
         self.host = None
         self.user = None
 
-    def get_suite_run_dir(self, suite_name, host, user):
-        """Get suite run directory on given host.
-
-        Should be absolute (may contain remote $USER - known on suite host), or
-        relative to home (where home is the default ssh landing point)
-        """
+    def get_suite_run_work_dir(self, item, suite_name, host, user):
+        """Get suite run or work (item) directory on given host."""
         try:
             out = self.popen(
                 "cylc", "get-global-config", "-i",
-                "[hosts][%s]run directory" % host)[0]
+                "[hosts][%s]%s directory" % (host, item))[0]
         except RosePopenError:
             out = self.SUITE_DIR_REL_ROOT
-        run_d = out.splitlines()[0]
+        the_d = out.splitlines()[0]
         # TODO - DOCUMENT ONLY '$USER' is replaced in 'run directory'
         # (env vars would have to be evaluated on the remote host).
         # (can be done for rose-suite-run remote, but not rsync!).
-        run_d = run_d.replace('$USER', user)
-        return "%s/%s" % (run_d, suite_name)
-
-    def get_suite_work_dir(self, suite_name, host, user):
-        """Get suite run directory on given host.
-
-        Should be absolute (may contain remote $USER - known on suite host), or
-        relative to home (where home is the default ssh landing point)
-        """
-        try:
-            out = self.popen(
-                "cylc", "get-global-config", "-i",
-                "[hosts][%s]work directory" % host)[0]
-        except RosePopenError:
-            out = self.SUITE_DIR_REL_ROOT
-        wrk_d = out.splitlines()[0]
-        # TODO - DOCUMENT ONLY '$USER' is replaced in 'run directory'
-        # (env vars would have to be evaluated on the remote host).
-        # (can be done for rose-suite-run remote, but not rsync!).
-        wrk_d = wrk_d.replace('$USER', user)
-        return "%s/%s" % (wrk_d, suite_name)
+        the_d = the_d.replace('$USER', user)
+        return "%s/%s" % (the_d, suite_name)
 
     def check_global_conf_compat(self):
         """Raise exception on incompatible Cylc global configuration."""

--- a/lib/python/rose/suite_engine_procs/cylc.py
+++ b/lib/python/rose/suite_engine_procs/cylc.py
@@ -86,6 +86,25 @@ class CylcProcessor(SuiteEngineProcessor):
         run_d = run_d.replace('$USER', user)
         return "%s/%s" % (run_d, suite_name)
 
+    def get_suite_work_dir(self, suite_name, host, user):
+        """Get suite run directory on given host.
+
+        Should be absolute (may contain remote $USER - known on suite host), or
+        relative to home (where home is the default ssh landing point)
+        """
+        try:
+            out = self.popen(
+                "cylc", "get-global-config", "-i",
+                "[hosts][%s]work directory" % host)[0]
+        except RosePopenError:
+            out = self.SUITE_DIR_REL_ROOT
+        wrk_d = out.splitlines()[0]
+        # TODO - DOCUMENT ONLY '$USER' is replaced in 'run directory'
+        # (env vars would have to be evaluated on the remote host).
+        # (can be done for rose-suite-run remote, but not rsync!).
+        wrk_d = wrk_d.replace('$USER', user)
+        return "%s/%s" % (wrk_d, suite_name)
+
     def check_global_conf_compat(self):
         """Raise exception on incompatible Cylc global configuration."""
         expected = os.path.join("~", self.SUITE_DIR_REL_ROOT)

--- a/lib/python/rose/suite_engine_procs/cylc.py
+++ b/lib/python/rose/suite_engine_procs/cylc.py
@@ -67,6 +67,25 @@ class CylcProcessor(SuiteEngineProcessor):
         self.host = None
         self.user = None
 
+    def get_suite_run_dir(self, suite_name, host, user):
+        """Get suite run directory on given host.
+
+        Should be absolute (may contain remote $USER - known on suite host), or
+        relative to home (where home is the default ssh landing point)
+        """
+        try:
+            out = self.popen(
+                "cylc", "get-global-config", "-i",
+                "[hosts][%s]run directory" % host)[0]
+        except RosePopenError:
+            out = self.SUITE_DIR_REL_ROOT
+        run_d = out.splitlines()[0]
+        # TODO - DOCUMENT ONLY '$USER' is replaced in 'run directory'
+        # (env vars would have to be evaluated on the remote host).
+        # (can be done for rose-suite-run remote, but not rsync!).
+        run_d = run_d.replace('$USER', user)
+        return "%s/%s" % (run_d, suite_name)
+
     def check_global_conf_compat(self):
         """Raise exception on incompatible Cylc global configuration."""
         expected = os.path.join("~", self.SUITE_DIR_REL_ROOT)

--- a/lib/python/rose/suite_run.py
+++ b/lib/python/rose/suite_run.py
@@ -380,10 +380,10 @@ class SuiteRunner(Runner):
             # Build remote "rose suite-run" command
             shcommand += " %s suite-run -vv -n %s" % (rose_bin, suite_name)
             shcommand += " --run-dir=%s --work-dir=%s" % (
-                self.suite_engine_proc.get_suite_run_dir(
-                    suite_name, host, user),
-                self.suite_engine_proc.get_suite_work_dir(
-                    suite_name, host, user))
+                self.suite_engine_proc.get_suite_run_work_dir(
+                    "run", suite_name, host, user),
+                self.suite_engine_proc.get_suite_run_work_dir(
+                    "work", suite_name, host, user))
             for key in ["new", "debug", "install-only"]:
                 attr = key.replace("-", "_") + "_mode"
                 if getattr(opts, attr, None) is not None:
@@ -444,8 +444,8 @@ class SuiteRunner(Runner):
                 else:
                     user = os.environ['USER']
                 target = (auth + ":" +
-                          self.suite_engine_proc.get_suite_run_dir(
-                              suite_name, host, user))
+                          self.suite_engine_proc.get_suite_run_work_dir(
+                              "run", suite_name, host, user))
                 cmd = self._get_cmd_rsync(target, **filters)
                 proc_queue.append(
                     [self.popen.run_bg(*cmd), cmd, "rsync", auth])

--- a/lib/python/rose/suite_run.py
+++ b/lib/python/rose/suite_run.py
@@ -525,7 +525,7 @@ class SuiteRunner(Runner):
                 locs_conf.set(["localhost", "root-dir"], suite_dir_root)
             suite_dir_root = env_var_process(suite_dir_root)
         if (suite_dir_root and
-                os.path.realpath(suite_dir_home) != 
+                os.path.realpath(suite_dir_home) !=
                 os.path.realpath(suite_dir_root)):
             if opts.run_dir:
                 suite_dir_real = os.path.join(suite_dir_root, suite_name)
@@ -618,10 +618,10 @@ class SuiteRunner(Runner):
             if locs_conf is not None:
                 locs_conf.set(["localhost", key], item_root)
             item_root = env_var_process(item_root)
-            if (opts.work_dir and name == "work" or 
+            if (opts.work_dir and name == "work" or
                     opts.run_dir and name == "share"):
                 suite_dir_rel = suite_name
-            else: 
+            else:
                 suite_dir_rel = self._suite_dir_rel(suite_name)
             if os.path.isabs(item_root):
                 item_path_source = os.path.join(item_root, suite_dir_rel, name)

--- a/lib/python/rose/suite_run.py
+++ b/lib/python/rose/suite_run.py
@@ -514,7 +514,6 @@ class SuiteRunner(Runner):
             suite_dir_rel = self._suite_dir_rel(suite_name)
             home = os.path.expanduser("~")
             suite_dir_home = os.path.join(home, suite_dir_rel)
-        # TODO - CONSIDER root-dir etc.
         suite_dir_root = self._run_conf("root-dir", conf_tree=conf_tree,
                                         r_opts=r_opts)
         if suite_dir_root:
@@ -522,8 +521,12 @@ class SuiteRunner(Runner):
                 locs_conf.set(["localhost", "root-dir"], suite_dir_root)
             suite_dir_root = env_var_process(suite_dir_root)
         if (suite_dir_root and
-                os.path.realpath(home) != os.path.realpath(suite_dir_root)):
-            suite_dir_real = os.path.join(suite_dir_root, suite_dir_rel)
+                os.path.realpath(suite_dir_home) != 
+                os.path.realpath(suite_dir_root)):
+            if opts.run_dir:
+                suite_dir_real = os.path.join(suite_dir_root, suite_name)
+            else:
+                suite_dir_real = os.path.join(suite_dir_root, suite_dir_rel)
             self.fs_util.makedirs(suite_dir_real)
             self.fs_util.symlink(suite_dir_real, suite_dir_home,
                                  opts.no_overwrite_mode)

--- a/lib/python/rose/suite_run.py
+++ b/lib/python/rose/suite_run.py
@@ -618,7 +618,11 @@ class SuiteRunner(Runner):
             if locs_conf is not None:
                 locs_conf.set(["localhost", key], item_root)
             item_root = env_var_process(item_root)
-            suite_dir_rel = self._suite_dir_rel(suite_name)
+            if (opts.work_dir and name == "work" or 
+                    opts.run_dir and name == "share"):
+                suite_dir_rel = suite_name
+            else: 
+                suite_dir_rel = self._suite_dir_rel(suite_name)
             if os.path.isabs(item_root):
                 item_path_source = os.path.join(item_root, suite_dir_rel, name)
             else:


### PR DESCRIPTION
Works with a non-default cylc global config "run directory" setting, e.g:
```
# global.rc
[hosts]
   [[server1]]
       run directory = /nfs/home1/$USER
```
This can be useful if, for instance, your `$HOME` on the cylc remote server is not the same as `$HOME` on the compute cluster that it fronts (but the compute home dir is still mounted on the remote).  We need the suite run directory to be set up where the jobs see it.

TODO -
- [x] test with default and non-standard run directory on a remote host
- [x] handle the similar `work directory` setting too (for share and work location)
- [x] with rose `root-dir` symlinks 
- [x] with rose `root-dir{share/work}` symlinks
- [x] test with `--new` (not working?)
- [ ] document
- [ ] testing?