### PR TITLE
rosie: only raise SuiteIdTextError if there is actually a suite id error

### DIFF
--- a/lib/python/rosie/suite_id.py
+++ b/lib/python/rosie/suite_id.py
@@ -515,8 +515,12 @@ class SuiteId(object):
             try:
                 info_entry = info_parser.parse(
                     self.svn("info", "--xml", location))
-            except RosePopenError:
-                raise SuiteIdTextError(location)
+            except RosePopenError as exc:
+                if 'E200009' in exc.stderr:
+                    # E200009: Could not display info for all targets
+                    #          because some targets don't exist
+                    raise SuiteIdTextError(location)
+                raise
             else:
                 if "commit:revision" in info_entry:
                     revision = int(info_entry["commit:revision"])


### PR DESCRIPTION
Rosie unhelpfully raises a `SuiteIdTextError` upon any error in `svn info <location>`.

Whilst error could mean an invalid suite name it could also mean a connection problem e.g. authentication.

I've seen this recently with the `rosie copy` command.

TODO:

* [ ] Forward port to Rose 2
* [ ] Test?