### PR TITLE
docs: add debug info in travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,12 +11,10 @@ before_install:
   - export PATH="$PWD/.travis:$PATH"
 
 after_success:
-  - now report_coverage
+  - now report coverage
 
 after_failure:
-  - printenv PATH PYTHONPATH
-  - rose check-software
-  - cat /tmp/sphinx-err*  # sphinx traceback
+  - now report error
 
 jobs:
   include:

--- a/.travis/now
+++ b/.travis/now
@@ -92,7 +92,8 @@ _install_sphinx () {
     # sphinx documentation and its extensions
     APT+=(latexmk texlive texlive-generic-extra texlive-latex-extra \
           texlive-fonts-recommended graphviz)
-    PIP+=(sphinx sphinx_rtd_theme sphinxcontrib-httpdomain hieroglyph)
+    PIP+=(sphinx sphinx_rtd_theme sphinxcontrib-httpdomain hieroglyph \
+          sphinxcontrib-svg2pdfconverter)
 }
 
 _install_tut_suite () {

--- a/.travis/now
+++ b/.travis/now
@@ -161,10 +161,25 @@ install () {
         <<<"export PYTHONPATH=\"$(_join ':' "${PY_PATH[@]}"):\$PYTHONPATH\";"
 }
 
-report_coverage () {
+_report_coverage () {
     coverage combine --append
     coverage xml --ignore-errors
     bash <(curl -s https://codecov.io/bash)
+}
+
+_report_error() {
+    # don't bail out on error
+    set +eu
+
+    printenv PATH PYTHONPATH
+    rose check-software
+    cat /tmp/sphinx-err*  # sphinx traceback
+}
+
+report () {
+    for arg in "$@"; do
+        "_report_${arg}"
+    done
 }
 
 test () {


### PR DESCRIPTION
* Output Sphinx traceback in the event of error.
* When error reporting don't bail on failure.
* Add the `sphinxcontrib-svg2pdfconverter` dependency.