### PR TITLE
New "rose suite-run" config: root-dir{log}.

### DIFF
--- a/etc/rose-meta/rose-suite-conf/rose-meta.conf
+++ b/etc/rose-meta/rose-suite-conf/rose-meta.conf
@@ -21,6 +21,14 @@ help=A new line delimited list of PATTERN=DIR pairs.
     = The DIR should be the root directory where the suite's directory
     = should be created.
 
+[=root-dir{log}]
+description=Specify the suite's log/ directory location on particular hosts.
+help=A new line delimited list of PATTERN=DIR pairs.
+    =
+    = The PATTERN should be a glob-like pattern for matching a host name.
+    = The DIR should be the root directory where the suite's share directory
+    = should be created.
+
 [=root-dir{share}]
 description=Specify the suite's share/ directory location on particular hosts.
 help=A new line delimited list of PATTERN=DIR pairs.


### PR DESCRIPTION
Close #2287 

Allow `rose suite-run` to put suite log directories in other locations, symlinked to the standard location.

(I had a crack at this because we need it pretty desperately on the new HPC at NIWA).

Handles archiving of symlinked log dirs by making a local symlink to the external archive.

Example:
```
root-dir{log}=*=/tmp/$USER
```
Result after one run:
```
ls -grt ~/cylc-run/foo                                                                                                 
total 16
lrwxrwxrwx 1 oliverh   46 Feb 20 12:29 log.20190219T232926Z -> /tmp/oliverh/cylc-run/foo/log.20190219T232926Z/
lrwxrwxrwx 1 oliverh   20 Feb 20 12:29 log -> log.20190219T232926Z/
-rw-r--r-- 1 oliverh  607 Feb 20 12:29 suite.rc
...
```

After another run:
```
ls -grt ~/cylc-run/foo                                                                                                 
total 16
-rw-r--r-- 1 oliverh  607 Feb 20 12:29 suite.rc
lrwxrwxrwx 1 oliverh    6 Feb 20 12:29 cylc-suite.db -> log/db
lrwxrwxrwx 1 oliverh   46 Feb 20 12:31 log.20190219T233124Z -> /tmp/oliverh/cylc-run/foo/log.20190219T233124Z/
lrwxrwxrwx 1 oliverh   20 Feb 20 12:31 log -> log.20190219T233124Z/
lrwxrwxrwx 1 oliverh   53 Feb 20 12:31 log.20190219T232926Z.tar.gz -> /tmp/oliverh/cylc-run/foo/log.20190219T232926Z.tar.gz
-rw-r--r-- 1 oliverh  362 Feb 20 12:31 suite.rc.processed
drwxr-xr-x 3 oliverh 4096 Feb 20 12:31 work/
...
```