### PR TITLE
edit: fix bug w/ element removal on array-like types

### DIFF
--- a/lib/python/rose/config_editor/valuewidget/array/entry.py
+++ b/lib/python/rose/config_editor/valuewidget/array/entry.py
@@ -378,7 +378,8 @@ class EntryArrayValueWidget(gtk.HBox):
         """Remove the last selected or the last entry."""
         if (self.last_selected_src is not None and
                 self.last_selected_src in self.entries):
-            entry = self.entries.pop(self.last_selected_src)
+            entry = self.entries.pop(
+                self.entries.index(self.last_selected_src))
             self.last_selected_src = None
         else:
             entry = self.entries.pop()

--- a/lib/python/rose/config_editor/valuewidget/array/python_list.py
+++ b/lib/python/rose/config_editor/valuewidget/array/python_list.py
@@ -348,7 +348,8 @@ class PythonListValueWidget(gtk.HBox):
         if (self.last_selected_src is not None and
                 self.last_selected_src in self.entries):
             text = self.last_selected_src.get_text()
-            widget = self.entries.pop(self.last_selected_src)
+            widget = self.entries.pop(
+                self.entries.index(self.last_selected_src))
             self.last_selected_src = None
         else:
             text = self.entries[-1].get_text()

--- a/lib/python/rose/config_editor/valuewidget/array/spaced_list.py
+++ b/lib/python/rose/config_editor/valuewidget/array/spaced_list.py
@@ -343,7 +343,8 @@ class SpacedListValueWidget(gtk.HBox):
         if (self.last_selected_src is not None and
                 self.last_selected_src in self.entries):
             text = self.last_selected_src.get_text()
-            entry = self.entries.pop(self.last_selected_src)
+            entry = self.entries.pop(
+                self.entries.index(self.last_selected_src))
             self.last_selected_src = None
         else:
             text = self.entries[-1].get_text()


### PR DESCRIPTION
Close #2272, which has been returned to as it has been noticed by another user in a different context (for the ``spaced_list`` type instead i.e. from within ``rose/config_editor/valuewidget/array/spaced_list.py``).

Upon investigation, the issue has arisen from the commit https://github.com/metomi/rose/commit/493750a2e4cdeac45ff664decb438ac82b1e13f7. The ``pop()`` method requires any argument to be an index instead of a matching element like ``remove()``. Admittedly this was a reviewing oversight on my part.