### PR TITLE
Fix overzealous informational message about KGO in grepper class

### DIFF
--- a/lib/python/rose/apps/ana_builtin/grepper.py
+++ b/lib/python/rose/apps/ana_builtin/grepper.py
@@ -157,19 +157,18 @@ class SingleCommandStatus(AnalysisTask):
         # Parse the kgo index
         if kgo is not None:
             if kgo.strip() == "":
+                self.reporter("No KGO files are present")
                 kgo = None
             elif kgo.isdigit():
                 kgo = int(kgo)
                 if int(kgo) > len(self.files):
                     msg = "KGO index cannot be greater than number of files"
                     raise ValueError(msg)
+                self.reporter("KGO is file {0}".format(kgo + 1))
             else:
-                msg = "KGO index not recognised; must be a digit or blank"
+                msg = ("KGO index not recognised; should be either a digit or "
+                       "left blank")
                 raise ValueError(msg)
-        if kgo is not None:
-            self.reporter("KGO is file {0}".format(kgo + 1))
-        else:
-            self.reporter("No KGO files are present")
         self.kgo = kgo
 
     def process_opt_command(self):

--- a/lib/python/rose/apps/ana_builtin/grepper.py
+++ b/lib/python/rose/apps/ana_builtin/grepper.py
@@ -157,7 +157,6 @@ class SingleCommandStatus(AnalysisTask):
         # Parse the kgo index
         if kgo is not None:
             if kgo.strip() == "":
-                self.reporter("No KGO files are present")
                 kgo = None
             elif kgo.isdigit():
                 kgo = int(kgo)


### PR DESCRIPTION
There's a bit of logic in the way the `grepper` class deals with the specification of the KGO files which leads to it spamming a message in an unhelpful way...

Currently the behaviour if the `kgo_file` input is completely omitted and the behaviour if it is provided but left completely empty are exactly the same.  As a result a `rose_ana` task which omits the setting because it doens't care about KGO at all (it may simply not use the concept of KGO) will print the message "No KGO files are present" for every single comparison made.  Clearly this is undesirable...

The solution is to reshuffle the logic so that the message is only printed in the case of the input being explicitly set to blank (with complete omission printing no messags at all)