### PR TITLE
Remove unreachable code in macro.py

### DIFF
--- a/lib/python/rose/macro.py
+++ b/lib/python/rose/macro.py
@@ -402,7 +402,6 @@ class MacroBaseRoseEdit(MacroBase):
             return names
         else:
             return [v.name for v in config_data["variables"].get(section, [])]
-        return []
 
     def _get_config_has_id(self, config_data, id_):
         """Return whether the config_data contains the id_."""


### PR DESCRIPTION
After the `if` and `else`, I think there's no way for the extra `return` to be used.