### PR TITLE
Implement threading to speed up rose-ana (PR on Master)

### DIFF
--- a/metomi/rose/apps/rose_ana.py
+++ b/metomi/rose/apps/rose_ana.py
@@ -462,13 +462,18 @@ class RoseAnaApp(BuiltinApp):
             # Start threads within the set number of concurrent threads until
             # all have been started
             itask = 0
+            running = []
             while itask < len(threads):
-                if threading.active_count() < n_threads:
+                if len(running) < n_threads:
                     self.reporter(
                         "Starting thread for task {0} at {1}"
                         .format(itask + 1, timestamp()))
+                    running.append(threads[itask])
                     threads[itask].start()
                     itask += 1
+                for thread in running:
+                    if not thread.is_alive():
+                        running.remove(thread)
 
             # Gather up the results
             number_of_failures = 0

--- a/metomi/rose/apps/rose_ana.py
+++ b/metomi/rose/apps/rose_ana.py
@@ -31,6 +31,7 @@ import sqlite3
 import time
 import traceback
 import fcntl
+import threading
 from contextlib import contextmanager
 
 # Rose modules
@@ -224,6 +225,80 @@ class AnalysisTask(object, metaclass=abc.ABCMeta):
             raise ValueError(msg.format(unhandled))
 
 
+class TaskRunner(threading.Thread):
+    def __init__(self, app, index, task):
+        threading.Thread.__init__(self)
+        self.name = "Task-{0}".format(index + 1)
+        self.app = app
+        self.index = index
+        self.task = task
+
+        self.skips = 0
+        self.failures = 0
+        self.task_error = False
+        self.summary_status = []
+        self.reporter_args = []
+
+    def run(self):
+        # Create a temporary handler for the reporter class
+        reporter = Reporter(self.app.opts.verbosity -
+                            self.app.opts.quietness)
+        def handler(message, kind, level, prefix, clip):
+            self.reporter_args.append((message, kind, level, prefix, clip))
+        reporter.event_handler = handler
+        self.task.reporter = reporter
+
+        # Report the name of the task and a banner line to aid readability.
+        self.app.titlebar("Running task #{0}".format(self.index + 1),
+                          reporter)
+        reporter("Method: {0}".format(self.task.options["full_task_name"]))
+
+        # Since the run_analysis method is out of rose's control in many
+        # cases the safest thing to do is a blanket try/except; since we
+        # have no way of knowing what exceptions might be raised.
+        try:
+            self.task.run_analysis()
+            # In the case that the task didn't raise any exception,
+            # we can now check whether it passed or failed.
+            if self.task.passed:
+                msg = "Task #{0} passed".format(self.index + 1)
+                self.summary_status.append(("{0} ({1})".format(
+                    msg, self.task.options["full_task_name"]),
+                    self.app._prefix_pass))
+                reporter(msg, prefix=self.app._prefix_pass)
+            elif self.task.skipped:
+                self.skips = 1
+                msg = "Task #{0} skipped by method".format(self.index + 1)
+                self.summary_status.append(("{0} ({1})".format(
+                    msg, self.task.options["full_task_name"]),
+                    self.app._prefix_skip))
+                reporter(msg, prefix=self.app._prefix_skip)
+            else:
+                self.failures = 1
+                msg = "Task #{0} did not pass".format(self.index + 1)
+                self.summary_status.append(("{0} ({1})".format(
+                    msg, self.task.options["full_task_name"]),
+                    self.app._prefix_fail))
+                reporter(msg, prefix=self.app._prefix_fail)
+
+        except Exception:
+            # If an exception was raised, print a traceback and treat it
+            # as a failure.
+            self.task_error = True
+            self.failures = 1
+            msg = "Task #{0} encountered an error".format(self.index + 1)
+            self.summary_status.append(("{0} ({1})".format(
+                msg, self.task.options["full_task_name"]),
+                self.app._prefix_fail))
+            reporter(msg + " (see stderr)",
+                     prefix=self.app._prefix_fail)
+            exception = traceback.format_exc()
+            reporter(msg, prefix=self.app._prefix_fail,
+                     kind=reporter.KIND_ERR)
+            reporter(exception, prefix=self.app._prefix_fail,
+                     kind=reporter.KIND_ERR)
+
+
 class RoseAnaApp(BuiltinApp):
 
     """Run rosa ana as an application."""
@@ -294,59 +369,35 @@ class RoseAnaApp(BuiltinApp):
         self._load_analysis_methods()
         self._load_tasks()
 
+        # Create threading objects for each comparison task
+        threads = []
+        for itask, task in enumerate(self.analysis_tasks):
+            threads.append(TaskRunner(self, itask, task))
+
+        # Start the threads, ensuring no more than NPROC are running at once
+        # (this could be made into a user-settable option later)
+        NPROC = 4
+        itask = 0
+        while itask < len(threads):
+            if threading.active_count() < NPROC:
+                threads[itask].start()
+                itask += 1
+
+        # Gather up the results
         number_of_failures = 0
         number_of_skips = 0
         task_error = False
         summary_status = []
-        for itask, task in enumerate(self.analysis_tasks):
-            # Report the name of the task and a banner line to aid readability.
-            self.titlebar("Running task #{0}".format(itask + 1))
-            self.reporter("Method: {0}".format(task.options["full_task_name"]))
-
-            # Since the run_analysis method is out of rose's control in
-            # many cases the safest thing to do is a blanket try/except; since
-            # we have no way of knowing what exceptions might be raised.
-            try:
-                task.run_analysis()
-                # In the case that the task didn't raise any exception,
-                # we can now check whether it passed or failed.
-                if task.passed:
-                    msg = "Task #{0} passed".format(itask + 1)
-                    summary_status.append(("{0} ({1})".format(
-                        msg, task.options["full_task_name"]),
-                        self._prefix_pass))
-                    self.reporter(msg, prefix=self._prefix_pass)
-                elif task.skipped:
-                    number_of_skips += 1
-                    msg = "Task #{0} skipped by method".format(itask + 1)
-                    summary_status.append(("{0} ({1})".format(
-                        msg, task.options["full_task_name"]),
-                        self._prefix_skip))
-                    self.reporter(msg, prefix=self._prefix_skip)
-                else:
-                    number_of_failures += 1
-                    msg = "Task #{0} did not pass".format(itask + 1)
-                    summary_status.append(("{0} ({1})".format(
-                        msg, task.options["full_task_name"]),
-                        self._prefix_fail))
-                    self.reporter(msg, prefix=self._prefix_fail)
-
-            except Exception:
-                # If an exception was raised, print a traceback and treat it
-                # as a failure.
-                task_error = True
-                number_of_failures += 1
-                msg = "Task #{0} encountered an error".format(itask + 1)
-                summary_status.append(("{0} ({1})".format(
-                    msg, task.options["full_task_name"]),
-                    self._prefix_fail))
-                self.reporter(msg + " (see stderr)", prefix=self._prefix_fail)
-                exception = traceback.format_exc()
-                self.reporter(msg, prefix=self._prefix_fail,
-                              kind=self.reporter.KIND_ERR)
-                self.reporter(exception, prefix=self._prefix_fail,
-                              kind=self.reporter.KIND_ERR)
-
+        for thread in threads:
+            # If any threads haven't finished yet make sure to wait
+            thread.join()
+            number_of_failures += thread.failures
+            number_of_skips += thread.skips
+            task_error = (task_error or thread.task_error)
+            summary_status += thread.summary_status
+            # And print the output via the main reporter
+            for args in thread.reporter_args:
+                self.reporter(*args)
         # The KGO database (if needed by the task) also stores its status - to
         # indicate whether there was some unexpected exception above.
         if self.kgo_db is not None and not task_error:
@@ -389,9 +440,11 @@ class RoseAnaApp(BuiltinApp):
         if number_of_failures > 0 or number_of_skips == total:
             raise TestsFailedException(number_of_failures)
 
-    def titlebar(self, title):
+    def titlebar(self, title, reporter=None):
+        if reporter is None:
+            reporter = self.reporter
         sidebarlen = (self._printbar_width - len(title) + 1) / 2 - 1
-        self.reporter("{0} {1} {0}".format("*" * int(sidebarlen), title))
+        reporter("{0} {1} {0}".format("*" * int(sidebarlen), title))
 
     def _get_global_ana_config(self):
         """Retrieves all rose_ana config options; these could be from

--- a/metomi/rose/apps/rose_ana.py
+++ b/metomi/rose/apps/rose_ana.py
@@ -437,7 +437,7 @@ class RoseAnaApp(BuiltinApp):
                     # it as a failure.
                     task_error = True
                     number_of_failures += 1
-                    msg = ("Task #{0} encountered an error at "
+                    msg = ("Task #{0} encountered an error at {1}"
                            .format(itask + 1, timestamp()))
                     summary_status.append(("{0} ({1})".format(
                         msg, task.options["full_task_name"]),

--- a/t/rose-ana/00-run-basic.t
+++ b/t/rose-ana/00-run-basic.t
@@ -21,7 +21,7 @@
 #-------------------------------------------------------------------------------
 . $(dirname $0)/test_header
 #-------------------------------------------------------------------------------
-N_TESTS=52
+N_TESTS=81
 tests $N_TESTS
 #-------------------------------------------------------------------------------
 
@@ -45,88 +45,104 @@ run_fail "$TEST_KEY" \
     --host=localhost -- --no-detach --debug
 #-------------------------------------------------------------------------------
 # Test the output
+#
+# Note that t1 and t5 are identical except t5 uses threading, so use a loop here
+for t in t1 t5 ; do
+  OUTPUT="${HOME}/cylc-run/${NAME}/log/job/1/rose_ana_$t/01/job.out"
+  file_pcregrep "${TEST_KEY_BASE}-$t-exact_list_fail}" \
+      'Running task #([0-9]+).*\n.*Exact List Match Fail.*\n.*Task #\1 did not pass' \
+      "${OUTPUT}"
+  file_pcregrep "${TEST_KEY_BASE}-$t-exact_list_success" \
+      'Running task #([0-9]+).*\n.*Exact List Match Success.*\n.*Task #\1 passed' \
+      "${OUTPUT}"
+  file_pcregrep "${TEST_KEY_BASE}-$t-exact_numeric_fail" \
+      'Running task #([0-9]+).*\n.*Exact Numeric Match Fail.*\n.*Task #\1 did not pass' \
+      "${OUTPUT}"
+  file_pcregrep "${TEST_KEY_BASE}-$t-exact_numeric_success" \
+      'Running task #([0-9]+).*\n.*Exact Numeric Match Success.*\n.*Task #\1 passed' \
+      "${OUTPUT}"
+  file_pcregrep "${TEST_KEY_BASE}-$t-exact_text_fail" \
+      'Running task #([0-9]+).*\n.*Exact Text Match Fail.*\n.*Task #\1 did not pass' \
+      "${OUTPUT}"
+  file_pcregrep "${TEST_KEY_BASE}-$t-exact_text_success" \
+      'Running task #([0-9]+).*\n.*Exact Text Match Success.*\n.*Task #\1 passed' \
+      "${OUTPUT}"
+  file_pcregrep "${TEST_KEY_BASE}-$t-within_list_fail" \
+      'Running task #([0-9]+).*\n.*Within List Match Fail.*\n.*Task #\1 did not pass' \
+      "${OUTPUT}"
+  file_pcregrep "${TEST_KEY_BASE}-$t-within_list_success" \
+      'Running task #([0-9]+).*\n.*Within List Match Success.*\n.*Task #\1 passed' \
+      "${OUTPUT}"
+  file_pcregrep "${TEST_KEY_BASE}-$t-within_absolute_fail" \
+      'Running task #([0-9]+).*\n.*Within Match Absolute Fail.*\n.*Task #\1 did not pass' \
+      "${OUTPUT}"
+  file_pcregrep "${TEST_KEY_BASE}-$t-within_absolute_success" \
+      'Running task #([0-9]+).*\n.*Within Match Absolute Success.*\n.*Task #\1 passed' \
+      "${OUTPUT}"
+  file_pcregrep "${TEST_KEY_BASE}-$t-within_percentage_fail" \
+      'Running task #([0-9]+).*\n.*Within Match Percentage Fail.*\n.*Task #\1 did not pass' \
+      "${OUTPUT}"
+  file_pcregrep "${TEST_KEY_BASE}-$t-within_percentage_success" \
+      'Running task #([0-9]+).*\n.*Within Match Percentage Success.*\n.*Task #\1 passed' \
+      "${OUTPUT}"
+  file_pcregrep "${TEST_KEY_BASE}-$t-simple_command_success" \
+      'Running task #([0-9]+).*\n.*Simple-Command Success.*\n.*Task #\1 passed' \
+      "${OUTPUT}"
+  file_pcregrep "${TEST_KEY_BASE}-$t-simple_command_fail" \
+      'Running task #([0-9]+).*\n.*Simple-Command Failure.*\n.*Task #\1 did not pass' \
+      "${OUTPUT}"
+  file_pcregrep "${TEST_KEY_BASE}-$t-file_command_success" \
+      'Running task #([0-9]+).*\n.*File-Command Success.*\n.*Task #\1 passed' \
+      "${OUTPUT}"
+  file_pcregrep "${TEST_KEY_BASE}-$t-file_command_fail" \
+      'Running task #([0-9]+).*\n.*File-Command Failure.*\n.*Task #\1 did not pass' \
+      "${OUTPUT}"
+  file_pcregrep "${TEST_KEY_BASE}-$t-simple_command_pattern_success" \
+      'Running task #([0-9]+).*\n.*Simple-Command Pattern Success.*\n.*Task #\1 passed' \
+      "${OUTPUT}"
+  file_pcregrep "${TEST_KEY_BASE}-$t-simple_command_pattern_fail" \
+      'Running task #([0-9]+).*\n.*Simple-Command Pattern Failure.*\n.*Task #\1 did not pass' \
+      "${OUTPUT}"
+  file_pcregrep "${TEST_KEY_BASE}-$t-file_command_pattern_success" \
+      'Running task #([0-9]+).*\n.*File-Command Pattern Success.*\n.*Task #\1 passed' \
+      "${OUTPUT}"
+  file_pcregrep "${TEST_KEY_BASE}-$t-file_command_pattern_fail" \
+      'Running task #([0-9]+).*\n.*File-Command Pattern Failure.*\n.*Task #\1 did not pass' \
+      "${OUTPUT}"
+  file_pcregrep "${TEST_KEY_BASE}-$t-file_command_fail_but_pattern_success" \
+      'Running task #([0-9]+).*\n.*File-Command Fail but Pattern Success.*\n.*Task #\1 passed' \
+      "${OUTPUT}"
+  file_pcregrep "${TEST_KEY_BASE}-$t-multi_command_success" \
+      'Running task #([0-9]+).*\n.*Multi-Command Success.*\n.*Task #\1 passed' \
+      "${OUTPUT}"
+  file_pcregrep "${TEST_KEY_BASE}-$t-multi_command_fail" \
+      'Running task #([0-9]+).*\n.*Multi-Command Failure.*\n.*Task #\1 did not pass' \
+      "${OUTPUT}"
+  file_pcregrep "${TEST_KEY_BASE}-$t-multi_group_success" \
+      'Running task #([0-9]+).*\n.*Multi-Group Success.*\n.*Task #\1 passed' \
+      "${OUTPUT}"
+  file_pcregrep "${TEST_KEY_BASE}-$t-multi_group_fail" \
+      'Running task #([0-9]+).*\n.*Multi-Group Failure.*\n.*Task #\1 did not pass' \
+      "${OUTPUT}"
+  file_pcregrep "${TEST_KEY_BASE}-$t-multi_group_multi_occurence_success" \
+      'Running task #([0-9]+).*\n.*Multi-Group Multi-Occurence Success.*\n.*Task #\1 passed' \
+      "${OUTPUT}"
+  file_pcregrep "${TEST_KEY_BASE}-$t-multi_group_multi_occurence_fail" \
+      'Running task #([0-9]+).*\n.*Multi-Group Multi-Occurence Failure.*\n.*Task #\1 did not pass' \
+      "${OUTPUT}"
+done
+
+# Now check that the threading option is reflected in the output
 OUTPUT="${HOME}/cylc-run/${NAME}/log/job/1/rose_ana_t1/01/job.out"
-file_pcregrep "${TEST_KEY_BASE}-exact_list_fail}" \
-    'Running task #([0-9]+).*\n.*Exact List Match Fail.*\n.*Task #\1 did not pass' \
-    "${OUTPUT}"
-file_pcregrep "${TEST_KEY_BASE}-exact_list_success" \
-    'Running task #([0-9]+).*\n.*Exact List Match Success.*\n.*Task #\1 passed' \
-    "${OUTPUT}"
-file_pcregrep "${TEST_KEY_BASE}-exact_numeric_fail" \
-    'Running task #([0-9]+).*\n.*Exact Numeric Match Fail.*\n.*Task #\1 did not pass' \
-    "${OUTPUT}"
-file_pcregrep "${TEST_KEY_BASE}-exact_numeric_success" \
-    'Running task #([0-9]+).*\n.*Exact Numeric Match Success.*\n.*Task #\1 passed' \
-    "${OUTPUT}"
-file_pcregrep "${TEST_KEY_BASE}-exact_text_fail" \
-    'Running task #([0-9]+).*\n.*Exact Text Match Fail.*\n.*Task #\1 did not pass' \
-    "${OUTPUT}"
-file_pcregrep "${TEST_KEY_BASE}-exact_text_success" \
-    'Running task #([0-9]+).*\n.*Exact Text Match Success.*\n.*Task #\1 passed' \
-    "${OUTPUT}"
-file_pcregrep "${TEST_KEY_BASE}-within_list_fail" \
-    'Running task #([0-9]+).*\n.*Within List Match Fail.*\n.*Task #\1 did not pass' \
-    "${OUTPUT}"
-file_pcregrep "${TEST_KEY_BASE}-within_list_success" \
-    'Running task #([0-9]+).*\n.*Within List Match Success.*\n.*Task #\1 passed' \
-    "${OUTPUT}"
-file_pcregrep "${TEST_KEY_BASE}-within_absolute_fail" \
-    'Running task #([0-9]+).*\n.*Within Match Absolute Fail.*\n.*Task #\1 did not pass' \
-    "${OUTPUT}"
-file_pcregrep "${TEST_KEY_BASE}-within_absolute_success" \
-    'Running task #([0-9]+).*\n.*Within Match Absolute Success.*\n.*Task #\1 passed' \
-    "${OUTPUT}"
-file_pcregrep "${TEST_KEY_BASE}-within_percentage_fail" \
-    'Running task #([0-9]+).*\n.*Within Match Percentage Fail.*\n.*Task #\1 did not pass' \
-    "${OUTPUT}"
-file_pcregrep "${TEST_KEY_BASE}-within_percentage_success" \
-    'Running task #([0-9]+).*\n.*Within Match Percentage Success.*\n.*Task #\1 passed' \
-    "${OUTPUT}"
-file_pcregrep "${TEST_KEY_BASE}-simple_command_success" \
-    'Running task #([0-9]+).*\n.*Simple-Command Success.*\n.*Task #\1 passed' \
-    "${OUTPUT}"
-file_pcregrep "${TEST_KEY_BASE}-simple_command_fail" \
-    'Running task #([0-9]+).*\n.*Simple-Command Failure.*\n.*Task #\1 did not pass' \
-    "${OUTPUT}"
-file_pcregrep "${TEST_KEY_BASE}-file_command_success" \
-    'Running task #([0-9]+).*\n.*File-Command Success.*\n.*Task #\1 passed' \
-    "${OUTPUT}"
-file_pcregrep "${TEST_KEY_BASE}-file_command_fail" \
-    'Running task #([0-9]+).*\n.*File-Command Failure.*\n.*Task #\1 did not pass' \
-    "${OUTPUT}"
-file_pcregrep "${TEST_KEY_BASE}-simple_command_pattern_success" \
-    'Running task #([0-9]+).*\n.*Simple-Command Pattern Success.*\n.*Task #\1 passed' \
-    "${OUTPUT}"
-file_pcregrep "${TEST_KEY_BASE}-simple_command_pattern_fail" \
-    'Running task #([0-9]+).*\n.*Simple-Command Pattern Failure.*\n.*Task #\1 did not pass' \
-    "${OUTPUT}"
-file_pcregrep "${TEST_KEY_BASE}-file_command_pattern_success" \
-    'Running task #([0-9]+).*\n.*File-Command Pattern Success.*\n.*Task #\1 passed' \
-    "${OUTPUT}"
-file_pcregrep "${TEST_KEY_BASE}-file_command_pattern_fail" \
-    'Running task #([0-9]+).*\n.*File-Command Pattern Failure.*\n.*Task #\1 did not pass' \
-    "${OUTPUT}"
-file_pcregrep "${TEST_KEY_BASE}-file_command_fail_but_pattern_success" \
-    'Running task #([0-9]+).*\n.*File-Command Fail but Pattern Success.*\n.*Task #\1 passed' \
-    "${OUTPUT}"
-file_pcregrep "${TEST_KEY_BASE}-multi_command_success" \
-    'Running task #([0-9]+).*\n.*Multi-Command Success.*\n.*Task #\1 passed' \
-    "${OUTPUT}"
-file_pcregrep "${TEST_KEY_BASE}-multi_command_fail" \
-    'Running task #([0-9]+).*\n.*Multi-Command Failure.*\n.*Task #\1 did not pass' \
-    "${OUTPUT}"
-file_pcregrep "${TEST_KEY_BASE}-multi_group_success" \
-    'Running task #([0-9]+).*\n.*Multi-Group Success.*\n.*Task #\1 passed' \
-    "${OUTPUT}"
-file_pcregrep "${TEST_KEY_BASE}-multi_group_fail" \
-    'Running task #([0-9]+).*\n.*Multi-Group Failure.*\n.*Task #\1 did not pass' \
-    "${OUTPUT}"
-file_pcregrep "${TEST_KEY_BASE}-multi_group_multi_occurence_success" \
-    'Running task #([0-9]+).*\n.*Multi-Group Multi-Occurence Success.*\n.*Task #\1 passed' \
-    "${OUTPUT}"
-file_pcregrep "${TEST_KEY_BASE}-multi_group_multi_occurence_fail" \
-    'Running task #([0-9]+).*\n.*Multi-Group Multi-Occurence Failure.*\n.*Task #\1 did not pass' \
-    "${OUTPUT}"
+TEST_KEY=$TEST_KEY_BASE-t1-serial_statement
+REGEXP="Running in SERIAL mode"
+file_grep $TEST_KEY "$REGEXP" $OUTPUT
+
+OUTPUT="${HOME}/cylc-run/${NAME}/log/job/1/rose_ana_t5/01/job.out"
+TEST_KEY=$TEST_KEY_BASE-t5-threading_statement
+REGEXP="Running in THREADED mode, with 4 threads"
+file_grep $TEST_KEY "$REGEXP" $OUTPUT
+
 #-------------------------------------------------------------------------------
 # Test of ignoring a task
 # First, test that the basic task ran ok

--- a/t/rose-ana/00-run-basic/app/rose_ana_t5/file/kgo.txt
+++ b/t/rose-ana/00-run-basic/app/rose_ana_t5/file/kgo.txt
@@ -1,0 +1,81 @@
+
+
+Test of Exact Numeric Match Success
+
+Semi-major Axis: 1.0000 AU
+
+
+Test of Exact Numeric Match Fail
+
+Orbital Period: 1.0000 Earth Years
+
+
+Test of Exact Text Match Success
+
+Atmosphere: Oxygen/Nitrogen
+
+
+Test of Exact Text Match Fail
+
+Planet: Earth
+
+
+
+Test of Within Match Percentage Success
+
+Oxygen Partial Pressure:  0.2095
+
+
+Test of Within Match Percentage Fail
+
+Ocean coverage:  70.8%
+
+
+
+Test of Within Match Absolute Success
+
+Rotation Period: 0.99727 Standard days
+
+
+Test of Within Match Absolute Fail
+
+Surface Gravity: 9.80665 m/s^2
+
+Test of Exact List Match Success
+
+Periastron/Apastron:  0.98326
+Periastron/Apastron:  1.01559 
+ 
+
+
+Test of Within List Match Success
+
+Satellites Natural/Artificial:   1
+Satellites Natural/Artificial:   21000
+
+
+Test of Exact List Match Fail
+
+Other Planets:   Jupiter
+Other Planets:   Saturn
+Other Planets:   Uranus
+Other Planets:   Neptune
+
+
+
+Test of Within List Match Fail
+
+Inclination/Axial Tilt:   7.155
+Inclination/Axial Tilt:   23.43
+
+
+
+Test of Multi Pattern Success
+
+Known planet races: Earthlings Martians Jovians Neptunians
+
+
+Test of Multi Pattern Fail
+
+Friendly planet races: Earthlings Martians Jovians
+

--- a/t/rose-ana/00-run-basic/app/rose_ana_t5/file/results.txt
+++ b/t/rose-ana/00-run-basic/app/rose_ana_t5/file/results.txt
@@ -1,0 +1,80 @@
+
+
+Test of Exact Numeric Match Success
+
+Semi-major Axis: 1.0000 AU
+
+
+Test of Exact Numeric Match Fail
+
+Orbital Period: 1.05234 Earth Years
+
+
+Test of Exact Text Match Success
+
+Atmosphere: Oxygen/Nitrogen
+
+
+Test of Exact Text Match Fail
+
+Planet: Atlantica
+
+
+
+Test of Within Match Percentage Success
+
+Oxygen Partial Pressure:  0.2103
+
+
+Test of Within Match Percentage Fail
+
+Ocean coverage: 95.8%
+
+
+Test of Within Match Absolute Success
+
+Surface Gravity: 9.72210 m/s^2
+
+
+Test of Within Match Absolute Fail
+
+Rotation Period: 0.9270 Standard days
+
+
+Test of Exact List Match Success
+
+Satellites Natural/Artificial:   1
+Satellites Natural/Artificial:   21000
+ 
+
+
+Test of Within List Match Success
+
+Periastron/Apastron:  0.98326
+Periastron/Apastron:  1.02559 
+
+
+Test of Exact List Match Fail
+
+Other Planets:   Lugh
+Other Planets:   Sulis
+Other Planets:   Morrigan
+Other Planets:   Brigantia
+
+
+
+Test of Within List Match Fail
+
+Inclination/Axial Tilt:   27.60
+Inclination/Axial Tilt:   2.453
+
+
+
+Test of Multi Pattern Success
+
+Known planet races: Earthlings Martians Jovians Neptunians
+
+
+Test of Multi Pattern Fail
+
+Friendly planet races: Earthlings Martians Plutonians

--- a/t/rose-ana/00-run-basic/app/rose_ana_t5/rose-app.conf
+++ b/t/rose-ana/00-run-basic/app/rose_ana_t5/rose-app.conf
@@ -1,0 +1,157 @@
+[ana:config]
+threads=4
+
+[ana:grepper.FilePattern(Test of Exact List Match Fail)]
+files=kgo.txt
+     =results.txt
+pattern='Other Planets:\s*(\S+)'
+kgo_file=0
+
+[ana:grepper.FilePattern(Test of Exact List Match Success)]
+files=kgo.txt
+     =results.txt
+pattern='Satellites Natural/Artificial:\s*(\S+)'
+kgo_file=0
+
+[ana:grepper.FilePattern(Test of Exact Numeric Match Fail)]
+files=kgo.txt
+     =results.txt
+pattern='Orbital Period:\s*(\S+)'
+kgo_file=0
+
+[ana:grepper.FilePattern(Test of Exact Numeric Match Success)]
+files=kgo.txt
+     =results.txt
+pattern='Semi-major Axis:\s*(\S+)'
+kgo_file=0
+
+[ana:grepper.FilePattern(Test of Exact Text Match Fail)]
+files=kgo.txt
+     =results.txt
+pattern='Planet:\s*(\S+)'
+kgo_file=0
+
+[ana:grepper.FilePattern(Test of Exact Text Match Success)]
+files=kgo.txt
+     =results.txt
+pattern='Atmosphere:\s*(\S+)'
+kgo_file=0
+
+[ana:grepper.FilePattern(Test of Within List Match Fail)]
+files=kgo.txt
+     =results.txt
+pattern='Inclination/Axial Tilt:\s*(\S+)'
+kgo_file=0
+tolerance=5%
+
+[ana:grepper.FilePattern(Test of Within List Match Success)]
+files=kgo.txt
+     =results.txt
+pattern='Periastron/Apastron:\s*(\S+)'
+kgo_file=0
+tolerance=5%
+
+[ana:grepper.FilePattern(Test of Within Match Absolute Fail)]
+files=kgo.txt
+     =results.txt
+pattern='Rotation Period:\s*(\S+)'
+kgo_file=0
+tolerance=0.05
+
+[ana:grepper.FilePattern(Test of Within Match Absolute Success)]
+files=kgo.txt
+     =results.txt
+pattern='Surface Gravity:\s*(\S+)'
+kgo_file=0
+tolerance=1.0
+
+[ana:grepper.FilePattern(Test of Within Match Percentage Fail)]
+files=kgo.txt
+     =results.txt
+pattern='Ocean coverage:\s*(\S+)%'
+kgo_file=0
+tolerance=5%
+
+[ana:grepper.FilePattern(Test of Within Match Percentage Success)]
+files=kgo.txt
+     =results.txt
+pattern='Oxygen Partial Pressure:\s*(\S+)'
+kgo_file=0
+tolerance=5%
+
+[ana:grepper.SingleCommandStatus(Test of Simple-Command Success)]
+command="ls"
+
+[ana:grepper.SingleCommandStatus(Test of Simple-Command Failure)]
+command="ls nonexistentfile"
+
+[ana:grepper.SingleCommandStatus(Test of File-Command Success)]
+command="cmp {0} {1}"
+files=kgo.txt
+     =kgo.txt
+
+[ana:grepper.SingleCommandStatus(Test of File-Command Failure)]
+command="cmp {0} {1}"
+files=kgo.txt
+     =results.txt
+
+[ana:grepper.SingleCommandPattern(Test of Simple-Command Pattern Success)]
+command="ls"
+pattern="\w+.txt"
+
+[ana:grepper.SingleCommandPattern(Test of Simple-Command Pattern Failure)]
+command="ls"
+pattern="nonexist.*.txt"
+
+[ana:grepper.SingleCommandPattern(Test of File-Command Pattern Success)]
+command="cat {0}"
+files=kgo.txt
+pattern=".*Oxygen.*"
+
+[ana:grepper.SingleCommandPattern(Test of File-Command Pattern Failure)]
+command="cat {0}"
+files=kgo.txt
+pattern=".*NonExistent.*"
+
+[ana:grepper.SingleCommandPattern(Test of File-Command Fail but Pattern Success)]
+command="cmp {0} {1}"
+files=kgo.txt
+     =results.txt
+pattern=".*differ.*"
+
+[ana:grepper.FileCommandPattern(Test of Multi-Command Success)]
+command="stat {0}"
+files=kgo.txt
+     =results.txt
+pattern="Access: \((.*?)\)"
+
+[ana:grepper.FileCommandPattern(Test of Multi-Command Failure)]
+command="stat {0}"
+files=kgo.txt
+     =results.txt
+pattern="Size: (\S+)"
+
+[ana:grepper.FilePattern(Test of Multi-Group Success)]
+files=kgo.txt
+     =results.txt
+pattern='Known planet races:\s+(\S+)\s+(\S+)\s+(\S+)\s+(\S+)'
+kgo_file=0
+
+[ana:grepper.FilePattern(Test of Multi-Group Failure)]
+files=kgo.txt
+     =results.txt
+pattern='Friendly planet races:\s+(\S+)\s+(\S+)\s+(\S+)'
+kgo_file=0
+
+[ana:grepper.FilePattern(Test of Multi-Group Multi-Occurence Success)]
+files=kgo.txt
+     =results.txt
+pattern='planet races:\s+(\S+)\s+(\S+)'
+kgo_file=0
+
+[ana:grepper.FilePattern(Test of Multi-Group Multi-Occurence Failure)]
+files=kgo.txt
+     =results.txt
+pattern='planet races:\s+(\S+)\s+(\S+)\s(\S+)'
+kgo_file=0
+

--- a/t/rose-ana/00-run-basic/suite.rc
+++ b/t/rose-ana/00-run-basic/suite.rc
@@ -14,6 +14,7 @@ UTC mode=True
           rose_ana_t3_within_tolerance & rose_ana_t3_outside_tolerance:fail => \
           rose_ana_t1:fail & rose_ana_t2_deactivated => db_check
           rose_ana_t4
+          rose_ana_t5
         """
 
 [runtime]
@@ -37,6 +38,9 @@ UTC mode=True
             TOLERANCE=2%
 
     [[rose_ana_t4]]
+        script = rose task-run -v -v --debug
+
+    [[rose_ana_t5]]
         script = rose task-run -v -v --debug
 
     [[db_check]]


### PR DESCRIPTION
We have a few cases in our test suite of rose-ana taking a long time - typically when doing lots of file comparisons (in the worst case a rose-ana task with ~20 operations had 4 or 5 that took ~10 minutes each, for a total runtime of over an hour)

It seems like an easy win for all rose-ana users to make it able to run operations in parallel.  Given the way the analysis tasks are written (as classes/plugins) it seems it would lend itself most nicely to multi-threading rather than multi-process (despite the process approach generally being easier to manage)