### PR TITLE
2019.01.x docs: fix what-is-cylc page

### DIFF
--- a/sphinx/hyperlinks.rst
+++ b/sphinx/hyperlinks.rst
@@ -9,9 +9,9 @@
        .. include:: path/to/thisfile.rst
           :start-line: 1
 
-.. _Cylc: http://cylc.github.io/cylc-flow/
-.. _Cylc User Guide: http://cylc.github.io/documentation.html#the-cylc-user-guide
-.. _Cylc Suite Design Guide: http://cylc.github.io/doc/built-sphinx/suite-design-guide/suite-design-guide-master.html
+.. _Cylc: https://cylc.github.io/cylc-flow/
+.. _Cylc User Guide: https://cylc.github.io/documentation.html#the-cylc-user-guide
+.. _Cylc Suite Design Guide: https://cylc.github.io/doc/built-sphinx/suite-design-guide/suite-design-guide-master.html
 .. _EmPy: http://www.alcyone.com/software/empy/
 .. _extglob pattern matching: https://www.gnu.org/software/bash/manual/html_node/Pattern-Matching.html#Pattern-Matching
 .. _FCM: https://metomi.github.io/fcm/doc/

--- a/sphinx/tutorial/cylc/introduction.rst
+++ b/sphinx/tutorial/cylc/introduction.rst
@@ -1,33 +1,30 @@
-.. slideconf::
-   :autoslides: False
-
 .. _cylc-introduction:
 
 Introduction
 ============
 
-.. slide:: Introduction
 
 What Is A Workflow?
 -------------------
 
-.. slide:: What Is A Workflow?
-   :level: 2
+.. epigraph::
 
-   .. epigraph::
+   A workflow consists of an orchestrated and repeatable pattern of business
+   activity enabled by the systematic organization of resources into processes
+   that transform materials, provide services, or process information.
 
-      A workflow consists of an orchestrated and repeatable pattern of business
-      activity enabled by the systematic organization of resources into processes
-      that transform materials, provide services, or process information.
+   -- Wikipedia
 
-      -- Wikipedia
+.. ifnotslides::
 
-In research, business and other fields we may have processes that we repeat
-in the course of our work. At its simplest a workflow is a set of steps that
-must be followed in a particular order to achieve some end goal.
+   In research, business and other fields we may have processes that we repeat
+   in the course of our work. At its simplest a workflow is a set of steps that
+   must be followed in a particular order to achieve some end goal.
 
-We can represent each "step" in a workflow as a oval and the order with
-arrows.
+   We can represent each "step" in a workflow as a oval and the order with
+   arrows.
+
+.. nextslide::
 
 .. digraph:: bakery
    :align: center
@@ -40,60 +37,58 @@ arrows.
 What Is Cylc?
 -------------
 
-Cylc (pronounced silk) is a workflow engine, a system that automatically
-executes tasks according to their schedules and dependencies.
-In a Cylc workflow each step is a
-computational task, a script to execute. Cylc runs each task as soon as it is
-appropriate to do so.
+.. ifnotslides::
 
-.. slide:: What Is Cylc?
-   :level: 2
+   Cylc (pronounced silk) is a workflow engine, a system that automatically
+   executes tasks according to their schedules and dependencies.
 
-   .. minicylc::
-      :align: center
-      :theme: demo
+   In a Cylc workflow each step is a computational task, a script to execute.
+   Cylc runs each task as soon as it is appropriate to do so.
 
-       a => b => c
-       b => d => f
-       e => f
+.. minicylc::
+   :align: center
+   :theme: demo
 
-.. slide:: What Is Cylc?
-   :level: 2
+    a => b => c
+    b => d => f
+    e => f
 
-   Cylc can automatically:
+.. nextslide::
 
-   - Submit tasks across computer systems and resource managers.
-   - Recover from failures.
-   - Repeat workflows.
+Cylc can automatically:
 
-Cylc was originally developed at NIWA (The National Institute of Water and
-Atmospheric Research - New Zealand) for running their weather forecasting
-workflows. Cylc is now developed by an international partnership including
-members from NIWA and the Met Office (UK). Though initially developed for
-meteorological purposes Cylc is a general purpose tool as applicable in
-business as in scientific research.
+- Submit tasks across computer systems and resource managers.
+- Recover from failures.
+- Repeat workflows.
 
-.. ifslides::
+.. ifnotslides::
 
-   .. slide:: What Is Cylc?
-      :level: 2
+   Cylc was originally developed at NIWA (The National Institute of Water and
+   Atmospheric Research - New Zealand) for running their weather forecasting
+   workflows. Cylc is now developed by an international partnership including
+   members from NIWA and the Met Office (UK). Though initially developed for
+   meteorological purposes Cylc is a general purpose tool as applicable in
+   business as in scientific research.
 
-      * Originally developed at NIWA (New Zealand)
-      * Now developed by an international partnership including the
-        Met Office (UK).
-      * General purpose tool as applicable in business as in
-        scientific research.
-
-.. slide:: What Is Cylc?
-   :level: 2
-
-   Cylc provides a variety of command line and GUI tools for visualising and
-   interacting with workflows.
-
-   .. image:: img/cylc-gui.png
+.. nextslide::
 
 .. ifslides::
 
-   .. slide:: Next
+   * Originally developed at NIWA (New Zealand)
+   * Now developed by an international partnership including the
+     Met Office (UK).
+   * General purpose tool as applicable in business as in
+     scientific research.
 
-      :ref:`tutorial-cylc-graphing`
+.. nextslide::
+
+Cylc provides a variety of command line and GUI tools for visualising and
+interacting with workflows.
+
+.. image:: img/cylc-gui.png
+
+.. nextslide::
+
+.. ifslides::
+
+   :ref:`tutorial-cylc-graphing`


### PR DESCRIPTION
Back-port of #2347, not too urgent but ideally we would slide this into next-release as it is a pretty straight-forward change.