### PR TITLE
Very minor typo fix in tutorial

### DIFF
--- a/sphinx/tutorial/rose/furthertopics/optional-configurations.rst
+++ b/sphinx/tutorial/rose/furthertopics/optional-configurations.rst
@@ -120,7 +120,7 @@ following lines:
    [env]
    FLAVOUR=fudge
    CONE_TYPE=tub
-   TOPPINGS=nuts
+   TOPPING=nuts
 
 Run the app using both the ``chocolate`` and ``fudge-sundae`` optional
 configurations::


### PR DESCRIPTION
The 'S' in toppings in tutorial (optional-configurations) was making the suite not run as intended. I have removed this rogue 'S'.
Tutorial now works as intended.