### PR TITLE
Ignore *.egg-info dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ venv
 .coverage.*
 coverage.xml
 htmlcov/
+
+*.egg-info


### PR DESCRIPTION
I have a `metomi_rose.egg-info` directory that is not ignored on this branch (but is on master)