### PR TITLE
Name LocalCopyStatusError as exc, so that str(exc) works below

### DIFF
--- a/lib/python/rosie/browser/suite.py
+++ b/lib/python/rosie/browser/suite.py
@@ -100,7 +100,7 @@ class SuiteDirector():
                 rose.gtk.dialog.run_dialog(rose.gtk.dialog.DIALOG_TYPE_ERROR,
                                            rosie.browser.ERROR_PERMISSIONS +
                                            "\n\n" + str(exc))
-            except LocalCopyStatusError:
+            except LocalCopyStatusError as exc:
                 rose.gtk.dialog.run_dialog(
                     rose.gtk.dialog.DIALOG_TYPE_ERROR,
                     rosie.browser.ERROR_MODIFIED_LOCAL_COPY_DELETE +


### PR DESCRIPTION
There's a call to `str(exc)` right below the `try/catch`. I think it was copy/paste'd, as `str(exc)` would fail in runtime?

Found doing a quick analysis of the project after working on the pull request for coverage, and before preparing things for Melbourne; so apologies for not doing thorough testing.