### PR TITLE
Fix docs (sphinx link)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@
 language: python
 python:
     - 2.7
+dist: xenial
 
 before_install:
     - wget 'https://github.com/cylc/cylc/archive/master.tar.gz' -O '/tmp/cylc-master.tar.gz'

--- a/sphinx/developing/autodoc.rst
+++ b/sphinx/developing/autodoc.rst
@@ -122,7 +122,7 @@ from being run):
 
 Doctests are performed in the doc/sphinx directory and any files created will
 have to be `tidied up
-<http://www.sphinx-doc.org/en/1.5.1/ext/doctest.html#directive-testcleanup>`_.
+<https://www.sphinx-doc.org/en/master/usage/extensions/doctest.html#directive-testcleanup>`_.
 
 See `doctest <https://docs.python.org/3.3/library/doctest.html>`_ for more
 details.


### PR DESCRIPTION
Looks like since the last successful build on `master`, Sphinx documentation has been updated.

One of its link, used in Rose's documentation, has changed. Causing the build to fail during the docs generation.

Also bumps up the distro to `xenial`, as Travis appears to be having issues with trusty to download artefacts from APT repositories - build#37 https://travis-ci.org/kinow/rose/jobs/461572030

After that, it is possible to see that APT packages are successfully installed, but on build#38 it failed due to the broken link (also failed in my PR for coverage #2230) https://travis-ci.org/kinow/rose/jobs/461573882

Once the `xenial` distro was in place, and the link was fixed to the latest I could find in their new website (hopefully got the right one), it passed successfully on my build#39 - https://travis-ci.org/kinow/rose/builds/461575854

The PR for coverage also bumps up the distro to `xenial`. But happy to remove the commit from this one, or from the coverage PR. Whichever gets merged last.

Hope that helps,
Bruno