### PR TITLE
rosie go: libsecret authentication caching issue

### DIFF
--- a/lib/python/rosie/browser/main.py
+++ b/lib/python/rosie/browser/main.py
@@ -19,16 +19,6 @@
 # -----------------------------------------------------------------------------
 """Implement "rosie go"."""
 
-# This try/except loop attempts to load the 'Secret' object. Running on systems
-# with GTK+ >=v3 this should work.
-try:
-    from gi import require_version, pygtkcompat
-    require_version('Gtk', '3.0')  # For GTK+ >=v3 use PyGObject; v2 use PyGTK
-    require_version('Secret', '1')
-    from gi.repository import Secret
-except ImportError:
-    pass
-
 import ast
 import os
 import pwd
@@ -41,18 +31,32 @@ from urlparse import urlparse
 import warnings
 import webbrowser
 
+# This try/except loop attempts to load the 'Secret' object. Running on systems
+# with GTK+ >=v3 this should work.
+try:
+    from gi import require_version, pygtkcompat
+    require_version('Gtk', '3.0')  # For GTK+ >=v3 use PyGObject; v2 use PyGTK
+    require_version('Secret', '1')
+    from gi.repository import Secret
+    del Secret
+    del pygtkcompat
+except ImportError:
+    pass
+
 import pygtk
 pygtk.require("2.0")
 # This try/except loop attempts to load the 'GObject' object. Running on
-# systems with GTK+ >=v3 this should work: Sytems on GTK <v3 will load the
+# systems with GTK+ >=v3 this should work: Systems on GTK <v3 will load the
 # older 'gobject' instead.
 try:
     from gi.repository import GObject
+    del GObject
 except ImportError:
-    with warnings.catch_warnings():
-        warnings.simplefilter('ignore')
-        import gobject
-import gtk
+    import gobject
+
+with warnings.catch_warnings():
+    warnings.simplefilter('ignore')
+    import gtk
 
 import rose.config_editor
 import rose.config_editor.main

--- a/lib/python/rosie/browser/main.py
+++ b/lib/python/rosie/browser/main.py
@@ -19,6 +19,16 @@
 # -----------------------------------------------------------------------------
 """Implement "rosie go"."""
 
+# This try/except loop attempts to load the 'Secret' object. Running on systems
+# with GTK+ >=v3 this should work.
+try:
+    from gi import require_version, pygtkcompat
+    require_version('Gtk', '3.0')  # For GTK+ >=v3 use PyGObject; v2 use PyGTK
+    require_version('Secret', '1')
+    from gi.repository import Secret
+except ImportError:
+    pass
+
 import ast
 import os
 import pwd
@@ -33,8 +43,16 @@ import webbrowser
 
 import pygtk
 pygtk.require("2.0")
+# This try/except loop attempts to load the 'GObject' object. Running on
+# systems with GTK+ >=v3 this should work: Sytems on GTK <v3 will load the
+# older 'gobject' instead.
+try:
+    from gi.repository import GObject
+except ImportError:
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore')
+        import gobject
 import gtk
-import gobject
 
 import rose.config_editor
 import rose.config_editor.main

--- a/lib/python/rosie/ws_client_auth.py
+++ b/lib/python/rosie/ws_client_auth.py
@@ -20,21 +20,24 @@
 """The authentication manager for the Rosie web service client."""
 
 # This try/except loop attempts to load the 'Secret' object. Running on
-# systems with GTK+ >=v3 this should work: Sytems on GTK <v3 will not load
+# systems with GTK+ >=v3 this should work: Systems on GTK <v3 will not load
 # this module.
+import warnings
 try:
     from gi import require_version, pygtkcompat
     require_version('Gtk', '3.0')  # For GTK+ >=v3 use PyGObject; v2 use PyGTK
     require_version('Secret', '1')
     from gi.repository import Secret
+    del pygtkcompat
     GI_FLAG = True
 except (ImportError, ValueError):
     GI_FLAG = False
-    pass
 try:
-    import gtk
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore')
+        import gtk
     import gnomekeyring
-except (ImportError, RuntimeError):
+except ImportError:
     pass
 
 import ast

--- a/lib/python/rosie/ws_client_auth.py
+++ b/lib/python/rosie/ws_client_auth.py
@@ -19,6 +19,23 @@
 # -----------------------------------------------------------------------------
 """The authentication manager for the Rosie web service client."""
 
+# This try/except loop attempts to load the 'Secret' object. Running on
+# systems with GTK+ >=v3 this should work: Sytems on GTK <v3 will not load
+# this module.
+try:
+    from gi import require_version, pygtkcompat
+    require_version('Gtk', '3.0')  # For GTK+ >=v3 use PyGObject; v2 use PyGTK
+    require_version('Secret', '1')
+    from gi.repository import Secret
+    GI_FLAG = True
+except (ImportError, ValueError):
+    GI_FLAG = False
+    pass
+try:
+    import gtk
+    import gnomekeyring
+except (ImportError, RuntimeError):
+    pass
 
 import ast
 from getpass import getpass
@@ -35,26 +52,9 @@ from rose.reporter import Reporter
 from rose.resource import ResourceLocator
 
 import socket
-try:
-    from gi import require_version, pygtkcompat
-    require_version('Gtk', '3.0')  # For GTK+ >=v3 use PyGObject; v2 use PyGTK
-    require_version('Secret', '1')
-    from gi.repository import Secret
-    GI_FLAG = True
-except (ImportError, ValueError):
-    GI_FLAG = False
-try:
-    if GI_FLAG:
-        pygtkcompat.enable()
-        pygtkcompat.enable_gtk(version='3.0')
-    import gtk
-    import gnomekeyring
-except (ImportError, RuntimeError):
-    pass
 
 
 class UndefinedRosiePrefixWS(Exception):
-
     """Raised if a prefix has no config."""
 
     def __str__(self):


### PR DESCRIPTION
Fix #2245 
This appears to fix the problem. I'm uncomfortable with the level of explanation I can provide for why it works. As far as I can tell a number of the later imports refuse to work if other libraries (`pygtk` in particular) have been loaded first.