### PR TITLE
metadata: clarify mini-language 'in' operator behaviour

### DIFF
--- a/sphinx/api/configuration/metadata.rst
+++ b/sphinx/api/configuration/metadata.rst
@@ -1106,6 +1106,14 @@ simple rules for variable values.
 Operators
 ^^^^^^^^^
 
+The following *logical* operators are supported:
+
+.. code-block:: python
+
+   and   # Logical AND
+   or    # Logical OR
+   not   # Logical NOT
+
 The following *numeric* operators are supported:
 
 .. code-block:: python
@@ -1125,8 +1133,6 @@ The following *string* operators are supported:
    +      # concatenate - e.g. "foo" + "bar" implies "foobar"
    *      # self-concatenate some number of times - e.g. "foo" * 2 implies "foofoo"
    %      # formatting - e.g. "foo %s baz" % "bar" implies "foo bar baz"
-   in     # contained in (True/False) - e.g. "oo" in "foobar" implies True
-   not in # opposite sense of in
 
    # Where m, n are integers or expressions that evaluate to integers
    # (negative numbers count from the end of the string):
@@ -1134,14 +1140,6 @@ The following *string* operators are supported:
    [m:n] # get slice of string from m to n - e.g. "foobar"[1:5] implies "ooba"
    [m:]  # get slice of string from m onwards - e.g. "foobar"[1:] implies "oobar"
    [:n]  # get slice of string up to n - e.g. "foobar"[:5] implies "fooba"
-
-The following *logical* operators are supported:
-
-.. code-block:: python
-
-   and   # Logical AND
-   or    # Logical OR
-   not   # Logical NOT
 
 The following *comparison* operators are supported:
 
@@ -1155,9 +1153,39 @@ The following *comparison* operators are supported:
    <=    # Less than or equal to
    !=    # Not equal to
 
-Operator precedence is intended to be the same as Python. However, with the
-current choice of language engine, the ``%`` and ``//`` operators may not
-obey this - make sure you force the correct behaviour using brackets.
+The following *membership* operator is supported:
+
+.. code-block:: python
+
+   in     # contained in (True/False)
+   # e.g. "oo" in "foobar" implies True; "foo" in ["bar", "baz"] implies False
+
+   # To test for lack of membership, combine with the "not" logical operator:
+   not in # not contained in, i.e. the opposite to that described above
+
+.. tip::
+   The ``in`` operator functions as it does in Python, testing for membership
+   in a collection which can be a sequence or string. This means that you
+   must contain value(s) to test for in a list, like so:
+
+   .. code-block:: python
+
+      this in ['that']  # equivalent to: this == 'that'
+
+   rather than comparing to the bare value(s):
+
+   .. code-block:: python
+
+      this in 'that'
+
+   as the latter will test that the setting is contained in the string 'that',
+   i.e. that it is one of the characters 't', 'h' and 'a'.
+
+.. note::
+
+   Operator precedence is intended to be the same as Python. However, with the
+   current choice of language engine, the ``%`` and ``//`` operators may not
+   obey this - make sure you force the correct behaviour using brackets.
 
 Constants
 ^^^^^^^^^

--- a/sphinx/api/configuration/metadata.rst
+++ b/sphinx/api/configuration/metadata.rst
@@ -3,7 +3,7 @@
 
 .. _floating point: https://docs.python.org/3/library/stdtypes.html#typesnumeric
 .. _cast: https://docs.python.org/2/library/ast.html#ast.literal_eval
-
+.. _Python in operator: https://docs.python.org/3/reference/expressions.html#membership-test-operations
 
 .. _Metadata:
 .. _conf-meta:
@@ -1164,22 +1164,20 @@ The following *membership* operator is supported:
    not in # not contained in, i.e. the opposite to that described above
 
 .. tip::
-   The ``in`` operator functions as it does in Python, testing for membership
-   in a collection which can be a sequence or string. This means that you
-   must contain value(s) to test for in a list, like so:
+   The ``in`` operator functions `as it does in Python <Python in operator>`_.
+   Note the difference between testing if a setting's value is equal to some
+   possibility contained within a collection, for example as in:
 
    .. code-block:: python
 
-      this in ['that']  # equivalent to: this == 'that'
+      place in ['here', 'there']  # i.e: place == 'here' or place == 'there'
 
-   rather than comparing to the bare value(s):
+   and testing if it is a substring, as in:
 
    .. code-block:: python
 
-      this in 'that'
+      place in 'there'  # place could be 'there', 'here', 'er', 'the', etc.
 
-   as the latter will test that the setting is contained in the string 'that',
-   i.e. that it is one of the characters 't', 'h' and 'a'.
 
 .. note::
 


### PR DESCRIPTION
Several users have been confused about the behaviour of logical tests involving the membership operator ``in``. Specifically, ultimately many have assumed (e.g. ``trigger=env=``...) ``SETTING: this in 'VALUE'`` would evaluate  identically to ``SETTING: 'VALUE'``.

Looking at the documentation, I think we can make the Pythonic nature of ``in`` clearer by segregating it as a distinct test under an explicit "membership" title & providing some examples, as attempted here. Especially since many (most?) of our users are most familiar with FORTRAN, which doesn't seem to have an equivalent/similar operator, so it's behaviour might be non-intuitive to them.

Please let me know if I can make this clearer in any way. I wasn't sure if it was best to use an example with the smallest list allowing for relevant clarification (``this in ['that']``, as I went for) or to include more than one value to test against in the list, which would be the usual usage scenario. Thoughts would be welcome on that.

Feel free to demote the milestone, which I chose since this is documentation-based & trivial.