### PR TITLE
Fix setup.py for use with Cylc8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,6 @@ with open("README.md", "r") as fh:
 
 INSTALL_REQUIRES = [
     "jinja2>=2.10.1",
-    "cylc-flow==8.*",
     "aiofiles",
     "tornado",
     "sqlalchemy",

--- a/setup.py
+++ b/setup.py
@@ -49,8 +49,8 @@ with open("README.md", "r") as fh:
 
 
 INSTALL_REQUIRES = [
-    "jinja2>=2.10.1, <2.11.0",
-    "cylc-flow==8.0a1",
+    "jinja2>=2.10.1",
+    "cylc-flow==8.*",
     "aiofiles",
     "tornado",
     "sqlalchemy",

--- a/t/rose-macro/00-null.t
+++ b/t/rose-macro/00-null.t
@@ -52,7 +52,7 @@ setup
 run_fail "$TEST_KEY" rose macro --unknown-option
 file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" <<'__CONTENT__'
-Usage: rose macro [OPTIONS] [MACRO_NAME ...]
+Usage: rose macro [options]
 
 rose macro: error: no such option: --unknown-option
 __CONTENT__

--- a/t/rose-macro/00-null.t
+++ b/t/rose-macro/00-null.t
@@ -52,7 +52,7 @@ setup
 run_fail "$TEST_KEY" rose macro --unknown-option
 file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" <<'__CONTENT__'
-Usage: rose macro [options]
+Usage: rose macro [OPTIONS] [MACRO_NAME ...]
 
 rose macro: error: no such option: --unknown-option
 __CONTENT__


### PR DESCRIPTION
## Fix setup.py for use with Cylc8
I can't see why there is an upper limit to jinja2 - it was introduced when I created the package a year ago.

## Fix broken macro test
This test was broken on master.