### PR TITLE
macro: document optional_config_name feature

### DIFF
--- a/lib/python/rose/macro.py
+++ b/lib/python/rose/macro.py
@@ -199,6 +199,24 @@ class MacroBase(object):
         ...    def report(self, config, meta_config=None):
         ...        # Perform some analysis of the config but return nothing.
         ...        pass
+
+        Keyword arguments can be used, ``rose macro`` will prompt the user to
+        provide values for these arguments when the macro is run.
+
+        >>> def validate(self, config, meta_config=None, answer=None):
+        ...     # User will be prompted to provide a value for "answer".
+        ...     return self.reports
+
+        There is a special keyword argument called ``optional_config_name``
+        which is set to the name of the optional configuration a macro is
+        running under, or ``None`` if no optional configuration is being used.
+
+        >>> def report(self, config, meta_config=None,
+        ...            optional_config_name=None):
+        ...     if optional_config_name:
+        ...         print('Macro is being run using the "%s" '
+        ...               'optional configuration' % optional_config_name)
+
     """
 
     def __init__(self):

--- a/lib/python/rose/macro.py
+++ b/lib/python/rose/macro.py
@@ -209,7 +209,8 @@ class MacroBase(object):
 
         There is a special keyword argument called ``optional_config_name``
         which is set to the name of the optional configuration a macro is
-        running under, or ``None`` if no optional configuration is being used.
+        running on, or ``None`` if only the default configuration is being
+        used.
 
         >>> def report(self, config, meta_config=None,
         ...            optional_config_name=None):

--- a/sphinx/api/rose-macro.rst
+++ b/sphinx/api/rose-macro.rst
@@ -208,8 +208,8 @@ On running your macro the user will be prompted to supply values for these
 arguments or accept the default values.
 
 There is a special keyword argument called ``optional_config_name`` which is
-set to the name of the optional configuration the macro is being run by, or
-``None`` if no optional configurations are being used.
+set to the name of the optional configuration the macro is being run on, or
+``None`` if only the default configuration is being used.
 
 .. note::
    Python keyword arguments require default values (``=None`` in this

--- a/sphinx/api/rose-macro.rst
+++ b/sphinx/api/rose-macro.rst
@@ -75,6 +75,9 @@ configuration that provides information about the configuration items.
 
    See also :ref:`config-api`.
 
+Validator / Reporter Macros
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 A validator macro should look like:
 
 .. code-block:: python
@@ -130,6 +133,9 @@ to :py:meth:`self.add_report`, ``is_warning``, like so:
                    "Could be 'sed'",
                    is_warning=True)
 
+Transformer Macros
+^^^^^^^^^^^^^^^^^^
+
 A transformer macro should look like:
 
 .. code-block:: python
@@ -184,6 +190,9 @@ as validator and transform macros but does not require a return value.
        with open('report/file', 'r') as report_file:
            report_file.write(str(config.get(["namelist:snowflakes"])))
 
+Optional Arguments
+^^^^^^^^^^^^^^^^^^
+
 Macros also support the use of keyword arguments, giving you the ability to
 have the user specify some input or override to your macro. For example a
 transformer macro could be written as follows to allow the user to input
@@ -195,14 +204,16 @@ transformer macro could be written as follows to allow the user to input
        """Some transformer macro"""
        return
 
-.. note::
-   The extra arguments require default values (``=None`` in this
-   example) and that you should add error handling for the input
-   accordingly.
-
 On running your macro the user will be prompted to supply values for these
 arguments or accept the default values.
 
+There is a special keyword argument called ``optional_config_name`` which is
+set to the name of the optional configuration the macro is being run by, or
+``None`` if no optional configurations are being used.
+
+.. note::
+   Python keyword arguments require default values (``=None`` in this
+   example). You should add error handling for the input accordingly.
 
 .. _api-rose-macro-base:
 


### PR DESCRIPTION
Add documentation for a feature quietly slid in way back (#1915).

@r-sharp pinging you in on this one, do these docs make sense?
@matthewrmshin don't allow this to be a release blocker, bump to soon if we can't get it reviewed.