### PR TITLE
docs: sphinx 2.1.0 compatability

### DIFF
--- a/sphinx/ext/rose_domain.py
+++ b/sphinx/ext/rose_domain.py
@@ -953,7 +953,11 @@ class RoseAutoDirective(Directive):
             raise
 
         nodes = []
-        nodes.append(addnodes.highlightlang(lang='rose', linenothreshold=20))
+        nodes.append(addnodes.highlightlang(
+            lang='rose',
+            force=False,
+            linenothreshold=20
+        ))
 
         # Append file level comments if present.
         if conf.comments:
@@ -1003,7 +1007,11 @@ class RoseAutoDirective(Directive):
             node.append(section.run()[1])
         nodes.append(node)
 
-        nodes.append(addnodes.highlightlang(lang='bash', linenothreshold=20))
+        nodes.append(addnodes.highlightlang(
+            lang='bash',
+            force=False,
+            linenothreshold=20
+        ))
 
         return nodes
 


### PR DESCRIPTION
Fix to counter an un-documented breaking change in Sphinx 2.1.0 resulting from the addition of a new attribute on the [`highlight` directive](https://www.sphinx-doc.org/en/2.0/usage/restructuredtext/directives.html#directive-highlight).

This doesn't affect 2019.01.x due to the removal of Python2 support in latest Sphinx.