### PR TITLE
docs: patch hieroglyph to work with sphinx 1.8.0+

### DIFF
--- a/bin/rose-check-software
+++ b/bin/rose-check-software
@@ -317,7 +317,7 @@ def docs(check=check):
                version_template='graphviz version ([^\s]+)', outfile=2),
         # TODO remove Sphinx version dependency
         # https://github.com/nyergler/hieroglyph/issues/148
-        check('py:sphinx', (1, 5, 3), (1, 8)),
+        check('py:sphinx', (1, 5, 3)),
         check('py:sphinx_rtd_theme', (0, 2, 4)),
         check('py:sphinxcontrib.httpdomain'),
         check('py:hieroglyph')

--- a/bin/rose-make-docs
+++ b/bin/rose-make-docs
@@ -177,12 +177,10 @@ venv-install () {
     venv-destroy
     virtualenv --python=python2.7 "${VENV_PATH}"
     venv-activate
-    # TODO remove Sphinx version dependency
-    # https://github.com/nyergler/hieroglyph/issues/148
-    pip install 'sphinx==1.7.9'
-    pip install sphinx_rtd_theme
-    pip install sphinxcontrib-httpdomain
-    pip install hieroglyph
+    pip install 'sphinx'
+    pip install 'sphinx_rtd_theme'
+    pip install 'sphinxcontrib-httpdomain'
+    pip install 'hieroglyph'
 }
 
 venv-deactivate () {

--- a/etc/rose-docs-env.yaml
+++ b/etc/rose-docs-env.yaml
@@ -4,7 +4,7 @@ channels:
   - defaults
 dependencies:
   - python=2.7
-  - sphinx=1.7.9
+  - sphinx
   - requests
   - sphinx_rtd_theme
   - sphinxcontrib-httpdomain

--- a/sphinx/conf.py
+++ b/sphinx/conf.py
@@ -43,6 +43,7 @@ extensions = [
     'hieroglyph',
     'sphinxcontrib.httpdomain',
     # custom project extensions (located in ext/)
+    'hieroglyph_patch',  # https://github.com/nyergler/hieroglyph/issues/148
     'auto_cli_doc',
     'cylc_lang',
     'minicylc',

--- a/sphinx/ext/hieroglyph_patch.py
+++ b/sphinx/ext/hieroglyph_patch.py
@@ -1,0 +1,41 @@
+"""Monkey patch hieroglyph to work with Sphinx 1.8.0+.
+
+This extension serves as a temporary workaround, for more information see
+`https://github.com/nyergler/hieroglyph/issues/148`_.
+
+If an extension provides its own visit or depart methods, patch them into the
+``HTMLTranslator`` class below.
+
+It would be possible to patch the ``add_node`` method of the Sphinx application
+to patch extensions automatically but in the interests of keeping the hack to a
+minimum this hard-coded extension should suffice.
+
+"""
+
+import sphinx
+
+from sphinx.writers.html import HTMLTranslator
+
+from sphinx.ext.graphviz import html_visit_graphviz
+from sphinx.ext.autosummary import (autosummary_toc_visit_html,
+                                    autosummary_table_visit_html)
+from minicylc import MiniCylc
+
+
+def none(*args, **kwargs):
+    pass
+
+
+def setup(app):
+    if tuple(int(x) for x in sphinx.__version__.split('.')) > (1, 7, 9):
+        # sphinx.ext.graphviz
+        HTMLTranslator.visit_graphviz = html_visit_graphviz
+
+        # sphinx.ext.autosummary
+        HTMLTranslator.visit_autosummary_toc = autosummary_toc_visit_html
+        HTMLTranslator.depart_autosummary_toc = none
+        HTMLTranslator.visit_autosummary_table = autosummary_table_visit_html
+        HTMLTranslator.depart_autosummary_table = none
+
+        # ext.minicylc
+        HTMLTranslator.visit_MiniCylc = MiniCylc.visit_html


### PR DESCRIPTION
Temporary fix to allow the documentation to be built with contemporary versions of Sphinx (note v2.0 is under development).