### PR TITLE
Suite variable dictionary containing all variables inserted in template

### DIFF
--- a/bin/rose-suite-run
+++ b/bin/rose-suite-run
@@ -117,11 +117,14 @@
 #         Each `KEY` in this space delimited list switches on an optional
 #         configuration. The configurations are applied first-to-last.
 #
-# JINJA2 VARIABLES
-#     `rose suite-run` provides the following Jinja2 variables to the suite.
+# SUITE VARIABLES
+#     `rose suite-run` provides the following variables to the suite.
 #
 #     ROSE_ORIG_HOST
 #         The name of the host where the `rose suite-run` command was invoked.
+#     ROSE_SUITE_VARIABLES
+#         Dictionary containing all suite variables inserted via
+#         `[jinja2:suite.rc]` or `[empy:suite.rc]` section.
 #
 # SEE ALSO
 #     * `cylc help gui`

--- a/bin/rose-suite-run
+++ b/bin/rose-suite-run
@@ -118,7 +118,8 @@
 #         configuration. The configurations are applied first-to-last.
 #
 # SUITE VARIABLES
-#     `rose suite-run` provides the following variables to the suite.
+#     `rose suite-run` provides the following variables to the suite as
+#      template variables (i.e. Jinja2 or EmPy).
 #
 #     ROSE_ORIG_HOST
 #         The name of the host where the `rose suite-run` command was invoked.

--- a/lib/python/rose/config_processors/empy.py
+++ b/lib/python/rose/config_processors/empy.py
@@ -27,7 +27,7 @@ class ConfigProcessorForEmPy(ConfigProcessorForJinja2):
     """Processor for [empy:FILE] sections in a runtime configuration."""
 
     SCHEME = "empy"
-    ASSIGN_TEMPL = "@{ %s=%s }@\n"
+    ASSIGN_TEMPL = "@{%s=%s}@\n"
     COMMENT_TEMPL = "@# %s\n"
 
 

--- a/lib/python/rose/config_processors/jinja2.py
+++ b/lib/python/rose/config_processors/jinja2.py
@@ -69,6 +69,7 @@ class ConfigProcessorForJinja2(ConfigProcessorBase):
             tmp_file = NamedTemporaryFile()
             tmp_file.write(scheme_ln)
             tmp_file.write(msg_init_ln)
+            suite_variables = ['{']
             for key, node in sorted(s_node.value.items()):
                 if node.is_ignored():
                     continue
@@ -77,6 +78,10 @@ class ConfigProcessorForJinja2(ConfigProcessorBase):
                 except UnboundEnvironmentVariableError as exc:
                     raise ConfigProcessError([s_key, key], node.value, exc)
                 tmp_file.write(self.ASSIGN_TEMPL % (key, value))
+                suite_variables.append("    '%s': %s," % (key, key))
+            suite_variables.append('}')
+            tmp_file.write(self.ASSIGN_TEMPL % ('ROSE_SUITE_VARIABLES',
+                                                '\n'.join(suite_variables)))
             environ = kwargs.get("environ")
             if environ:
                 tmp_file.write('[cylc]\n')

--- a/t/rose-suite-run/26-jinja2-insert.t
+++ b/t/rose-suite-run/26-jinja2-insert.t
@@ -62,6 +62,14 @@ for I in $(seq 1 $N_TESTS); do
 {% set ROSE_VERSION="$ROSE_VERSION" %}
 {% set bar="barley drink" %}
 {% set foo="food store" %}
+{% set ROSE_SUITE_VARIABLES={
+    'CYLC_VERSION': CYLC_VERSION,
+    'ROSE_ORIG_HOST': ROSE_ORIG_HOST,
+    'ROSE_SITE': ROSE_SITE,
+    'ROSE_VERSION': ROSE_VERSION,
+    'bar': bar,
+    'foo': foo,
+} %}
 [cylc]
     [[environment]]
         CYLC_VERSION=${CYLC_VERSION}

--- a/t/rose-suite-run/27-empy-insert.t
+++ b/t/rose-suite-run/27-empy-insert.t
@@ -61,12 +61,20 @@ for I in $(seq 1 $N_TESTS); do
     file_cmp "$TEST_KEY" "$SUITE_RUN_DIR/suite.rc" <<__SUITE_RC__
 #!empy
 @# Rose Configuration Insertion: Init
-@{ CYLC_VERSION="$CYLC_VERSION" }@
-@{ ROSE_ORIG_HOST="$ROSE_ORIG_HOST" }@
-@{ ROSE_SITE="" }@
-@{ ROSE_VERSION="$ROSE_VERSION" }@
-@{ baz=True }@
-@{ foo="food store" }@
+@{CYLC_VERSION="$CYLC_VERSION"}@
+@{ROSE_ORIG_HOST="$ROSE_ORIG_HOST"}@
+@{ROSE_SITE=""}@
+@{ROSE_VERSION="$ROSE_VERSION"}@
+@{baz=True}@
+@{foo="food store"}@
+@{ROSE_SUITE_VARIABLES={
+    'CYLC_VERSION': CYLC_VERSION,
+    'ROSE_ORIG_HOST': ROSE_ORIG_HOST,
+    'ROSE_SITE': ROSE_SITE,
+    'ROSE_VERSION': ROSE_VERSION,
+    'baz': baz,
+    'foo': foo,
+}}@
 [cylc]
     [[environment]]
         CYLC_VERSION=${CYLC_VERSION}

--- a/t/rose-suite-run/28-rose-site-env.t
+++ b/t/rose-suite-run/28-rose-site-env.t
@@ -59,6 +59,12 @@ for I in $(seq 1 "${N_TESTS}"); do
 {% set ROSE_ORIG_HOST="${ROSE_ORIG_HOST}" %}
 {% set ROSE_SITE="my-site" %}
 {% set ROSE_VERSION="${ROSE_VERSION}" %}
+{% set ROSE_SUITE_VARIABLES={
+    'CYLC_VERSION': CYLC_VERSION,
+    'ROSE_ORIG_HOST': ROSE_ORIG_HOST,
+    'ROSE_SITE': ROSE_SITE,
+    'ROSE_VERSION': ROSE_VERSION,
+} %}
 [cylc]
     [[environment]]
         CYLC_VERSION=${CYLC_VERSION}


### PR DESCRIPTION
Implements https://github.com/cylc/cylc-flow/issues/2960#issuecomment-466043979 - a special  `ROSE_SUITE_VARIABLES` Jinja2 (EmPy) dictionary containing all variables inserted in template, so that their names can be resolved in a programmatic way.
