### PR TITLE
tutorial-bug: Clarify that suite won't run _yet_

### DIFF
--- a/sphinx/tutorial/rose/suites.rst
+++ b/sphinx/tutorial/rose/suites.rst
@@ -413,8 +413,6 @@ See the :ref:`Cheat Sheet` for more information.
 
    #. **Install The Suite.**
 
-      Running :ref:`command-rose-suite-run` will cause the suite to be
-      installed, validated and run.
 
       This suite is not ready to run yet but you can install it: Use the
       ``--local-install-only`` command-line option to install the suite on

--- a/sphinx/tutorial/rose/suites.rst
+++ b/sphinx/tutorial/rose/suites.rst
@@ -416,8 +416,9 @@ See the :ref:`Cheat Sheet` for more information.
       Running :ref:`command-rose-suite-run` will cause the suite to be
       installed, validated and run.
 
-      Use the ``--local-install-only`` command-line option to install the
-      suite on your local machine and validate it::
+      This suite is not ready to run yet but you can install it: Use the
+      ``--local-install-only`` command-line option to install the suite on
+      your local machine and validate it::
 
          rose suite-run --local-install-only
 


### PR DESCRIPTION
I don't think it's clear that this suite won't run yet, and that we are only testing the installation and validation at this point.