### PR TITLE
Use metomi-isodatetime in preference to isodatetime

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -7,5 +7,4 @@ exclude_paths:
   - lib/html/static/js/jquery*
   - lib/html/static/js/livestamp.min.js
   - lib/html/static/js/moment.min.js
-  - lib/python/isodatetime/
   - etc/tutorial/cylc/python/png.py

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -45,7 +45,6 @@ ignore:
   - "sphinx/**/*.py"
   - "t/**/*.py"
   - ".travis/**/*.py"
-  - "lib/python/isodatetime/**/*.py"
 
 # turn off comments to pull requests
 comment: off

--- a/.coveragerc
+++ b/.coveragerc
@@ -46,9 +46,6 @@ debug=
 #    trace
 # Include can be used only if source is not used!
 note=
-omit=
-    */lib/python/isodatetime*
-    */lib/python/sitecustomize.py
 parallel = True
 plugins=
 include=
@@ -69,9 +66,6 @@ exclude_lines =
 fail_under=0
 ignore_errors = False
 include=
-omit=
-    */lib/python/isodatetime*
-    */lib/python/sitecustomize.py
 partial_branches=
 precision=2
 show_missing=False

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ jobs:
   include:
     - name: "Unit Tests"
       install:
-        - now install coverage linters pytest isodatetime cylc rose
+        - now install coverage linters pytest cylc rose
       script:
         - now test style
         - now test units
@@ -30,12 +30,12 @@ jobs:
         - export PATH="$PWD/.travis:$PATH"
         - now install coverage fcm tut_suite
       install:
-        - now install isodatetime cylc rose
+        - now install cylc rose
       script:
         - now test battery
 
     - name: "Documentation"
       install:
-        - now install coverage isodatetime rose sphinx tut_suite
+        - now install coverage rose sphinx tut_suite
       script:
         - now test docs

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ jobs:
   include:
     - name: "Unit Tests"
       install:
-        - now install coverage linters pytest cylc rose
+        - now install coverage linters pytest isodatetime cylc rose
       script:
         - now test style
         - now test units

--- a/.travis/now
+++ b/.travis/now
@@ -91,12 +91,6 @@ _install_cylc () {
     RC_PATH+=("${HOME}/cylc-master/bin")
 }
 
-_install_isodatetime () {
-    wget 'https://github.com/metomi/isodatetime/archive/master.tar.gz' \
-        -O - | tar -xz -C "${HOME}"
-    pip install -e "${HOME}/isodatetime-master"
-}
-
 _install_fcm () {
     APT+=(subversion build-essential gfortran libxml-parser-perl \
           libconfig-inifiles-perl libdbi-perl libdbd-sqlite3-perl)

--- a/ACKNOWLEDGEMENT.md
+++ b/ACKNOWLEDGEMENT.md
@@ -67,9 +67,5 @@ lib/html/static/js/moment.min.js:
 * Unmodified external software library released under the MIT license.
   See <http://momentjs.com/>
 
-lib/python/isodatetime/:
-* Unmodified external software library released under the LGPL license.
-  See <https://github.com/metomi/isodatetime>
-
 lib/python/rose/tests/test_ancils/unicode.txt:
 * Markus Kuhn <http://www.cl.cam.ac.uk/~mgk25/> - 2015-08-28 - CC BY 4.0

--- a/metomi/rose/app_run.py
+++ b/metomi/rose/app_run.py
@@ -26,8 +26,8 @@ import sys
 from time import localtime, sleep, strftime, time
 import traceback
 
-from isodatetime.data import get_timepoint_for_now
-from isodatetime.parsers import ISO8601SyntaxError
+from metomi.isodatetime.data import get_timepoint_for_now
+from metomi.isodatetime.parsers import ISO8601SyntaxError
 from metomi.rose.config import ConfigDumper
 from metomi.rose.date import RoseDateTimeOperator
 from metomi.rose.env import env_var_process, UnboundEnvironmentVariableError

--- a/metomi/rose/date.py
+++ b/metomi/rose/date.py
@@ -20,9 +20,9 @@
 """Parse and format date and time."""
 
 from datetime import datetime
-from isodatetime.data import Calendar, Duration, get_timepoint_for_now
-from isodatetime.dumpers import TimePointDumper
-from isodatetime.parsers import TimePointParser, DurationParser
+from metomi.isodatetime.data import Calendar, Duration, get_timepoint_for_now
+from metomi.isodatetime.dumpers import TimePointDumper
+from metomi.isodatetime.parsers import TimePointParser, DurationParser
 import os
 import re
 from metomi.rose.env import UnboundEnvironmentVariableError
@@ -84,7 +84,8 @@ class RoseDateTimeOperator(object):
         utc_mode -- If True, parse/print in UTC mode rather than local or
                     other timezones.
 
-        calendar_mode -- Set calendar mode, for isodatetime.data.Calendar.
+        calendar_mode -- Set calendar mode for
+                         metomi.isodatetime.data.Calendar.
 
         ref_point_str -- Set the reference time point for operations.
                          If not specified, operations use current date time.
@@ -128,8 +129,8 @@ class RoseDateTimeOperator(object):
     def date_parse(self, time_point_str=None):
         """Parse time_point_str.
 
-        Return (t, format) where t is a isodatetime.data.TimePoint object and
-        format is the format that matches time_point_str.
+        Return (t, format) where t is a metomi.isodatetime.data.TimePoint
+        object and format is the format that matches time_point_str.
 
         time_point_str -- The time point string to parse.
                           Otherwise, use ref time.
@@ -273,14 +274,17 @@ class RoseDateTimeOperator(object):
             Calendar.default().set_mode(calendar_mode)
 
     def strftime(self, time_point, print_format):
-        """Use either the isodatetime or datetime strftime time formatting."""
+        """Use either the metomi.isodatetime or datetime strftime time
+        formatting.
+        """
         try:
             return time_point.strftime(print_format)
         except ValueError:
             return self.get_datetime_strftime(time_point, print_format)
 
     def strptime(self, time_point_str, parse_format):
-        """Use either the isodatetime or datetime strptime time parsing."""
+        """Use either the metomi.isodatetime or datetime strptime time parsing.
+        """
         try:
             return self.time_point_parser.strptime(time_point_str,
                                                    parse_format)

--- a/metomi/rose/suite_engine_proc.py
+++ b/metomi/rose/suite_engine_proc.py
@@ -19,8 +19,8 @@
 # -----------------------------------------------------------------------------
 """Suite engine processor management."""
 
-from isodatetime.data import Duration
-from isodatetime.parsers import DurationParser, ISO8601SyntaxError
+from metomi.isodatetime.data import Duration
+from metomi.isodatetime.parsers import DurationParser, ISO8601SyntaxError
 from glob import glob
 import os
 import pwd

--- a/metomi/rosie/ws.py
+++ b/metomi/rosie/ws.py
@@ -46,7 +46,7 @@ from tornado.ioloop import IOLoop, PeriodicCallback
 import tornado.log
 import tornado.web
 
-from isodatetime.data import get_timepoint_from_seconds_since_unix_epoch
+from metomi.isodatetime.data import get_timepoint_from_seconds_since_unix_epoch
 from metomi.rose.host_select import HostSelector
 from metomi.rose.opt_parse import RoseOptionParser
 from metomi.rose.resource import ResourceLocator

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,7 +1,6 @@
 [pytest]
 addopts = --verbose
     --doctest-modules
-    --ignore=metomi/isodatetime
     --ignore=metomi/rosie
     --ignore=metomi/rose/ws.py
     --ignore=metomi/rose/metadata_graph.py

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ INSTALL_REQUIRES = [
     "aiofiles",
     "tornado",
     "sqlalchemy",
-    "isodatetime",
+    "metomi-isodatetime",
     "requests",
     "ldap3",
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,5 @@ exclude=
     .git,
     __pycache__,
     .tox,
-    lib/python/isodatetime/,
     ; purposely corrupt file
     t/rose-metadata-check/lib/custom_macro_corrupt.py


### PR DESCRIPTION
## Change dependency in Rose from isodatetime to metomi.isodatetime
The isodatetime module was recently renamed metomi.isodatetime ([PR 132](https://github.com/metomi/isodatetime/pull/132)). 

This PR changes the namespaces in cylc to reflect this.

- [x] Grepping for `isodatime` without `metomi` produces reasonable results.
- [x] All existing tests pass - this is unlikely to happen before [Cylc-flow PR3222](https://github.com/cylc/cylc-flow/pull/3222) is accepted.
