### PR TITLE
docs: add missing characters to fix formatting errors

### DIFF
--- a/sphinx/api/built-in/rose_prune.rst
+++ b/sphinx/api/built-in/rose_prune.rst
@@ -60,7 +60,7 @@ Configuration
       .. rose:conf:: cycle-format{key}=format
 
          Specify a key to a format string for use in conjunction with a
-         :rose:conf`prune{item-root}=cycle:globs` setting. For example, we may
+         :rose:conf:`prune{item-root}=cycle:globs` setting. For example, we may
          have something like ``cycle-format{cycle_year}=CCYY`` and
          ``prune{share}=-P1Y:xmas-present-%(cycle_year)s/``. In Cylc, if the
          current cycle point is ``20151201T0000Z``, it will clear out the

--- a/sphinx/api/configuration/metadata.rst
+++ b/sphinx/api/configuration/metadata.rst
@@ -345,7 +345,7 @@ The metadata options for a configuration fall into four categories:
          Define a comma ``,`` separated list of permitted values of a setting
          (or an element in the setting if it is an array). This metadata
          overrides the :rose:conf:`type`, :rose:conf:`range` and
-         :rose:conf`pattern` metadata.
+         :rose:conf:`pattern` metadata.
 
          For example, :ref:`command-rose-config-edit` may use this list to
          determine the widget


### PR DESCRIPTION
I noticed a Sphinx formatting error under the ``rose-meta.conf[SETTING]values`` section in the online documentation & though I might as well put in a fix given it is straightforward. Whilst amending this I did a ``git grep "\:rose\:conf\`"`` to reveal one more instance of the same typo.

Trivial hence lone reviewer sufficient.