### PR TITLE
rosie: fix traceback from importing gi.repository.Secret

### DIFF
--- a/lib/python/rosie/browser/main.py
+++ b/lib/python/rosie/browser/main.py
@@ -40,7 +40,7 @@ try:
     from gi.repository import Secret
     del Secret
     del pygtkcompat
-except ImportError:
+except (ImportError, ValueError, AttributeError):
     pass
 
 import pygtk


### PR DESCRIPTION
Fix user reported traceback where attempting to import `gi.repository.Secret` results in `ValueError: Namespace Secret not available`.

From a [quick web search](
https://www.programcreek.com/python/example/72048/gi.require_version) it would appear that `AttributeError` can crop up for older versions so I've chucked that in for safety.