### PR TITLE
tutorial suite: remove pythonpath

### DIFF
--- a/etc/tutorial/consolidation-tutorial/suite.rc
+++ b/etc/tutorial/consolidation-tutorial/suite.rc
@@ -60,8 +60,6 @@
     [[consolidate_observations]]
         script = consolidate-observations
         [[[environment]]]
-            # Add the `python` directory to the PYTHONPATH.
-            PYTHONPATH="$CYLC_SUITE_RUN_DIR/lib/python:${PYTHONPATH:-}"
             # The dimensions of each grid cell in degrees.
             RESOLUTION = 0.2
             # The area to generate forecasts for (lng1, lat1, lng2, lat2)
@@ -73,8 +71,6 @@
             # The key required to get weather data from the DataPoint service.
             # To use archived data comment this line out.
             API_KEY = DATAPOINT_API_KEY
-            # Add the `python` directory to the PYTHONPATH.
-            PYTHONPATH="$CYLC_SUITE_RUN_DIR/lib/python:${PYTHONPATH:-}"
             # The dimensions of each grid cell in degrees.
             RESOLUTION = 0.2
             # The area to generate forecasts for (lng1, lat1, lng2, lat2)
@@ -83,8 +79,6 @@
     [[forecast]]
         script = forecast 60 5  # Generate 5 forecasts at 60 minute intervals.
         [[[environment]]]
-            # Add the `python` directory to the PYTHONPATH.
-            PYTHONPATH="$CYLC_SUITE_RUN_DIR/lib/python:${PYTHONPATH:-}"
             # The dimensions of each grid cell in degrees.
             RESOLUTION = 0.2
             # The area to generate forecasts for (lng1, lat1, lng2, lat2)
@@ -105,8 +99,6 @@
         # Generate a forecast for Exeter 60 minutes in the future.
         script = post-process exeter 60
         [[[environment]]]
-            # Add the `python` directory to the PYTHONPATH.
-            PYTHONPATH="$CYLC_SUITE_RUN_DIR/lib/python:${PYTHONPATH:-}"
             # The dimensions of each grid cell in degrees.
             RESOLUTION = 0.2
             # The area to generate forecasts for (lng1, lat1, lng2, lat2)

--- a/etc/tutorial/consolidation-tutorial/suite.rc
+++ b/etc/tutorial/consolidation-tutorial/suite.rc
@@ -61,7 +61,7 @@
         script = consolidate-observations
         [[[environment]]]
             # Add the `python` directory to the PYTHONPATH.
-            PYTHONPATH="$CYLC_SUITE_RUN_DIR/lib/python:$PYTHONPATH"
+            PYTHONPATH="$CYLC_SUITE_RUN_DIR/lib/python:${PYTHONPATH:-}"
             # The dimensions of each grid cell in degrees.
             RESOLUTION = 0.2
             # The area to generate forecasts for (lng1, lat1, lng2, lat2)
@@ -74,7 +74,7 @@
             # To use archived data comment this line out.
             API_KEY = DATAPOINT_API_KEY
             # Add the `python` directory to the PYTHONPATH.
-            PYTHONPATH="$CYLC_SUITE_RUN_DIR/lib/python:$PYTHONPATH"
+            PYTHONPATH="$CYLC_SUITE_RUN_DIR/lib/python:${PYTHONPATH:-}"
             # The dimensions of each grid cell in degrees.
             RESOLUTION = 0.2
             # The area to generate forecasts for (lng1, lat1, lng2, lat2)
@@ -84,7 +84,7 @@
         script = forecast 60 5  # Generate 5 forecasts at 60 minute intervals.
         [[[environment]]]
             # Add the `python` directory to the PYTHONPATH.
-            PYTHONPATH="$CYLC_SUITE_RUN_DIR/lib/python:$PYTHONPATH"
+            PYTHONPATH="$CYLC_SUITE_RUN_DIR/lib/python:${PYTHONPATH:-}"
             # The dimensions of each grid cell in degrees.
             RESOLUTION = 0.2
             # The area to generate forecasts for (lng1, lat1, lng2, lat2)
@@ -106,7 +106,7 @@
         script = post-process exeter 60
         [[[environment]]]
             # Add the `python` directory to the PYTHONPATH.
-            PYTHONPATH="$CYLC_SUITE_RUN_DIR/lib/python:$PYTHONPATH"
+            PYTHONPATH="$CYLC_SUITE_RUN_DIR/lib/python:${PYTHONPATH:-}"
             # The dimensions of each grid cell in degrees.
             RESOLUTION = 0.2
             # The area to generate forecasts for (lng1, lat1, lng2, lat2)

--- a/etc/tutorial/cylc-forecasting-suite/suite.rc
+++ b/etc/tutorial/cylc-forecasting-suite/suite.rc
@@ -41,8 +41,6 @@
     [[root]]
         # These environment variables will be available to all tasks.
         [[[environment]]]
-            # Add the `python` directory to the PYTHONPATH.
-            PYTHONPATH="$CYLC_SUITE_RUN_DIR/lib/python:${PYTHONPATH:-}"
             # The dimensions of each grid cell in degrees.
             RESOLUTION = 0.2
             # The area to generate forecasts for (lng1, lat1, lng2, lat2)

--- a/etc/tutorial/cylc-forecasting-suite/suite.rc
+++ b/etc/tutorial/cylc-forecasting-suite/suite.rc
@@ -42,7 +42,7 @@
         # These environment variables will be available to all tasks.
         [[[environment]]]
             # Add the `python` directory to the PYTHONPATH.
-            PYTHONPATH="$CYLC_SUITE_RUN_DIR/lib/python:$PYTHONPATH"
+            PYTHONPATH="$CYLC_SUITE_RUN_DIR/lib/python:${PYTHONPATH:-}"
             # The dimensions of each grid cell in degrees.
             RESOLUTION = 0.2
             # The area to generate forecasts for (lng1, lat1, lng2, lat2)

--- a/etc/tutorial/rose-weather-forecasting-suite/suite.rc
+++ b/etc/tutorial/rose-weather-forecasting-suite/suite.rc
@@ -42,7 +42,7 @@
         # These environment variables will be available to all tasks.
         [[[environment]]]
             # Add the `python` directory to the PYTHONPATH.
-            PYTHONPATH="$CYLC_SUITE_RUN_DIR/lib/python:$PYTHONPATH"
+            PYTHONPATH="$CYLC_SUITE_RUN_DIR/lib/python:${PYTHONPATH:-}"
 
     [[get_observations<station>]]
         script = get-observations

--- a/etc/tutorial/rose-weather-forecasting-suite/suite.rc
+++ b/etc/tutorial/rose-weather-forecasting-suite/suite.rc
@@ -38,12 +38,6 @@
             """
 
 [runtime]
-    [[root]]
-        # These environment variables will be available to all tasks.
-        [[[environment]]]
-            # Add the `python` directory to the PYTHONPATH.
-            PYTHONPATH="$CYLC_SUITE_RUN_DIR/lib/python:${PYTHONPATH:-}"
-
     [[get_observations<station>]]
         script = get-observations
         [[[environment]]]

--- a/etc/tutorial/runtime-tutorial/runtime
+++ b/etc/tutorial/runtime-tutorial/runtime
@@ -1,8 +1,6 @@
     [[consolidate_observations]]
         script = consolidate-observations
         [[[environment]]]
-            # Add the `python` directory to the PYTHONPATH.
-            PYTHONPATH="$CYLC_SUITE_RUN_DIR/lib/python:${PYTHONPATH:-}"
             # The dimensions of each grid cell in degrees.
             RESOLUTION = 0.2
             # The area to generate forecasts for (lng1, lat1, lng2, lat2)
@@ -14,8 +12,6 @@
             # The key required to get weather data from the DataPoint service.
             # To use archived data comment this line out.
             API_KEY = DATAPOINT_API_KEY
-            # Add the `python` directory to the PYTHONPATH.
-            PYTHONPATH="$CYLC_SUITE_RUN_DIR/lib/python:${PYTHONPATH:-}"
             # The dimensions of each grid cell in degrees.
             RESOLUTION = 0.2
             # The area to generate forecasts for (lng1, lat1, lng2, lat2)
@@ -24,8 +20,6 @@
     [[forecast]]
         script = forecast 60 5  # Generate 5 forecasts at 60 minute intervals.
         [[[environment]]]
-            # Add the `python` directory to the PYTHONPATH.
-            PYTHONPATH="$CYLC_SUITE_RUN_DIR/lib/python:${PYTHONPATH:-}"
             # The dimensions of each grid cell in degrees.
             RESOLUTION = 0.2
             # The area to generate forecasts for (lng1, lat1, lng2, lat2)
@@ -47,8 +41,6 @@
         # Generate a forecast for Exeter 60 minutes in the future.
         script = post-process exeter 60
         [[[environment]]]
-            # Add the `python` directory to the PYTHONPATH.
-            PYTHONPATH="$CYLC_SUITE_RUN_DIR/lib/python:${PYTHONPATH:-}"
             # The dimensions of each grid cell in degrees.
             RESOLUTION = 0.2
             # The area to generate forecasts for (lng1, lat1, lng2, lat2)

--- a/etc/tutorial/runtime-tutorial/runtime
+++ b/etc/tutorial/runtime-tutorial/runtime
@@ -2,7 +2,7 @@
         script = consolidate-observations
         [[[environment]]]
             # Add the `python` directory to the PYTHONPATH.
-            PYTHONPATH="$CYLC_SUITE_RUN_DIR/lib/python:$PYTHONPATH"
+            PYTHONPATH="$CYLC_SUITE_RUN_DIR/lib/python:${PYTHONPATH:-}"
             # The dimensions of each grid cell in degrees.
             RESOLUTION = 0.2
             # The area to generate forecasts for (lng1, lat1, lng2, lat2)
@@ -15,7 +15,7 @@
             # To use archived data comment this line out.
             API_KEY = DATAPOINT_API_KEY
             # Add the `python` directory to the PYTHONPATH.
-            PYTHONPATH="$CYLC_SUITE_RUN_DIR/lib/python:$PYTHONPATH"
+            PYTHONPATH="$CYLC_SUITE_RUN_DIR/lib/python:${PYTHONPATH:-}"
             # The dimensions of each grid cell in degrees.
             RESOLUTION = 0.2
             # The area to generate forecasts for (lng1, lat1, lng2, lat2)
@@ -25,7 +25,7 @@
         script = forecast 60 5  # Generate 5 forecasts at 60 minute intervals.
         [[[environment]]]
             # Add the `python` directory to the PYTHONPATH.
-            PYTHONPATH="$CYLC_SUITE_RUN_DIR/lib/python:$PYTHONPATH"
+            PYTHONPATH="$CYLC_SUITE_RUN_DIR/lib/python:${PYTHONPATH:-}"
             # The dimensions of each grid cell in degrees.
             RESOLUTION = 0.2
             # The area to generate forecasts for (lng1, lat1, lng2, lat2)
@@ -48,7 +48,7 @@
         script = post-process exeter 60
         [[[environment]]]
             # Add the `python` directory to the PYTHONPATH.
-            PYTHONPATH="$CYLC_SUITE_RUN_DIR/lib/python:$PYTHONPATH"
+            PYTHONPATH="$CYLC_SUITE_RUN_DIR/lib/python:${PYTHONPATH:-}"
             # The dimensions of each grid cell in degrees.
             RESOLUTION = 0.2
             # The area to generate forecasts for (lng1, lat1, lng2, lat2)

--- a/sphinx/tutorial/cylc/runtime/configuration-consolidation/families.rst
+++ b/sphinx/tutorial/cylc/runtime/configuration-consolidation/families.rst
@@ -245,7 +245,7 @@ Families and ``cylc graph``
 
       .. code-block:: none
 
-         PYTHONPATH="$CYLC_SUITE_DEF_PATH/lib/python:$PYTHONPATH"
+         PYTHONPATH="$CYLC_SUITE_DEF_PATH/lib/python:${PYTHONPATH:-}"
          RESOLUTION = 0.2
          DOMAIN = -12,48,5,61  # Do not change!
 
@@ -261,7 +261,7 @@ Families and ``cylc graph``
          +    [[root]]
          +        [[[environment]]]
          +            # Add the `python` directory to the PYTHONPATH.
-         +            PYTHONPATH="$CYLC_SUITE_DEF_PATH/lib/python:$PYTHONPATH"
+         +            PYTHONPATH="$CYLC_SUITE_DEF_PATH/lib/python:${PYTHONPATH:-}"
          +            # The dimensions of each grid cell in degrees.
          +            RESOLUTION = 0.2
          +            # The area to generate forecasts for (lng1, lat1, lng2, lat2).
@@ -273,7 +273,7 @@ Families and ``cylc graph``
               script = consolidate-observations
          -    [[[environment]]]
          -        # Add the `python` directory to the PYTHONPATH.
-         -        PYTHONPATH="$CYLC_SUITE_RUN_DIR/lib/python:$PYTHONPATH"
+         -        PYTHONPATH="$CYLC_SUITE_RUN_DIR/lib/python:${PYTHONPATH:-}"
          -        # The dimensions of each grid cell in degrees.
          -        RESOLUTION = 0.2
          -        # The area to generate forecasts for (lng1, lat1, lng2, lat2).
@@ -286,7 +286,7 @@ Families and ``cylc graph``
                   # To use archived data comment this line out.
                   API_KEY = xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
          -        # Add the `python` directory to the PYTHONPATH.
-         -        PYTHONPATH="$CYLC_SUITE_RUN_DIR/lib/python:$PYTHONPATH"
+         -        PYTHONPATH="$CYLC_SUITE_RUN_DIR/lib/python:${PYTHONPATH:-}"
          -        # The dimensions of each grid cell in degrees.
          -        RESOLUTION = 0.2
          -        # The area to generate forecasts for (lng1, lat1, lng2, lat2).
@@ -296,7 +296,7 @@ Families and ``cylc graph``
               script = forecast 60 5  # Generate 5 forecasts at 60 minute intervals.
               [[[environment]]]
          -        # Add the `python` directory to the PYTHONPATH.
-         -        PYTHONPATH="$CYLC_SUITE_RUN_DIR/lib/python:$PYTHONPATH"
+         -        PYTHONPATH="$CYLC_SUITE_RUN_DIR/lib/python:${PYTHONPATH:-}"
          -        # The dimensions of each grid cell in degrees.
          -        RESOLUTION = 0.2
          -        # The area to generate forecasts for (lng1, lat1, lng2, lat2)
@@ -319,7 +319,7 @@ Families and ``cylc graph``
               script = post-process exeter 60
          -    [[[environment]]]
          -        # Add the `python` directory to the PYTHONPATH.
-         -        PYTHONPATH="$CYLC_SUITE_RUN_DIR/lib/python:$PYTHONPATH"
+         -        PYTHONPATH="$CYLC_SUITE_RUN_DIR/lib/python:${PYTHONPATH:-}"
          -        # The dimensions of each grid cell in degrees.
          -        RESOLUTION = 0.2
          -        # The area to generate forecasts for (lng1, lat1, lng2, lat2).

--- a/sphinx/tutorial/cylc/runtime/configuration-consolidation/families.rst
+++ b/sphinx/tutorial/cylc/runtime/configuration-consolidation/families.rst
@@ -241,18 +241,17 @@ Families and ``cylc graph``
 
    2. **Move Site-Wide Settings Into The** ``root`` **Family.**
 
-      The following three environment variables are used by multiple tasks:
+      The following two environment variables are used by multiple tasks:
 
       .. code-block:: none
 
-         PYTHONPATH="$CYLC_SUITE_DEF_PATH/lib/python:${PYTHONPATH:-}"
          RESOLUTION = 0.2
          DOMAIN = -12,48,5,61  # Do not change!
 
       Rather than manually adding them to each task individually we could put
       them in the ``root`` family, making them accessible to all tasks.
 
-      Add a ``root`` section containing these three environment variables.
+      Add a ``root`` section containing these two environment variables.
       Remove the variables from any other task's ``environment`` sections:
 
       .. code-block:: diff
@@ -260,8 +259,6 @@ Families and ``cylc graph``
           [runtime]
          +    [[root]]
          +        [[[environment]]]
-         +            # Add the `python` directory to the PYTHONPATH.
-         +            PYTHONPATH="$CYLC_SUITE_DEF_PATH/lib/python:${PYTHONPATH:-}"
          +            # The dimensions of each grid cell in degrees.
          +            RESOLUTION = 0.2
          +            # The area to generate forecasts for (lng1, lat1, lng2, lat2).
@@ -272,8 +269,6 @@ Families and ``cylc graph``
           [[consolidate_observations]]
               script = consolidate-observations
          -    [[[environment]]]
-         -        # Add the `python` directory to the PYTHONPATH.
-         -        PYTHONPATH="$CYLC_SUITE_RUN_DIR/lib/python:${PYTHONPATH:-}"
          -        # The dimensions of each grid cell in degrees.
          -        RESOLUTION = 0.2
          -        # The area to generate forecasts for (lng1, lat1, lng2, lat2).
@@ -285,8 +280,6 @@ Families and ``cylc graph``
                   # The key required to get weather data from the DataPoint service.
                   # To use archived data comment this line out.
                   API_KEY = xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
-         -        # Add the `python` directory to the PYTHONPATH.
-         -        PYTHONPATH="$CYLC_SUITE_RUN_DIR/lib/python:${PYTHONPATH:-}"
          -        # The dimensions of each grid cell in degrees.
          -        RESOLUTION = 0.2
          -        # The area to generate forecasts for (lng1, lat1, lng2, lat2).
@@ -295,8 +288,6 @@ Families and ``cylc graph``
           [[forecast]]
               script = forecast 60 5  # Generate 5 forecasts at 60 minute intervals.
               [[[environment]]]
-         -        # Add the `python` directory to the PYTHONPATH.
-         -        PYTHONPATH="$CYLC_SUITE_RUN_DIR/lib/python:${PYTHONPATH:-}"
          -        # The dimensions of each grid cell in degrees.
          -        RESOLUTION = 0.2
          -        # The area to generate forecasts for (lng1, lat1, lng2, lat2)
@@ -318,8 +309,6 @@ Families and ``cylc graph``
               # Generate a forecast for Exeter 60 minutes into the future.
               script = post-process exeter 60
          -    [[[environment]]]
-         -        # Add the `python` directory to the PYTHONPATH.
-         -        PYTHONPATH="$CYLC_SUITE_RUN_DIR/lib/python:${PYTHONPATH:-}"
          -        # The dimensions of each grid cell in degrees.
          -        RESOLUTION = 0.2
          -        # The area to generate forecasts for (lng1, lat1, lng2, lat2).

--- a/sphinx/tutorial/cylc/runtime/introduction.rst
+++ b/sphinx/tutorial/cylc/runtime/introduction.rst
@@ -72,14 +72,18 @@ We can also call other scripts or executables in this way, e.g:
        [[hello_world]]
            script = ~/foo/bar/baz/hello_world
 
-.. nextslide::
+
+:envvar:`PATH` and :envvar:`PYTHONPATH`
+---------------------------------------
 
 .. ifnotslides::
 
-   It is often a good idea to keep our scripts within the Cylc suite directory
-   tree rather than leaving them somewhere else on the system. If you create a
-   ``bin`` sub-directory within the :term:`suite directory` this directory will
-   be added to the path when tasks run, e.g:
+   It is often a good idea to keep our scripts with the Cylc suite rather than
+   leaving them somewhere else on the system.
+
+   If you create a ``bin/`` sub-directory within the :term:`suite directory`
+   Cylc will automatically prepend it to the :envvar:`PATH` environment
+   variable when the task runs.
 
 .. code-block:: bash
    :caption: bin/hello_world
@@ -89,11 +93,30 @@ We can also call other scripts or executables in this way, e.g:
 
 .. code-block:: cylc
    :caption: suite.rc
-   :emphasize-lines: 3
 
    [runtime]
        [[hello_world]]
            script = hello_world
+
+.. nextslide::
+
+.. ifnotslides::
+
+   Similarly the ``lib/python/`` directory gets prepended to the
+   :envvar:`PYTHONPATH` variable.
+
+.. code-block:: python
+   :caption: lib/python/hello.py
+
+   def world():
+      print('Hello World!')
+
+.. code-block:: cylc
+   :caption: suite.rc
+
+   [runtime]
+      [[hello_world]]
+         script = python -c 'import hello; hello.world()'
 
 
 .. _tutorial-tasks-and-jobs:

--- a/sphinx/tutorial/rose/suites.rst
+++ b/sphinx/tutorial/rose/suites.rst
@@ -393,7 +393,7 @@ See the :ref:`Cheat Sheet` for more information.
                   # These environment variables will be available to all tasks.
                   [[[environment]]]
                       # Add the `python` directory to the PYTHONPATH.
-                      PYTHONPATH="$CYLC_SUITE_RUN_DIR/lib/python:$PYTHONPATH"
+                      PYTHONPATH="$CYLC_SUITE_RUN_DIR/lib/python:${PYTHONPATH:-}"
          -            # The dimensions of each grid cell in degrees.
          -            RESOLUTION = 0.2
          -            # The area to generate forecasts for (lng1, lat1, lng2, lat2).

--- a/sphinx/tutorial/rose/suites.rst
+++ b/sphinx/tutorial/rose/suites.rst
@@ -388,12 +388,10 @@ See the :ref:`Cheat Sheet` for more information.
 
       .. code-block:: diff
 
-          [runtime]
-              [[root]]
-                  # These environment variables will be available to all tasks.
-                  [[[environment]]]
-                      # Add the `python` directory to the PYTHONPATH.
-                      PYTHONPATH="$CYLC_SUITE_RUN_DIR/lib/python:${PYTHONPATH:-}"
+         -[runtime]
+         -    [[root]]
+         -        # These environment variables will be available to all tasks.
+         -        [[[environment]]]
          -            # The dimensions of each grid cell in degrees.
          -            RESOLUTION = 0.2
          -            # The area to generate forecasts for (lng1, lat1, lng2, lat2).


### PR DESCRIPTION
Rose 2.0 equivalent of https://github.com/metomi/rose/pull/2336

Since https://github.com/cylc/cylc-flow/pull/3168 went through (with surprisingly little fuss) we can now get rid of all the horrible `PYTHONPATH` mess we have been expecting students to put up with in the tutorial suite.

Will assign reviewers once tests pass.