### PR TITLE
Simplify boolean expression

### DIFF
--- a/lib/python/rose/macros/trigger.py
+++ b/lib/python/rose/macros/trigger.py
@@ -61,7 +61,7 @@ class TriggerMacro(rose.macro.MacroBaseRoseEdit):
                 expr = opt_node.value
                 id_value_dict = rose.variable.parse_trigger_expression(expr)
                 for trig_id, values in id_value_dict.items():
-                    if values == []:
+                    if not len(values):
                         id_value_dict.update({trig_id: [None]})
                 self.trigger_family_lookup.update({setting_id: id_value_dict})
         self._trigger_involved_ids = self.get_all_ids()


### PR DESCRIPTION
Besides searching for `== True` and `== False`, now I'm also searching for `== []` when syncing code :smile: 

I think these two statements are equivalent, but without creating an empty array (though I suspect compiler/interpreter/etc should optimize it)?

Cheers
Bruno