### PR TITLE
reporter: mojibake

### DIFF
--- a/lib/python/rose/reporter.py
+++ b/lib/python/rose/reporter.py
@@ -178,7 +178,8 @@ class Reporter(object):
                         msg = unicode(msg, 'utf-8')
                     except TypeError:
                         msg = str(msg)
-                    except UnicodeEncodeError:
+                    except (UnicodeEncodeError, UnicodeDecodeError):
+                        # allow mojibake to pass through
                         pass
 
             msg_lines = self.format_msg(msg, context.verbosity, prefix, clip)


### PR DESCRIPTION
This requirement comes through `rose_ana` where non-unicode characters may appear in file differences. Currently this causes Rose to bail out with a `UnicodeDecodeError`.

This change allows the error to pass and dumps non-unicode to screen if decoding fails.