### PR TITLE
[7.x] cylc tutorial: don't depend on PYTHONPATH being defined

### DIFF
--- a/etc/tutorial/consolidation-tutorial/suite.rc
+++ b/etc/tutorial/consolidation-tutorial/suite.rc
@@ -57,7 +57,7 @@
         script = consolidate-observations
         [[[environment]]]
             # Add the `python` directory to the PYTHONPATH.
-            PYTHONPATH="$CYLC_SUITE_RUN_DIR/lib/python:$PYTHONPATH"
+            PYTHONPATH="$CYLC_SUITE_RUN_DIR/lib/python:${PYTHONPATH:-}"
             # The dimensions of each grid cell in degrees.
             RESOLUTION = 0.2
             # The area to generate forecasts for (lng1, lat1, lng2, lat2)
@@ -70,7 +70,7 @@
             # To use archived data comment this line out.
             API_KEY = DATAPOINT_API_KEY
             # Add the `python` directory to the PYTHONPATH.
-            PYTHONPATH="$CYLC_SUITE_RUN_DIR/lib/python:$PYTHONPATH"
+            PYTHONPATH="$CYLC_SUITE_RUN_DIR/lib/python:${PYTHONPATH:-}"
             # The dimensions of each grid cell in degrees.
             RESOLUTION = 0.2
             # The area to generate forecasts for (lng1, lat1, lng2, lat2)
@@ -80,7 +80,7 @@
         script = forecast 60 5  # Generate 5 forecasts at 60 minute intervals.
         [[[environment]]]
             # Add the `python` directory to the PYTHONPATH.
-            PYTHONPATH="$CYLC_SUITE_RUN_DIR/lib/python:$PYTHONPATH"
+            PYTHONPATH="$CYLC_SUITE_RUN_DIR/lib/python:${PYTHONPATH:-}"
             # The dimensions of each grid cell in degrees.
             RESOLUTION = 0.2
             # The area to generate forecasts for (lng1, lat1, lng2, lat2)
@@ -102,7 +102,7 @@
         script = post-process exeter 60
         [[[environment]]]
             # Add the `python` directory to the PYTHONPATH.
-            PYTHONPATH="$CYLC_SUITE_RUN_DIR/lib/python:$PYTHONPATH"
+            PYTHONPATH="$CYLC_SUITE_RUN_DIR/lib/python:${PYTHONPATH:-}"
             # The dimensions of each grid cell in degrees.
             RESOLUTION = 0.2
             # The area to generate forecasts for (lng1, lat1, lng2, lat2)

--- a/etc/tutorial/cylc-forecasting-suite/suite.rc
+++ b/etc/tutorial/cylc-forecasting-suite/suite.rc
@@ -39,7 +39,7 @@
         # These environment variables will be available to all tasks.
         [[[environment]]]
             # Add the `python` directory to the PYTHONPATH.
-            PYTHONPATH="$CYLC_SUITE_RUN_DIR/lib/python:$PYTHONPATH"
+            PYTHONPATH="$CYLC_SUITE_RUN_DIR/lib/python:${PYTHONPATH:-}"
             # The dimensions of each grid cell in degrees.
             RESOLUTION = 0.2
             # The area to generate forecasts for (lng1, lat1, lng2, lat2)

--- a/etc/tutorial/rose-weather-forecasting-suite/suite.rc
+++ b/etc/tutorial/rose-weather-forecasting-suite/suite.rc
@@ -38,7 +38,7 @@
         # These environment variables will be available to all tasks.
         [[[environment]]]
             # Add the `python` directory to the PYTHONPATH.
-            PYTHONPATH="$CYLC_SUITE_RUN_DIR/lib/python:$PYTHONPATH"
+            PYTHONPATH="$CYLC_SUITE_RUN_DIR/lib/python:${PYTHONPATH:-}"
 
     [[get_observations<station>]]
         script = get-observations

--- a/etc/tutorial/runtime-tutorial/runtime
+++ b/etc/tutorial/runtime-tutorial/runtime
@@ -2,7 +2,7 @@
         script = consolidate-observations
         [[[environment]]]
             # Add the `python` directory to the PYTHONPATH.
-            PYTHONPATH="$CYLC_SUITE_RUN_DIR/lib/python:$PYTHONPATH"
+            PYTHONPATH="$CYLC_SUITE_RUN_DIR/lib/python:${PYTHONPATH:-}"
             # The dimensions of each grid cell in degrees.
             RESOLUTION = 0.2
             # The area to generate forecasts for (lng1, lat1, lng2, lat2)
@@ -15,7 +15,7 @@
             # To use archived data comment this line out.
             API_KEY = DATAPOINT_API_KEY
             # Add the `python` directory to the PYTHONPATH.
-            PYTHONPATH="$CYLC_SUITE_RUN_DIR/lib/python:$PYTHONPATH"
+            PYTHONPATH="$CYLC_SUITE_RUN_DIR/lib/python:${PYTHONPATH:-}"
             # The dimensions of each grid cell in degrees.
             RESOLUTION = 0.2
             # The area to generate forecasts for (lng1, lat1, lng2, lat2)
@@ -25,7 +25,7 @@
         script = forecast 60 5  # Generate 5 forecasts at 60 minute intervals.
         [[[environment]]]
             # Add the `python` directory to the PYTHONPATH.
-            PYTHONPATH="$CYLC_SUITE_RUN_DIR/lib/python:$PYTHONPATH"
+            PYTHONPATH="$CYLC_SUITE_RUN_DIR/lib/python:${PYTHONPATH:-}"
             # The dimensions of each grid cell in degrees.
             RESOLUTION = 0.2
             # The area to generate forecasts for (lng1, lat1, lng2, lat2)
@@ -48,7 +48,7 @@
         script = post-process exeter 60
         [[[environment]]]
             # Add the `python` directory to the PYTHONPATH.
-            PYTHONPATH="$CYLC_SUITE_RUN_DIR/lib/python:$PYTHONPATH"
+            PYTHONPATH="$CYLC_SUITE_RUN_DIR/lib/python:${PYTHONPATH:-}"
             # The dimensions of each grid cell in degrees.
             RESOLUTION = 0.2
             # The area to generate forecasts for (lng1, lat1, lng2, lat2)

--- a/sphinx/tutorial/cylc/runtime/configuration-consolidation/families.rst
+++ b/sphinx/tutorial/cylc/runtime/configuration-consolidation/families.rst
@@ -249,7 +249,7 @@ Families and ``cylc graph``
 
       .. code-block:: none
 
-         PYTHONPATH="$CYLC_SUITE_DEF_PATH/lib/python:$PYTHONPATH"
+         PYTHONPATH="$CYLC_SUITE_DEF_PATH/lib/python:${PYTHONPATH:-}"
          RESOLUTION = 0.2
          DOMAIN = -12,48,5,61  # Do not change!
 
@@ -265,7 +265,7 @@ Families and ``cylc graph``
          +    [[root]]
          +        [[[environment]]]
          +            # Add the `python` directory to the PYTHONPATH.
-         +            PYTHONPATH="$CYLC_SUITE_DEF_PATH/lib/python:$PYTHONPATH"
+         +            PYTHONPATH="$CYLC_SUITE_DEF_PATH/lib/python:${PYTHONPATH:-}"
          +            # The dimensions of each grid cell in degrees.
          +            RESOLUTION = 0.2
          +            # The area to generate forecasts for (lng1, lat1, lng2, lat2).
@@ -277,7 +277,7 @@ Families and ``cylc graph``
               script = consolidate-observations
          -    [[[environment]]]
          -        # Add the `python` directory to the PYTHONPATH.
-         -        PYTHONPATH="$CYLC_SUITE_RUN_DIR/lib/python:$PYTHONPATH"
+         -        PYTHONPATH="$CYLC_SUITE_RUN_DIR/lib/python:${PYTHONPATH:-}"
          -        # The dimensions of each grid cell in degrees.
          -        RESOLUTION = 0.2
          -        # The area to generate forecasts for (lng1, lat1, lng2, lat2).
@@ -290,7 +290,7 @@ Families and ``cylc graph``
                   # To use archived data comment this line out.
                   API_KEY = xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
          -        # Add the `python` directory to the PYTHONPATH.
-         -        PYTHONPATH="$CYLC_SUITE_RUN_DIR/lib/python:$PYTHONPATH"
+         -        PYTHONPATH="$CYLC_SUITE_RUN_DIR/lib/python:${PYTHONPATH:-}"
          -        # The dimensions of each grid cell in degrees.
          -        RESOLUTION = 0.2
          -        # The area to generate forecasts for (lng1, lat1, lng2, lat2).
@@ -300,7 +300,7 @@ Families and ``cylc graph``
               script = forecast 60 5  # Generate 5 forecasts at 60 minute intervals.
               [[[environment]]]
          -        # Add the `python` directory to the PYTHONPATH.
-         -        PYTHONPATH="$CYLC_SUITE_RUN_DIR/lib/python:$PYTHONPATH"
+         -        PYTHONPATH="$CYLC_SUITE_RUN_DIR/lib/python:${PYTHONPATH:-}"
          -        # The dimensions of each grid cell in degrees.
          -        RESOLUTION = 0.2
          -        # The area to generate forecasts for (lng1, lat1, lng2, lat2)
@@ -323,7 +323,7 @@ Families and ``cylc graph``
               script = post-process exeter 60
          -    [[[environment]]]
          -        # Add the `python` directory to the PYTHONPATH.
-         -        PYTHONPATH="$CYLC_SUITE_RUN_DIR/lib/python:$PYTHONPATH"
+         -        PYTHONPATH="$CYLC_SUITE_RUN_DIR/lib/python:${PYTHONPATH:-}"
          -        # The dimensions of each grid cell in degrees.
          -        RESOLUTION = 0.2
          -        # The area to generate forecasts for (lng1, lat1, lng2, lat2).

--- a/sphinx/tutorial/rose/suites.rst
+++ b/sphinx/tutorial/rose/suites.rst
@@ -396,7 +396,7 @@ See the :ref:`Cheat Sheet` for more information.
                   # These environment variables will be available to all tasks.
                   [[[environment]]]
                       # Add the `python` directory to the PYTHONPATH.
-                      PYTHONPATH="$CYLC_SUITE_RUN_DIR/lib/python:$PYTHONPATH"
+                      PYTHONPATH="$CYLC_SUITE_RUN_DIR/lib/python:${PYTHONPATH:-}"
          -            # The dimensions of each grid cell in degrees.
          -            RESOLUTION = 0.2
          -            # The area to generate forecasts for (lng1, lat1, lng2, lat2).


### PR DESCRIPTION
Due to packaging changes Cylc no longer inserts itself PYTHONPATH meaning that PYTHONPATH could potentially be undefined.

This causes tutorial job scripts to break due to `set -u`.

Reported by @wxtim

**[edit]** on master remove `PYTHONPATH` altogether (in a follow-on PR) after https://github.com/cylc/cylc-flow/pull/3168