### PR TITLE
rose suite-shutdown: fix traceback

### DIFF
--- a/lib/python/rose/suite_control.py
+++ b/lib/python/rose/suite_control.py
@@ -28,7 +28,7 @@ import sys
 
 
 YES = "y"
-PROMPT = "Really %s %s at %s? [" + YES + " or n (default)] "
+PROMPT = "Really %s %s? [" + YES + " or n (default)] "
 
 
 class SuiteControl(object):
@@ -67,7 +67,7 @@ class SuiteControl(object):
         args: extra arguments for the suite engine's shutdown command.
 
         """
-        if confirm is None or confirm("shutdown", suite_name, host_name):
+        if confirm is None or confirm("shutdown", suite_name):
             self.suite_engine_proc.shutdown(suite_name, args, stderr, stdout)
 
 
@@ -97,11 +97,9 @@ def get_suite_name(event_handler=None):
         conf_dir = up_dir
 
 
-def prompt(action, suite_name, host):
+def prompt(action, suite_name):
     """Prompt user to confirm action for suite_name at host."""
-    if not host:
-        host = "localhost"
-    return raw_input(PROMPT % (action, suite_name, host)).strip() in [YES]
+    return raw_input(PROMPT % (action, suite_name)).strip() in [YES]
 
 
 def main():


### PR DESCRIPTION
`rose suite-shutdown` currently fails with the current error:

```
NameError: global name 'host_name' is not defined
```

This seems to have slid through the test battery, we could add tests for it now but considering the imminent retirement of this command we may wish to leave as is for now.