### PR TITLE
pinned hieroglyph to version 1.x as V2 doesn't have python2 support

### DIFF
--- a/bin/rose-make-docs
+++ b/bin/rose-make-docs
@@ -180,7 +180,7 @@ venv-install () {
     pip install 'sphinx'
     pip install 'sphinx_rtd_theme'
     pip install 'sphinxcontrib-httpdomain'
-    pip install 'hieroglyph'
+    pip install 'hieroglyph=1'
 }
 
 venv-deactivate () {

--- a/bin/rose-make-docs
+++ b/bin/rose-make-docs
@@ -180,7 +180,7 @@ venv-install () {
     pip install 'sphinx'
     pip install 'sphinx_rtd_theme'
     pip install 'sphinxcontrib-httpdomain'
-    pip install 'hieroglyph=1'
+    pip install 'hieroglyph==1'
 }
 
 venv-deactivate () {

--- a/etc/rose-docs-env.yaml
+++ b/etc/rose-docs-env.yaml
@@ -9,5 +9,5 @@ dependencies:
   - sphinx_rtd_theme
   - sphinxcontrib-httpdomain
   - pip:
-    - hieroglyph
+    - hieroglyph==1
     - sphinxcontrib-svg2pdfconverter


### PR DESCRIPTION
Hieroglyph Version 2.0.0 removes Python 2 compatibility. This changes pins the Python 2 Rose branch to Version 1.