### PR TITLE
report debug statements only when requested

### DIFF
--- a/lib/python/rose/suite_engine_procs/cylc.py
+++ b/lib/python/rose/suite_engine_procs/cylc.py
@@ -115,7 +115,7 @@ class CylcProcessor(SuiteEngineProcessor):
             self.popen.run_simple("cylc", "register", suite_name, suite_dir)
         f_desc, new_suite_rc_processed = mkstemp()
         os.close(f_desc)
-        command = ["cylc", "validate", "-v", "-o", new_suite_rc_processed]
+        command = ["cylc", "validate", "-o", new_suite_rc_processed]
         if debug_mode:
             command.append("--debug")
         if strict_mode:


### PR DESCRIPTION
Following logging changes in Cylc, `rose suite-run` now spams users with `DEBUG` statements.

```console
$ rose suite-run
[INFO] export CYLC_VERSION=7.8.0
[INFO] export ROSE_ORIG_HOST=eld668
[INFO] export ROSE_SITE=
[INFO] export ROSE_VERSION=2018.11.0
[INFO] delete: log/rose-suite-run.conf
[INFO] symlink: rose-conf/20190122T140922-reload.conf <= log/rose-suite-run.conf
[INFO] delete: log/rose-suite-run.version
[INFO] symlink: rose-conf/20190122T140922-reload.version <= log/rose-suite-run.version
[INFO] 2019-01-22T14:09:23Z DEBUG - Loading site/user global config files
[INFO] 2019-01-22T14:09:23Z DEBUG - Reading file user/.cylc/global.rc
[INFO] 2019-01-22T14:09:23Z DEBUG - Reading file user/cylc-run/tmp.f0a2CJfOMd/suite.rc
[INFO] 2019-01-22T14:09:23Z DEBUG - Processing with Jinja2
[INFO] 2019-01-22T14:09:23Z DEBUG - Processed configuration dumped: /var/tmp/tmpltjFer
# and so on so forth
```

This change reverts behaviour to something cleaner:

```console
$ rose suite-run --reload
[INFO] export CYLC_VERSION=7.8.0-62-g457c8-dirty
[INFO] export ROSE_ORIG_HOST=eld668
[INFO] export ROSE_SITE=
[INFO] export ROSE_VERSION=2018.11.0-24-gc660e8c3
[INFO] delete: log/rose-suite-run.conf
[INFO] symlink: rose-conf/20190122T140917-reload.conf <= log/rose-suite-run.conf
[INFO] delete: log/rose-suite-run.version
[INFO] symlink: rose-conf/20190122T140917-reload.version <= log/rose-suite-run.version
[INFO] tmp.f0a2CJfOMd: reload complete. "suite.rc" unchanged
$ 
```