### PR TITLE
remove docs latex dependency

### DIFF
--- a/bin/rose-check-software
+++ b/bin/rose-check-software
@@ -315,8 +315,6 @@ def docs(check=check):
                outfile=2),
         check('graphviz-dot <dot>', command_template='-V',
                version_template='graphviz version ([^\s]+)', outfile=2),
-        check('tex', version_template=r'TeX ([^\s]+)'),
-        check('pdflatex', version_template=r'pdfTeX .*-.*-([^\s]+)'),
         # TODO remove Sphinx version dependency
         # https://github.com/nyergler/hieroglyph/issues/148
         check('py:sphinx', (1, 5, 3), (1, 8)),
@@ -325,8 +323,15 @@ def docs(check=check):
         check('py:hieroglyph')
     ])
 
+    check_all('Documentation Builder - Recommended Extras', [
+        check('rsvg', version_template=r'rsvg version (.*)'),
+        check('py:sphinxcontrib.svg2pdfconverter <sphinxcontrib.rsvgconverter>')
+    ])
+
     check_all('Documentation Builder - PDF Dependencies', [
-        check('latexmk', version_template=r'Version (.*)')
+        check('tex', version_template=r'TeX ([^\s]+)'),
+        check('latexmk', version_template=r'Version (.*)'),
+        check('pdflatex', version_template=r'pdfTeX .*-.*-([^\s]+)')
     ])
 
     check_all('Documentation Builder - Linkcheck Dependencies', [

--- a/etc/rose-docs-env.yaml
+++ b/etc/rose-docs-env.yaml
@@ -10,3 +10,4 @@ dependencies:
   - sphinxcontrib-httpdomain
   - pip:
     - hieroglyph
+    - sphinxcontrib-svg2pdfconverter

--- a/lib/python/rose/popen.py
+++ b/lib/python/rose/popen.py
@@ -249,7 +249,8 @@ class RosePopener(object):
         if stderr:
             self.handle_event(stderr, level=stderr_level)
 
-    def which(self, name):
+    @staticmethod
+    def which(name):
         """Search an executable file name in PATH, and return its full path.
 
         If name is an absolute path and is an executable file, return name.

--- a/sphinx/conf.py
+++ b/sphinx/conf.py
@@ -17,10 +17,10 @@
 # You should have received a copy of the GNU General Public License
 # along with Rose. If not, see <http://www.gnu.org/licenses/>.
 # -----------------------------------------------------------------------------
-import subprocess
 import sys
 import os
 
+from rose.popen import RosePopener
 from rose.resource import ResourceLocator
 
 # rose-documentation build configuration file, initial version created by
@@ -58,14 +58,14 @@ for svg_converter, extension in [
         ('rsvg', 'sphinxcontrib.rsvgconverter'),
         ('inkscape', 'sphinxcontrib.inkscapeconverter')]:
     try:
-        subprocess.check_call(['which', svg_converter], stdout=subprocess.PIPE,
-                              stderr=subprocess.PIPE)
+        assert RosePopener.which(svg_converter)
         __import__(extension)
-        extensions.append(extension)
-        break
-    except (subprocess.CalledProcessError, ImportError):
+    except (AssertionError, ImportError):
         # converter or extension not available
         pass
+    else:
+        extensions.append(extension)
+        break
 else:
     # no extensions or converters available, fall-back to default
     # vector graphics will be converted to bitmaps in all documents

--- a/sphinx/conf.py
+++ b/sphinx/conf.py
@@ -17,6 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with Rose. If not, see <http://www.gnu.org/licenses/>.
 # -----------------------------------------------------------------------------
+import subprocess
 import sys
 import os
 
@@ -36,8 +37,6 @@ extensions = [
     'sphinx.ext.autosummary',
     'sphinx.ext.doctest',
     'sphinx.ext.graphviz',
-    'sphinx.ext.imgconverter',
-    'sphinx.ext.mathjax',
     'sphinx.ext.napoleon',
     'sphinx.ext.viewcode',
     # sphinx user community extensions
@@ -53,6 +52,24 @@ extensions = [
     'script_include',
     'sub_lang'
 ]
+
+# Select best available SVG image converter.
+for svg_converter, extension in [
+        ('rsvg', 'sphinxcontrib.rsvgconverter'),
+        ('inkscape', 'sphinxcontrib.inkscapeconverter')]:
+    try:
+        subprocess.check_call(['which', svg_converter], stdout=subprocess.PIPE,
+                              stderr=subprocess.PIPE)
+        __import__(extension)
+        extensions.append(extension)
+        break
+    except (subprocess.CalledProcessError, ImportError):
+        # converter or extension not available
+        pass
+else:
+    # no extensions or converters available, fall-back to default
+    # vector graphics will be converted to bitmaps in all documents
+    extensions.append('sphinx.ext.imgconverter')
 
 # Slide (hieroglyph) settings.
 slide_theme = 'single-level'

--- a/sphinx/tutorial/cylc/img/iso8601-dates.svg
+++ b/sphinx/tutorial/cylc/img/iso8601-dates.svg
@@ -1,0 +1,265 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="1209.17"
+   height="301.79999"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.47 r22583"
+   sodipodi:docname="iso8601-dates.svg">
+  <defs
+     id="defs4">
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 526.18109 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="744.09448 : 526.18109 : 1"
+       inkscape:persp3d-origin="372.04724 : 350.78739 : 1"
+       id="perspective10" />
+    <inkscape:perspective
+       id="perspective3630"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="0.49497475"
+     inkscape:cx="719.50093"
+     inkscape:cy="279.57735"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     inkscape:window-width="1241"
+     inkscape:window-height="1105"
+     inkscape:window-x="665"
+     inkscape:window-y="0"
+     inkscape:window-maximized="0" />
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-125.11608,-81.191059)">
+    <g
+       id="g3741"
+       transform="matrix(2.653345,0,0,2.653345,-178.28661,-174.33873)">
+      <text
+         id="text2816"
+         y="166.45996"
+         x="113.42857"
+         style="font-size:40px;font-style:normal;font-weight:normal;fill:#505dce;fill-opacity:1;stroke:none;font-family:Times New Roman;-inkscape-font-specification:Times New Roman"
+         xml:space="preserve"><tspan
+           y="166.45996"
+           x="113.42857"
+           id="tspan2818"
+           sodipodi:role="line">1985-04-12 </tspan></text>
+      <text
+         id="text2820"
+         y="166.45996"
+         x="343.29651"
+         style="font-size:40px;font-style:normal;font-weight:normal;fill:#ce5055;fill-opacity:1;stroke:none;font-family:Times New Roman;-inkscape-font-specification:Times New Roman"
+         xml:space="preserve"><tspan
+           y="166.45996"
+           x="343.29651"
+           id="tspan2822"
+           sodipodi:role="line">23:20:30Z</tspan></text>
+      <text
+         id="text2824"
+         y="167.00684"
+         x="309.71429"
+         style="font-size:40px;font-style:normal;font-weight:normal;fill:#414141;fill-opacity:1;stroke:none;font-family:Times New Roman;-inkscape-font-specification:Times New Roman"
+         xml:space="preserve"><tspan
+           y="167.00684"
+           x="309.71429"
+           id="tspan2826"
+           sodipodi:role="line">T</tspan></text>
+      <text
+         id="text3600"
+         y="111.29256"
+         x="136.27867"
+         style="font-size:40px;font-style:normal;font-weight:normal;opacity:0.7;fill:#000000;fill-opacity:1;stroke:none;font-family:Bitstream Vera Sans"
+         xml:space="preserve"><tspan
+           style="font-size:18px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;fill:#505dce;fill-opacity:1;font-family:Arial;-inkscape-font-specification:Arial"
+           y="111.29256"
+           x="136.27867"
+           id="tspan3602"
+           sodipodi:role="line">Date Components</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-size:40px;font-style:normal;font-weight:normal;opacity:0.7;fill:#ce5055;fill-opacity:1;stroke:none;font-family:Bitstream Vera Sans"
+         x="353.29016"
+         y="111.29256"
+         id="use3604"><tspan
+           sodipodi:role="line"
+           id="tspan3608"
+           x="353.29016"
+           y="111.29256"
+           style="font-size:18px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;fill:#ce5055;fill-opacity:1;font-family:Arial;-inkscape-font-specification:Arial">Time Components</tspan></text>
+      <path
+         sodipodi:nodetypes="csscssc"
+         id="path3616"
+         d="m 120.26721,132.68737 c 0,0 1.35096,-5.77167 7.67188,-5.64202 17.35249,0.3559 50.98641,0.0706 72.20593,0.0706 4.1646,0 9.02574,-7.57143 9.02574,-7.57143 0,0 5.25208,7.57143 9.02574,7.57143 23.34124,0 56.37024,0.3036 72.20593,-0.14995 4.4142,-0.12643 7.67188,5.72138 7.67188,5.72138"
+         style="opacity:0.7;fill:none;stroke:#505dce;stroke-width:0.67838895;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         style="opacity:0.7;fill:none;stroke:#ce5055;stroke-width:0.67838895;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 347.59995,132.68737 c 0,0 1.19747,-5.77167 6.80018,-5.64202 15.38084,0.3559 45.19316,0.0706 64.00165,0.0706 3.6914,0 8.0002,-7.57143 8.0002,-7.57143 0,0 4.65532,7.57143 8.00021,7.57143 20.68912,0 49.96526,0.3036 64.00164,-0.14995 3.91265,-0.12643 6.80017,5.72138 6.80017,5.72138"
+         id="use3618"
+         sodipodi:nodetypes="csscssc" />
+      <path
+         sodipodi:nodetypes="csscssc"
+         id="path3616-4"
+         d="m 119.01607,174.55195 c 0,0 0.54892,5.77167 3.11722,5.64202 7.05062,-0.3559 20.71668,-0.0706 29.33854,-0.0706 1.69215,0 3.66732,7.57143 3.66732,7.57143 0,0 2.13401,-7.57143 3.66732,-7.57143 9.48395,0 22.90422,-0.3036 29.33854,0.14995 1.79357,0.12643 3.11722,-5.72138 3.11722,-5.72138"
+         style="opacity:0.7;fill:none;stroke:#505dce;stroke-width:0.67838895;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         style="opacity:0.7;fill:none;stroke:#505dce;stroke-width:0.67838895;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 207.40442,174.55195 c 0,0 0.29564,5.77167 1.67891,5.64202 3.7974,-0.3559 11.15781,-0.0706 15.80147,-0.0706 0.91137,0 1.97518,7.57143 1.97518,7.57143 0,0 1.14936,-7.57143 1.97519,-7.57143 5.10797,0 12.336,-0.3036 15.80147,0.14995 0.966,0.12643 1.67891,-5.72138 1.67891,-5.72138"
+         id="use3644"
+         sodipodi:nodetypes="csscssc" />
+      <path
+         sodipodi:nodetypes="csscssc"
+         id="use3648"
+         d="m 263.97296,174.55195 c 0,0 0.29564,5.77167 1.67891,5.64202 3.7974,-0.3559 11.15781,-0.0706 15.80147,-0.0706 0.91137,0 1.97518,7.57143 1.97518,7.57143 0,0 1.14936,-7.57143 1.97519,-7.57143 5.10797,0 12.336,-0.3036 15.80147,0.14995 0.966,0.12643 1.67891,-5.72138 1.67891,-5.72138"
+         style="opacity:0.7;fill:none;stroke:#505dce;stroke-width:0.67838895;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         style="opacity:0.7;fill:none;stroke:#ce5055;stroke-width:0.67838895;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 344.76486,174.55195 c 0,0 0.26878,5.77167 1.52636,5.64202 3.45236,-0.3559 10.14399,-0.0706 14.36572,-0.0706 0.82856,0 1.79571,7.57143 1.79571,7.57143 0,0 1.04493,-7.57143 1.79573,-7.57143 4.64385,0 11.21512,-0.3036 14.36572,0.14995 0.87822,0.12643 1.52636,-5.72138 1.52636,-5.72138"
+         id="use3652"
+         sodipodi:nodetypes="csscssc" />
+      <path
+         sodipodi:nodetypes="csscssc"
+         id="use3656"
+         d="m 396.30294,174.55195 c 0,0 0.26878,5.77167 1.52636,5.64202 3.45236,-0.3559 10.14399,-0.0706 14.36572,-0.0706 0.82856,0 1.79571,7.57143 1.79571,7.57143 0,0 1.04493,-7.57143 1.79573,-7.57143 4.64385,0 11.21512,-0.3036 14.36572,0.14995 0.87822,0.12643 1.52636,-5.72138 1.52636,-5.72138"
+         style="opacity:0.7;fill:none;stroke:#ce5055;stroke-width:0.67838895;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         style="opacity:0.7;fill:none;stroke:#ce5055;stroke-width:0.67838895;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 446.79026,174.55195 c 0,0 0.26878,5.77167 1.52636,5.64202 3.45236,-0.3559 10.14399,-0.0706 14.36572,-0.0706 0.82856,0 1.79571,7.57143 1.79571,7.57143 0,0 1.04493,-7.57143 1.79573,-7.57143 4.64385,0 11.21512,-0.3036 14.36572,0.14995 0.87822,0.12643 1.52636,-5.72138 1.52636,-5.72138"
+         id="use3660"
+         sodipodi:nodetypes="csscssc" />
+      <path
+         sodipodi:nodetypes="csscssc"
+         id="use3664"
+         d="m 490.69129,174.55195 c 0,0 0.15338,5.77167 0.87103,5.64202 1.97012,-0.3559 5.78876,-0.0706 8.19794,-0.0706 0.47282,0 1.02473,7.57143 1.02473,7.57143 0,0 0.5963,-7.57143 1.02475,-7.57143 2.65006,0 6.40001,-0.3036 8.19794,0.14995 0.50116,0.12643 0.87103,-5.72138 0.87103,-5.72138"
+         style="opacity:0.7;fill:none;stroke:#ce5055;stroke-width:0.67838901;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         sodipodi:nodetypes="csscssc"
+         id="use3668"
+         d="m 308.70909,132.68737 c 0,0 0.20355,-5.77167 1.15589,-5.64202 2.61441,0.3559 7.68186,0.0706 10.8789,0.0706 0.62746,0 1.35986,-7.57143 1.35986,-7.57143 0,0 0.79131,7.57143 1.35987,7.57143 3.5167,0 8.49302,0.3036 10.8789,-0.14995 0.66507,-0.12643 1.15588,5.72138 1.15588,5.72138"
+         style="opacity:0.7;fill:none;stroke:#414141;stroke-width:0.67838895;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <text
+         id="use3672"
+         y="111.29256"
+         x="295.58963"
+         style="font-size:12px;font-style:normal;font-weight:normal;opacity:0.7;fill:#414141;fill-opacity:1;stroke:none;font-family:Bitstream Vera Sans"
+         xml:space="preserve"><tspan
+           style="font-size:12px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;fill:#414141;fill-opacity:1;font-family:Arial;-inkscape-font-specification:Arial"
+           y="111.29256"
+           x="295.58963"
+           id="tspan3676"
+           sodipodi:role="line">Separator</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-size:15px;font-style:normal;font-weight:normal;opacity:0.7;fill:#505dce;fill-opacity:1;stroke:none;font-family:Bitstream Vera Sans"
+         x="139.73248"
+         y="205.00684"
+         id="use3678"><tspan
+           sodipodi:role="line"
+           id="tspan3682"
+           x="139.73248"
+           y="205.00684"
+           style="font-size:15px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;fill:#505dce;fill-opacity:1;font-family:Arial;-inkscape-font-specification:Arial">Year</tspan></text>
+      <text
+         id="use3684"
+         y="205.00684"
+         x="205.73248"
+         style="font-size:15px;font-style:normal;font-weight:normal;opacity:0.7;fill:#505dce;fill-opacity:1;stroke:none;font-family:Bitstream Vera Sans"
+         xml:space="preserve"><tspan
+           style="font-size:15px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;fill:#505dce;fill-opacity:1;font-family:Arial;-inkscape-font-specification:Arial"
+           y="205.00684"
+           x="205.73248"
+           id="tspan3688"
+           sodipodi:role="line">Month</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-size:15px;font-style:normal;font-weight:normal;opacity:0.7;fill:#505dce;fill-opacity:1;stroke:none;font-family:Bitstream Vera Sans"
+         x="269.73248"
+         y="205.00684"
+         id="use3690"><tspan
+           sodipodi:role="line"
+           id="tspan3694"
+           x="269.73248"
+           y="205.00684"
+           style="font-size:15px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;fill:#505dce;fill-opacity:1;font-family:Arial;-inkscape-font-specification:Arial">Day</tspan></text>
+      <text
+         id="use3696"
+         y="205.00684"
+         x="345.73248"
+         style="font-size:15px;font-style:normal;font-weight:normal;opacity:0.7;fill:#ce5055;fill-opacity:1;stroke:none;font-family:Bitstream Vera Sans"
+         xml:space="preserve"><tspan
+           style="font-size:15px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;fill:#ce5055;fill-opacity:1;font-family:Arial;-inkscape-font-specification:Arial"
+           y="205.00684"
+           x="345.73248"
+           id="tspan3700"
+           sodipodi:role="line">Hour</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-size:15px;font-style:normal;font-weight:normal;opacity:0.7;fill:#ce5055;fill-opacity:1;stroke:none;font-family:Bitstream Vera Sans"
+         x="391.73248"
+         y="205.00684"
+         id="use3702"><tspan
+           sodipodi:role="line"
+           id="tspan3706"
+           x="391.73248"
+           y="205.00684"
+           style="font-size:15px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;fill:#ce5055;fill-opacity:1;font-family:Arial;-inkscape-font-specification:Arial">Minute</tspan></text>
+      <text
+         id="use3708"
+         y="205.00684"
+         x="439.73248"
+         style="font-size:15px;font-style:normal;font-weight:normal;opacity:0.7;fill:#ce5055;fill-opacity:1;stroke:none;font-family:Bitstream Vera Sans"
+         xml:space="preserve"><tspan
+           style="font-size:15px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;fill:#ce5055;fill-opacity:1;font-family:Arial;-inkscape-font-specification:Arial"
+           y="205.00684"
+           x="439.73248"
+           id="tspan3712"
+           sodipodi:role="line">Second</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-size:15px;font-style:normal;font-weight:normal;opacity:0.7;fill:#ce5055;fill-opacity:1;stroke:none;font-family:Bitstream Vera Sans"
+         x="495.73248"
+         y="205.00684"
+         id="use3714"><tspan
+           sodipodi:role="line"
+           id="tspan3718"
+           x="495.73248"
+           y="205.00684"
+           style="font-size:15px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;fill:#ce5055;fill-opacity:1;font-family:Arial;-inkscape-font-specification:Arial">Time Zone</tspan></text>
+    </g>
+  </g>
+</svg>

--- a/sphinx/tutorial/cylc/scheduling/datetime-cycling.rst
+++ b/sphinx/tutorial/cylc/scheduling/datetime-cycling.rst
@@ -58,24 +58,9 @@ Date-Times
 
 .. Diagram of an iso8601 datetime's components.
 
-.. math::
-
-   \color{blue}{\overbrace{
-   \underbrace{\huge 1985}_{_{\text{Year}}}
-   {\huge\text{-}}
-   \underbrace{\huge 04}_{_{\text{Month}}}
-   {\huge\text{-}}
-   \underbrace{\huge 12}_{_{\text{Day}}}
-   }^{\text{Date Components}}}
-   \overbrace{\huge \text{T}}^{\text{Separator}}
-   \color{green}{\overbrace{
-   \underbrace{\huge 23}_{_{\text{Hour}}}
-   {\huge:}
-   \underbrace{\huge 20}_{_{\text{Minute}}}
-   {\huge:}
-   \underbrace{\huge 30}_{_{\text{Second}}}
-   \underbrace{\huge \text{Z}}_{_{\text{Time Zone}}}
-   }^{\text{Time Components}}}
+.. image:: ../img/iso8601-dates.svg
+   :width: 75%
+   :align: center
 
 .. nextslide::
 


### PR DESCRIPTION
When I started out writing the Cylc tutorial I though LaTeX diagrams might be useful, however, it turns out that `graphviz` and `svg` cover most use cases better and there is only one LaTeX diagram in the documentation.

This PR converts the one LaTeX diagram to an SVG (editable via Inkscape) removing the LaTeX dependency (except for PDF builds) and adds superior SVG graphic support where appropriate tools / extensions are available.