### PR TITLE
Handle cylc-flow as a module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,12 +9,11 @@ dist: xenial
 
 
 before_install:
-    - wget 'https://github.com/cylc/cylc-flow/archive/master.tar.gz' -O '/tmp/cylc-master.tar.gz'
-    - tar -xvf '/tmp/cylc-master.tar.gz' -C "${HOME}"
-    - mv "${HOME}/cylc-flow-master" "${HOME}/cylc-master"
+    - wget 'https://github.com/cylc/cylc-flow/archive/master.tar.gz' -O - | tar -xz -C "${HOME}"
+    - pip install -e "${HOME}/cylc-flow-master"
     - wget 'https://github.com/metomi/fcm/archive/master.tar.gz' -O '/tmp/fcm-master.tar.gz'
     - tar -xvf '/tmp/fcm-master.tar.gz' -C "${HOME}"
-    - cat >"${HOME}/.bashrc" <<<"export PATH=${PWD}/bin:${HOME}/fcm-master/bin:${HOME}/cylc-master/bin:\$PATH"
+    - echo "export PATH=${PWD}/bin:${HOME}/fcm-master/bin:\${PATH}" >"${HOME}/.bashrc"
     - source "${HOME}/.bashrc"
     - ssh-keygen -t 'rsa' -f "${HOME}/.ssh/id_rsa" -N '' -q
     - cat "${HOME}/.ssh/id_rsa.pub" >>"${HOME}/.ssh/authorized_keys"


### PR DESCRIPTION
Now that cylc/cylc-flow#2990 is merged, we should install cylc-flow in a different way for Travis CI.