### PR TITLE
Add environment variable parsing for rose_ana config and amend documentation for thread option

### DIFF
--- a/metomi/rose/apps/rose_ana.py
+++ b/metomi/rose/apps/rose_ana.py
@@ -639,7 +639,9 @@ class RoseAnaApp(BuiltinApp):
                     # any) of the names match existing config options from the
                     # global config it will be overwritten)
                     if task == "config":
-                        self.ana_config[keys[1]] = node.value
+                        # Process any environment variables first
+                        value = env_var_process(node.value)
+                        self.ana_config[keys[1]] = value
                         continue
 
                     _tasks.setdefault(task, {})

--- a/sphinx/tutorial/rose/furthertopics/rose-stem.rst
+++ b/sphinx/tutorial/rose/furthertopics/rose-stem.rst
@@ -202,12 +202,17 @@ class. An app may begin with a section like this:
    [ana:config]
    grepper-report-limit=5
    skip-if-all-files-missing=.true.
+   threads=10
 
 Each of these modifies the behaviour of ``grepper``. The first option
 suppresses printed output for each analysis task once the specified number
 of lines have been printed (in this case 5 lines). The second option
 causes Rose Ana to skip any ``grepper`` tasks which compare files in the
-case that both files do not exist.
+case that both files do not exist. Finally the third option will cause 
+rose_ana to use multiple threads (split across the individual analysis
+tasks). Be aware that any custom (user provided) analysis task which
+itself makes use of threading (e.g. by calling a library using OpenMP) 
+may clash or interfere with the correct operation of this setting.
 
 .. note::
 


### PR DESCRIPTION
Having tried to make use of the (relatively) new threading feature I added to `rose_ana` previously, I noticed that it doesn't apply the environment variable parsing to items in the `ana:config` section - which means I can't set things like the number of threads from the suite using an environment variable

While I'm there it was also pointed out to me that the threading option added previously isn't mentioned in the documentation anywhere, so I've added it