### PR TITLE
Rose fileinstall async (failing codecov)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ install:
         libdbi-perl libdbd-sqlite3-perl latexmk texlive
         texlive-generic-extra texlive-latex-extra texlive-fonts-recommended
     - pip install tornado EmPy Jinja2 requests sqlalchemy pycodestyle python-jose pyzmq colorama pillow
+    - pip install cherrypy EmPy Jinja2 requests sqlalchemy pycodestyle python-jose pyzmq colorama pillow aiofiles
     - pip install pygraphviz --install-option="--include-path=/usr/include/graphviz" --install-option="--library-path=/usr/lib/graphviz/"
     - sudo sh -c 'echo "deb http://opensource.wandisco.com/ubuntu `lsb_release -cs` svn19" >> /etc/apt/sources.list.d/subversion19.list'
     - sudo wget -q http://opensource.wandisco.com/wandisco-debian.gpg -O- | sudo apt-key add -

--- a/bin/rose-check-software
+++ b/bin/rose-check-software
@@ -286,7 +286,8 @@ def main(check=check):
     ret = check_all('Required Software', [
         check('python3', (3, 6), version_template=r'Python (.*)'),
         check('cylc', (8,)),
-        check('py:jinja2')
+        check('py:jinja2'),
+        check('py:aiofiles')
     ])
 
     check_all('Rosie', [

--- a/lib/python/rose/loc_handlers/fs.py
+++ b/lib/python/rose/loc_handlers/fs.py
@@ -54,7 +54,7 @@ class FileSystemLocHandler(object):
             loc.loc_type = loc.TYPE_TREE
 
     @classmethod
-    def pull(cls, loc, _):
+    async def pull(cls, loc, _):
         """If loc is in the file system, sets loc.cache to loc.name.
 
         Otherwise, raise an OSError.

--- a/lib/python/rose/loc_handlers/namelist.py
+++ b/lib/python/rose/loc_handlers/namelist.py
@@ -66,7 +66,7 @@ class NamelistLocHandler(object):
             raise ValueError(loc.name)
         return sections
 
-    def pull(self, loc, conf_tree):
+    async def pull(self, loc, conf_tree):
         """Write namelist to loc.cache."""
         sections = self.parse(loc, conf_tree)
         if loc.name.endswith("(:)"):

--- a/lib/python/rose/loc_handlers/rsync.py
+++ b/lib/python/rose/loc_handlers/rsync.py
@@ -112,10 +112,10 @@ elif os.path.isfile(path):
                         name, mtime, size)
                 loc.add_path(name, fake_sum, access_mode)
 
-    def pull(self, loc, _):
+    async def pull(self, loc, _):
         """Run "rsync" to pull files or directories of loc to its cache."""
         name = loc.name
         if loc.loc_type == loc.TYPE_TREE:
             name = loc.name + "/"
         cmd = self.manager.popen.get_cmd("rsync", name, loc.cache)
-        self.manager.popen(*cmd)
+        await self.manager.popen.run_ok_async(*cmd)

--- a/lib/python/rose/loc_handlers/svn.py
+++ b/lib/python/rose/loc_handlers/svn.py
@@ -65,11 +65,12 @@ class SvnLocHandler(object):
         loc.real_name = "%s@%s" % (info_entry["url"], info_entry["revision"])
         loc.key = info_entry["commit:revision"]
 
-    def pull(self, loc, conf_tree):
+    async def pull(self, loc, conf_tree):
         """Run "svn export" to get loc to its cache."""
         if not loc.real_name:
             self.parse(loc, conf_tree)
-        self.manager.popen("svn", "export", "-q", loc.real_name, loc.cache)
+        await self.manager.popen.run_ok_async(
+            "svn", "export", "-q", loc.real_name, loc.cache)
 
 
 class SvnInfoXMLParser(object):

--- a/t/rose-app-run/06-namelist.t
+++ b/t/rose-app-run/06-namelist.t
@@ -177,23 +177,27 @@ test_teardown
 TEST_KEY=$TEST_KEY_BASE-install-only
 test_setup
 run_pass "$TEST_KEY" rose app-run --config=../config -i --debug
-file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<__CONTENT__
-[INFO] export PATH=$PATH
-[INFO] install: vegetables.nl
-[INFO]     source: namelist:vegetables{green}(:)
-[INFO] install: shopping-list.nl
-[INFO]     source: namelist:shopping_list(:)
-[INFO] install: shopping-list-2.nl
-[INFO]     source: namelist:shopping_list(10)
+python3 -c "import re, sys
+print(''.join(sorted(sys.stdin.readlines())))" \
+    <"$TEST_KEY.out" >"$TEST_KEY.sorted.out"
+file_cmp "$TEST_KEY.out" "$TEST_KEY.sorted.out" <<__CONTENT__
+[INFO]     source: namelist:empty
+[INFO]     source: namelist:empty
+[INFO]     source: namelist:hello
+[INFO]     source: namelist:hello
 [INFO]     source: namelist:shopping_list(1)
-[INFO] install: hello.nl
-[INFO]     source: namelist:hello
-[INFO] install: empty.nl
-[INFO]     source: namelist:empty
-[INFO] install: empty-and-hello.nl
-[INFO]     source: namelist:empty
-[INFO]     source: namelist:hello
+[INFO]     source: namelist:shopping_list(10)
+[INFO]     source: namelist:shopping_list(:)
+[INFO]     source: namelist:vegetables{green}(:)
 [INFO] command: mkdir out && cp *.nl out/
+[INFO] export PATH=$PATH
+[INFO] install: empty-and-hello.nl
+[INFO] install: empty.nl
+[INFO] install: hello.nl
+[INFO] install: shopping-list-2.nl
+[INFO] install: shopping-list.nl
+[INFO] install: vegetables.nl
+
 __CONTENT__
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
 test_teardown


### PR DESCRIPTION
Early efforts to implement rose-fileinstall with asyncio.

## Evidence that this is doing something worthwhile:
I created a wee script
```bash
#!/bin/bash
# slow_svn - a deliberately sabotaged version of SVN
sleep 10
svn "$@"
exit
```
and changed the reference in `loc_handlers/svn.py` to use this script rather than SVN proper. Using a test setup from `t/rose-app-run/11-file-incr-2.t` I ran:
`/usr/bin/time -v rose app-run --config=../config -q`

Which gave the following results:

| Measure | Master | This Branch |
| ---| ---:| ---: |
| User time (seconds) | 12.16 | 12.71 |
| System time (seconds) | 1.72 | 1.90 |
| Percent of CPU this job got | 15% | 58% |
| Elapsed (wall clock) time (h:mm:ss or m:ss) | 1:31.83 | 0:24.85 |

