### PR TITLE
Fix tutorial

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,6 +46,7 @@ below:
 * Thomas Coleman (Bureau of Meteorology, Australia)
 * Bruno P. Kinoshita (National Institute of Water and Atmospheric Research, New Zealand)
 * Tim Pillinger (Met Office, UK)
+* Ronnie Dutta (Met Office, UK)
 
 (All contributors are identifiable with email addresses in the version control
 logs or otherwise.)

--- a/etc/tutorial/cylc-forecasting-suite/bin/get-observations
+++ b/etc/tutorial/cylc-forecasting-suite/bin/get-observations
@@ -56,9 +56,20 @@ def get_datapoint_data(site_id, time, api_key):
     time = datetime.strptime(time, '%Y%m%dT%H%MZ').strftime('%Y-%m-%dT%H:%MZ')
     url = BASE_URL.format(time=time, site_id=site_id,
                           api_key=api_key)
+    # HTTP header to prevent 403 error:
+    hdr = {'User-Agent': ('Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.11 '
+                          '(KHTML, like Gecko) Chrome/23.0.1271.64 '
+                          'Safari/537.11'),
+           'Accept': ('text/html,application/xhtml+xml,application/xml;'
+                      'q=0.9,*/*;q=0.8'),
+           'Accept-Charset': 'ISO-8859-1,utf-8;q=0.7,*;q=0.3',
+           'Accept-Encoding': 'none',
+           'Accept-Language': 'en-US,en;q=0.8',
+           'Connection': 'keep-alive'}
+    req = urllib2.Request(url, headers=hdr)
     # Get the data and parse it as JSON.
     print 'Opening URL: %s' % url
-    return json.loads(urllib2.urlopen(url).read())['SiteRep']['DV']['Location']
+    return json.loads(urllib2.urlopen(req).read())['SiteRep']['DV']['Location']
 
 
 def get_archived_data(site_id, time):

--- a/etc/tutorial/cylc-forecasting-suite/bin/get-observations
+++ b/etc/tutorial/cylc-forecasting-suite/bin/get-observations
@@ -83,10 +83,22 @@ def get_archived_data(site_id, time):
 
 def extract_observations(data):
     """Extract the relevant observations from the weather data."""
+    try:
+        direction = ORDINATES[data['Period']['Rep']['D']]
+    except KeyError:
+        direction = '0'
+        print 'No wind direction in file so using 0'
+
+    try:
+        speed = data['Period']['Rep']['S']
+    except KeyError:
+        speed = '0'
+        print 'No wind speed in file so using 0'
+
     return [data['lon'],
             data['lat'],
-            ORDINATES[data['Period']['Rep']['D']],
-            data['Period']['Rep']['S']]
+            direction,
+            speed]
 
 
 def main(site_id, api_key=None):

--- a/etc/tutorial/cylc-forecasting-suite/bin/get-rainfall
+++ b/etc/tutorial/cylc-forecasting-suite/bin/get-rainfall
@@ -97,16 +97,27 @@ def get_datapoint_radar_image(filename, time, api_key):
 
     Args:
         filename (str): The path to write the image file to.
-        time (str): The date-time of the image to reteieve in ISO8601 format.
+        time (str): The date-time of the image to retrieve in ISO8601 format.
         api_key (str): Datapoint API key.
 
     """
     time = datetime.strptime(time, '%Y%m%dT%H%MZ'
                             ).strftime('%Y-%m-%dT%H:%M:%SZ')
     url = URL.format(time=time, api_key=api_key)
+    # HTTP header to prevent 403 error:
+    hdr = {'User-Agent': ('Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.11 '
+                          '(KHTML, like Gecko) Chrome/23.0.1271.64 '
+                          'Safari/537.11'),
+           'Accept': ('text/html,application/xhtml+xml,application/xml;'
+                      'q=0.9,*/*;q=0.8'),
+           'Accept-Charset': 'ISO-8859-1,utf-8;q=0.7,*;q=0.3',
+           'Accept-Encoding': 'none',
+           'Accept-Language': 'en-US,en;q=0.8',
+           'Connection': 'keep-alive'}
+    req = urllib2.Request(url, headers=hdr)
     print 'Opening URL: %s' % url
     with open(filename, 'w+') as png_file:
-        png_file.write(urllib2.urlopen(url).read())
+        png_file.write(urllib2.urlopen(req).read())
 
 
 def get_archived_radar_image(filename, time):


### PR DESCRIPTION
I had a couple of problems with the cylc & rose tutorials, specifically with the [cylc runtime configuration tutorial](https://metomi.github.io/rose/2019.01.2/html/tutorial/cylc/runtime/runtime-configuration.html#admonition-0) and the [rose suite configuration tutorial](https://metomi.github.io/rose/2019.01.2/html/tutorial/rose/suites.html#admonition-5).

This PR fixes:
- HTTP 403 error in the weather data API request
- KeyError that sometimes happens when no wind direction/speed data is served (thanks to Joe)