### PR TITLE
Call opendir before testing contact file existence

### DIFF
--- a/lib/python/rose/suite_engine_procs/cylc.py
+++ b/lib/python/rose/suite_engine_procs/cylc.py
@@ -166,13 +166,18 @@ class CylcProcessor(SuiteEngineProcessor):
         Return (dict): suite contact information.
         """
         try:
+            # Note: low level directory open ensures that the file system
+            # containing the contact file is synchronised, e.g. in an NFS
+            # environment.
+            os.close(os.open(
+                self.get_suite_dir(suite_name, ".service"), os.O_DIRECTORY))
             ret = {}
             for line in open(
                     self.get_suite_dir(suite_name, ".service", "contact")):
                 key, value = [item.strip() for item in line.split("=", 1)]
                 ret[key] = value
             return ret
-        except (IOError, ValueError):
+        except (IOError, OSError, ValueError):
             raise SuiteNotRunningError(suite_name)
 
     @classmethod


### PR DESCRIPTION
Call `os.open(..., os.O_DIRECTORY)` on the suite's service directory
(i.e. the parent directory of the suite's contact file) before testing
for existence of the contact file. This ensures that the file system is
synchronised e.g. for NFS or the file existence test may fail even
though the file is already there.