### PR TITLE
pygments syntax: improve cylc lexer

### DIFF
--- a/sphinx/ext/cylc_lang.py
+++ b/sphinx/ext/cylc_lang.py
@@ -175,16 +175,26 @@ class CylcLexer(RegexLexer):
         ],
 
         # Task inter-cycle offset for graphing:  foo[-P1DT1M]
+        # Legal formats: POINT, POINT[+-]OFFSET, OFFSET
         'intercycle-offset': [
-            include('integer-duration'),
+            include('cycle-point'),
+            include('integer-duration'),  # matches a subset of iso8601
             include('iso8601-duration'),
             (r'[\^\$]', INTERCYCLE_OFFSET_TOKEN),
             (r'\]', Text, '#pop')
         ],
 
+        # generic Cylc cycle point:  2000
+        'cycle-point': [
+            # validating the cycle point as a regex [effectively] requires
+            # knowledge of the cycling mode so is not *really* possible,
+            # also validating iso8601 datetimes is horrible.
+            (r'[\+\-]?[\d\:\-T]+(Z)?\b', INTERCYCLE_OFFSET_TOKEN)
+        ],
+
         # An integer duration:  +P1
         'integer-duration': [
-            (r'[+-]P\d+(?![\w-])', INTERCYCLE_OFFSET_TOKEN)
+            (r'([+-])?P\d+(?![\w-])', INTERCYCLE_OFFSET_TOKEN)
         ],
 
         # An ISO8601 duration:  +P1DT1H

--- a/sphinx/ext/cylc_lang.py
+++ b/sphinx/ext/cylc_lang.py
@@ -103,7 +103,7 @@ class CylcLexer(RegexLexer):
             (r'[\]]+', HEADING_TOKEN, '#pop'),
             include('preproc'),
             include('parameterisation'),
-            (r'.', HEADING_TOKEN),
+            (r'(\\\n|.)', HEADING_TOKEN),  # Allow line continuation chars.
         ],
 
         # Cylc comments.

--- a/sphinx/ext/cylc_lang.py
+++ b/sphinx/ext/cylc_lang.py
@@ -87,7 +87,10 @@ class CylcLexer(RegexLexer):
             (r'(.*)(\s+)?(=)',
                 bygroups(SETTING_TOKEN,
                          Text,
-                         Operator), 'setting')
+                         Operator), 'setting'),
+
+            # Include files
+            (r'(%include)( )(.*)', bygroups(Operator, Text, String))
         ],
 
         'heading': [

--- a/sphinx/ext/cylc_lang.py
+++ b/sphinx/ext/cylc_lang.py
@@ -22,7 +22,7 @@ strings."""
 
 from pygments.lexer import RegexLexer, bygroups, include
 from pygments.token import (Name, Comment, Text, Operator, String,
-                            Punctuation, Error, Keyword)
+                            Punctuation, Error, Keyword, Other)
 
 
 class CylcLexer(RegexLexer):
@@ -139,9 +139,10 @@ class CylcLexer(RegexLexer):
             include('parameterisation'),
             (r'@\w+', GRAPH_XTRIGGER_TOKEN),
             (r'\w+', GRAPH_TASK_TOKEN),
+            (r'\!\w+', Other),
             (r'\s', Text),
             (r'=>', Operator),
-            (r'[\&\|\!]', Operator),
+            (r'[\&\|]', Operator),
             (r'[\(\)]', Punctuation),
             (r'\[', Text, 'intercycle-offset'),
             (r'.', Comment)

--- a/sphinx/ext/cylc_lang.py
+++ b/sphinx/ext/cylc_lang.py
@@ -33,6 +33,7 @@ class CylcLexer(RegexLexer):
     HEADING_TOKEN = Name.Tag
     SETTING_TOKEN = Name.Variable
     GRAPH_TASK_TOKEN = Keyword.Declaration
+    GRAPH_XTRIGGER_TOKEN = Keyword.Type
     PARAMETERISED_TASK_TOKEN = Name.Builtin
     EXTERNAL_SUITE_TOKEN = Name.Builtin.Pseudo
     INTERCYCLE_OFFSET_TOKEN = Name.Builtin
@@ -76,17 +77,15 @@ class CylcLexer(RegexLexer):
                          Operator), 'inline-graph'),
 
             # Multi-line settings:  key = """ ...
-            (r'(.*)(\s+)?(=)([\s+])?(\"\"\")',
+            (r'([^=\n]+)(=)([\s+])?(\"\"\")',
                 bygroups(SETTING_TOKEN,
-                         Text,
                          Operator,
                          Text,
                          String.Double), 'multiline-setting'),
 
             # Inline settings:  key = ...
-            (r'(.*)(\s+)?(=)',
+            (r'([^=\n]+)(=)',
                 bygroups(SETTING_TOKEN,
-                         Text,
                          Operator), 'setting'),
 
             # Include files
@@ -132,6 +131,7 @@ class CylcLexer(RegexLexer):
             include('comment'),
             include('inter-suite-trigger'),
             include('parameterisation'),
+            (r'@\w+', GRAPH_XTRIGGER_TOKEN),
             (r'\w+', GRAPH_TASK_TOKEN),
             (r'\s', Text),
             (r'=>', Operator),

--- a/sphinx/ext/cylc_lang.py
+++ b/sphinx/ext/cylc_lang.py
@@ -34,6 +34,7 @@ class CylcLexer(RegexLexer):
     SETTING_TOKEN = Name.Variable
     GRAPH_TASK_TOKEN = Keyword.Declaration
     PARAMETERISED_TASK_TOKEN = Name.Builtin
+    EXTERNAL_SUITE_TOKEN = Name.Builtin.Pseudo
     INTERCYCLE_OFFSET_TOKEN = Name.Builtin
 
     # Pygments values.
@@ -126,6 +127,7 @@ class CylcLexer(RegexLexer):
         'graph': [
             include('jinja2-openers'),
             include('comment'),
+            include('inter-suite-trigger'),
             include('parameterisation'),
             (r'\w+', GRAPH_TASK_TOKEN),
             (r'\s', Text),
@@ -134,6 +136,16 @@ class CylcLexer(RegexLexer):
             (r'[\(\)]', Punctuation),
             (r'\[', Text, 'intercycle-offset'),
             (r'.', Comment)
+        ],
+
+        'inter-suite-trigger': [
+            (r'(\<)'
+             r'([^\>]+)'  # foreign suite
+             r'(::)'
+             r'([^\>]+)'  # foreign task
+             r'(\>)',
+             bygroups(Text, EXTERNAL_SUITE_TOKEN, Text,
+                      PARAMETERISED_TASK_TOKEN, Text)),
         ],
 
         # Parameterised syntax:  <foo=1>


### PR DESCRIPTION
Support additional features of the Cylc suite.rc language to permit use in the Cylc documentation (cylc/cylc#2910).

Adds support for the following (see table in cylc/cylc#2752):
* Inter-Suite
* Include files
* xtriggers
* empy

Fixes:
* Line continuation characters in headings
   ```
    [foo, \
    bar]
    ```
* Cycle points in inter-cycle offsets