### PR TITLE
Fix tests broken by cylc/cylc#2781 and cylc/cylc#2849

### DIFF
--- a/etc/tutorial/consolidation-tutorial/.validate
+++ b/etc/tutorial/consolidation-tutorial/.validate
@@ -1,1 +1,1 @@
-cylc validate "$TUT_DIR" -v -v --icp=2000
+cylc validate "$TUT_DIR" --icp=2000

--- a/etc/tutorial/rose-stem/.validate
+++ b/etc/tutorial/rose-stem/.validate
@@ -1,4 +1,4 @@
 mkdir "${CYLC_RUN_DIR}/${REG}"
 echo -e '#!Jinja2\n{% set RUN_NAMES=["command_spaceship"] %}' > "${CYLC_RUN_DIR}/${REG}/suite.rc"
 cat "$TUT_DIR/rose-stem/suite.rc" >> "${CYLC_RUN_DIR}/${REG}/suite.rc"
-cylc validate -v -v "${CYLC_RUN_DIR}/${REG}" -s "SOURCE_SPACESHIP=foo"
+cylc validate "${CYLC_RUN_DIR}/${REG}" -s "SOURCE_SPACESHIP=foo"

--- a/etc/tutorial/rose-suite-tutorial/.validate
+++ b/etc/tutorial/rose-suite-tutorial/.validate
@@ -1,3 +1,3 @@
-cylc validate "$TUT_DIR" --icp=2000 -v -v
+cylc validate "$TUT_DIR" --icp=2000
 rose metadata-check -C "$TUT_DIR/app/forecast/meta"
 rose macro -C "$TUT_DIR/app/forecast" -V

--- a/t/rose-bush/00-basic.t
+++ b/t/rose-bush/00-basic.t
@@ -118,6 +118,7 @@ FOO0="{'cycle': '20000101T0000Z', 'name': 'foo0', 'submit_num': 1}"
 FOO0_JOB='log/job/20000101T0000Z/foo0/01/job'
 FOO1="{'cycle': '20000101T0000Z', 'name': 'foo1', 'submit_num': 1}"
 FOO1_JOB='log/job/20000101T0000Z/foo1/01/job'
+LOCALHOST="$(hostname -f)"
 rose_ws_json_greps "${TEST_KEY}.out" "${TEST_KEY}.out" \
     "[('rose_version',), '$(rose version | cut -d' ' -f 2)']" \
     "[('title',), 'Rose Bush']" \
@@ -138,7 +139,7 @@ rose_ws_json_greps "${TEST_KEY}.out" "${TEST_KEY}.out" \
     "[('states', 'is_failed',), False]" \
     "[('of_n_entries',), 2]" \
     "[('entries', ${FOO0}, 'task_status',), 'succeeded']" \
-    "[('entries', ${FOO0}, 'host',), 'localhost']" \
+    "[('entries', ${FOO0}, 'host',), '${LOCALHOST}']" \
     "[('entries', ${FOO0}, 'submit_method',), 'background']" \
     "[('entries', ${FOO0}, 'logs', 'job', 'path'), '${FOO0_JOB}']" \
     "[('entries', ${FOO0}, 'logs', 'job.err', 'path'), '${FOO0_JOB}.err']" \
@@ -162,7 +163,7 @@ rose_ws_json_greps "${TEST_KEY}.out" "${TEST_KEY}.out" \
     "[('entries', ${FOO0}, 'seq_logs_indexes', 'job.trace.*.html', '32'), 'job.trace.32.html']" \
     "[('entries', ${FOO0}, 'seq_logs_indexes', 'job.trace.*.html', '256'), 'job.trace.256.html']" \
     "[('entries', ${FOO1}, 'task_status',), 'succeeded']" \
-    "[('entries', ${FOO1}, 'host',), 'localhost']" \
+    "[('entries', ${FOO1}, 'host',), '${LOCALHOST}']" \
     "[('entries', ${FOO1}, 'submit_method',), 'background']" \
     "[('entries', ${FOO1}, 'logs', 'job', 'path'), '${FOO1_JOB}']" \
     "[('entries', ${FOO1}, 'logs', 'job.err', 'path'), '${FOO1_JOB}.err']" \


### PR DESCRIPTION
Suppress debug level log entries in validate commands by not running command in verbose mode.

Modify tests to expect background `localhost` jobs to store host name entry as `hostname -f`.

See also: cylc/cylc#2781 and cylc/cylc#2849

