### PR TITLE
Fix line length issue

### DIFF
--- a/lib/python/rose/apps/ana_builtin/grepper.py
+++ b/lib/python/rose/apps/ana_builtin/grepper.py
@@ -465,8 +465,8 @@ class FilePattern(SingleCommandPattern):
 
 
 class FileCommandPattern(FilePattern):
-    """Check for occurrences of a particular expression or value in the standard
-    output from a command applied to two or more files.
+    """Check for occurrences of a particular expression or value in the
+    standard output from a command applied to two or more files.
 
     Options:
         files (optional):


### PR DESCRIPTION
Looks like a fixed typo contains more characters than the typo - #2269. (Interestingly, my version of pycodestyle is not picking this up.)