### PR TITLE
Refactor loading of define overrides

### DIFF
--- a/lib/python/rose/config.py
+++ b/lib/python/rose/config.py
@@ -97,6 +97,7 @@ from rose.env import env_var_escape
 import shlex
 import sys
 from tempfile import NamedTemporaryFile, TemporaryFile
+from tempfile import NamedTemporaryFile, SpooledTemporaryFile
 
 
 CHAR_ASSIGN = "="
@@ -1193,7 +1194,7 @@ class ConfigLoader(object):
 
     def load_with_opts(self, source, node=None, more_keys=None,
                        used_keys=None, return_config_map=False,
-                       mark_opt_confs=False):
+                       mark_opt_confs=False, defines=None):
         """Read a source configuration file with optional configurations.
 
         Arguments:
@@ -1216,6 +1217,7 @@ class ConfigLoader(object):
                 a dict (config_map) containing config names vs their uncombined
                 nodes. Optional configurations use their opt keys as keys, and
                 the main configuration uses 'None'.
+            defines (list - optional): A list of [SECTION]KEY=VALUE overrides.
 
         Returns:
             tuple: node or (node, config_map):
@@ -1263,6 +1265,8 @@ class ConfigLoader(object):
 
         """
         node = self.load(source, node)
+        if defines is not None:
+            node = self.load(defines, node)  # enable opts override
         if return_config_map:
             config_map = {None: copy.deepcopy(node)}
         opt_conf_keys_node = node.unset(["opts"])
@@ -1304,45 +1308,18 @@ class ConfigLoader(object):
                     used_keys.append(key)
                 if return_config_map:
                     config_map[key] = self.load(opt_conf_file_name)
+        if defines is not None:
+            node = self.load(defines, node)
         if return_config_map:
             return node, config_map
-        return node
-
-    def load_defines(self, defines, node=None):
-        """Read configuration from a list of command line defines.
-
-        Arguments:
-            defines (list): A list of [SECTION]KEY=VALUE items.
-            node (ConfigNode - optional): A ConfigNode object if specified,
-                otherwise one is created.
-
-        Returns:
-            ConfigNode: A new ConfigNode object.
-        """
-        # N.B. In theory, we should write the values in "defines" to
-        # "node" directly. However, the values in "defines" may contain
-        # "ignore" flags. Rather than replicating the logic for parsing
-        # ignore flags, it is actually easier to write the values in
-        # "defines" to a file and pass it to the loader to parse it.
-        source = TemporaryFile()
-        for define in defines:
-            sect, key, value = self.RE_OPT_DEFINE.match(define).groups()
-            if sect is None:
-                sect = ""
-            if value is None:
-                value = ""
-            source.write("[%s]\n" % sect)
-            if key is not None:
-                source.write("%s=%s\n" % (key, value))
-        source.seek(0)
-        node = self.load(source, node)
         return node
 
     def load(self, source, node=None, default_comments=None):
         """Read a source configuration file.
 
         Arguments:
-            source (str): An open file handle or a string for a file path.
+            source (str): An open file handle, a string for a file path or
+                a list of [SECTION]KEY=VALUE items.
             node (ConfigNode): A ConfigNode object if specified, otherwise
                 created.
 
@@ -1509,9 +1486,23 @@ class ConfigLoader(object):
                 file_name = file_.name
             except AttributeError:
                 file_name = self.UNKNOWN_NAME
-        else:
+        elif isinstance(file_, str):
             file_name = os.path.abspath(file_)
             file_ = open(file_name, "r")
+        else:
+            defines = file_
+            file_ = SpooledTemporaryFile()
+            file_name = self.UNKNOWN_NAME
+            for define in defines:
+                sect, key, value = self.RE_OPT_DEFINE.match(define).groups()
+                if sect is None:
+                    sect = ""
+                if value is None:
+                    value = ""
+                file_.write(("[%s]\n" % sect).encode())
+                if key is not None:
+                    file_.write(("%s=%s\n" % (key, value)).encode())
+            file_.seek(0)
         return (file_, file_name)
 
 

--- a/lib/python/rose/config.py
+++ b/lib/python/rose/config.py
@@ -96,7 +96,6 @@ import re
 from rose.env import env_var_escape
 import shlex
 import sys
-from tempfile import NamedTemporaryFile, TemporaryFile
 from tempfile import NamedTemporaryFile, SpooledTemporaryFile
 
 

--- a/lib/python/rose/config_tree.py
+++ b/lib/python/rose/config_tree.py
@@ -81,7 +81,7 @@ class ConfigTreeLoader(object):
         self.node_loader = ConfigLoader(*args, **kwargs)
 
     def load(self, conf_dir, conf_name, conf_dir_paths=None, opt_keys=None,
-             conf_node=None, no_ignore=False):
+             conf_node=None, no_ignore=False, defines=None):
         """Load a (runtime) configuration directory with inheritance.
 
         Return a ConfigTree object that represents the result.
@@ -95,6 +95,7 @@ class ConfigTreeLoader(object):
         conf_node -- A rose.config.ConfigNode to extend, or None to use a
                      fresh one.
         no_ignore -- If True, skip loading ignored config settings.
+        defines -- A list of [SECTION]KEY=VALUE overrides.
 
         """
 
@@ -105,7 +106,8 @@ class ConfigTreeLoader(object):
         conf_file_name = os.path.join(conf_dir, conf_name)
         used_keys = []
         nodes[conf_dir] = self.node_loader.load_with_opts(
-            conf_file_name, more_keys=opt_keys, used_keys=used_keys)
+            conf_file_name, more_keys=opt_keys, used_keys=used_keys,
+            defines=defines)
 
         conf_tree = ConfigTree()
         conf_tree.conf_dirs = mro(

--- a/lib/python/rose/run.py
+++ b/lib/python/rose/run.py
@@ -160,12 +160,8 @@ class Runner(object):
             getattr(opts, 'defines_suite', [])))
 
         conf_tree = self.conf_tree_loader.load(conf_dir, conf_name,
-                                               opt_keys=opt_conf_keys)
-
-        # Optional defines
-        if opts.defines:
-            self.conf_tree_loader.node_loader.load_defines(opts.defines,
-                                                           conf_tree.node)
+                                               opt_keys=opt_conf_keys,
+                                               defines=opts.defines)
         return conf_tree
 
     def run(self, opts, args):

--- a/lib/python/rose/suite_run.py
+++ b/lib/python/rose/suite_run.py
@@ -191,8 +191,7 @@ class SuiteRunner(Runner):
             extra_defines.append('[%s]%s="%s"' % (suite_section, key, val))
 
         # Pass automatic Rose constants as suite defines
-        self.conf_tree_loader.node_loader.load_defines(extra_defines,
-                                                       conf_tree.node)
+        self.conf_tree_loader.node_loader.load(extra_defines, conf_tree.node)
 
         # See if suite is running or not
         if opts.run_mode == "reload":

--- a/t/rose-app-run/26-define-overrides.t
+++ b/t/rose-app-run/26-define-overrides.t
@@ -1,0 +1,81 @@
+#!/bin/bash
+#-------------------------------------------------------------------------------
+# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+#
+# This file is part of Rose, a framework for meteorological suites.
+#
+# Rose is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Rose is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Rose. If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test "rose app-run", command line define of opts and import keys.
+#-------------------------------------------------------------------------------
+. $(dirname $0)/test_header
+test_init <<'__CONFIG__'
+opts=foo
+import=non-existing-config
+[command]
+default = rose config -f rose-app-run.conf env
+[env]
+FOO = foo
+__CONFIG__
+mkdir -p config/opt
+cat >config/opt/rose-app-foo.conf <<'__CONFIG__'
+[env]
+FOO = foolish fool
+__CONFIG__
+#-------------------------------------------------------------------------------
+tests 6
+#-------------------------------------------------------------------------------
+# Undefine in-place import.
+TEST_KEY=$TEST_KEY_BASE-control
+test_setup
+run_pass "$TEST_KEY" rose app-run --config=../config --define='!import' -q
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<'__CONTENT__'
+FOO=foolish fool
+__CONTENT__
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+test_teardown
+#-------------------------------------------------------------------------------
+# Redefine import and undefine in-place optional configuration.
+TEST_KEY=$TEST_KEY_BASE-define-no-opts
+test_setup
+mkdir -p ../config2/opt ../config3
+cat >../config2/rose-app.conf <<'__CONFIG__'
+opts = bar
+[command]
+default = true
+[env]
+FOO = foo fighter
+BAR = bar
+__CONFIG__
+cat >../config2/opt/rose-app-bar.conf <<'__CONFIG__'
+import = config3
+[env]
+BAR = barman
+__CONFIG__
+cat >../config3/rose-app.conf <<'__CONFIG__'
+[env]
+BAZ = buzzing
+__CONFIG__
+run_pass "$TEST_KEY" rose app-run --config=../config \
+    --define='!opts' --define='import=config2' -q
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<'__CONTENT__'
+BAR=barman
+BAZ=buzzing
+FOO=foo
+__CONTENT__
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+rm -r ../config2 ../config3
+test_teardown
+#-------------------------------------------------------------------------------
+exit


### PR DESCRIPTION
For {suite,app,task}-run commands one can override config setting on the command line with `--define [section]key=value` options. This doesn't work, however, for some special, top-level keys like `opts` or `import` because applying these overrides happens too late in the config loading process. This PR removes this limitation.