### PR TITLE
Address pre-/post-commit hook issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ coverage.xml
 htmlcov/
 
 *.egg-info
+.vscode/
+.pytest_cache/

--- a/lib/python/rose/config.py
+++ b/lib/python/rose/config.py
@@ -1171,10 +1171,11 @@ class ConfigLoader(object):
         """Initialise the configuration utility.
 
         Arguments:
-        char_comment -- the character to indicate the start of a
-        comment.
-        char_assign -- the character to use to delimit a key=value
-        assignment.
+            char_assign (str): the character to use to delimit a key=value
+                assignment.
+            char_comment (str): the character to indicate the start of a
+                comment.
+            allow_sections (bool): whether to permit sections in the config.
 
         """
         self.char_assign = char_assign

--- a/lib/python/rose/config.py
+++ b/lib/python/rose/config.py
@@ -1377,10 +1377,10 @@ class ConfigLoader(object):
                     value_cont = value_cont[1:]
                 node.set(keys[:], value + "\n" + value_cont)
                 continue
-            if self.allow_sections:
-                # Match a section header?
-                match = self.RE_SECTION.match(line)
-                if match:
+            # Match a section header?
+            match = self.RE_SECTION.match(line)
+            if match:
+                if self.allow_sections:
                     head, section, state = match.group(
                         "head", "section", "state")
                     bad_index = self._check_section_value(section)
@@ -1409,6 +1409,10 @@ class ConfigLoader(object):
                             section_node.comments += comments
                     comments = []
                     continue
+                else:
+                    raise ConfigSyntaxError(
+                        ConfigSyntaxError.SECTIONS_NOT_ALLOWED, file_name,
+                        line_num, 0, line)
             # Match the start of an option setting?
             match = self.re_option.match(line)
             if not match:
@@ -1541,11 +1545,13 @@ class ConfigSyntaxError(Exception):
     BAD_CHAR = "BAD_CHAR"
     BAD_SYNTAX = "BAD_SYNTAX"
     BAD_SYNTAX_NO_SECTIONS = "BAD_SYNTAX_NO_SECTIONS"
+    SECTIONS_NOT_ALLOWED = "SECTIONS_NOT_ALLOWED"
 
     MESSAGES = {
-        BAD_CHAR: """unexpected character or end of value""",
-        BAD_SYNTAX: '''expecting "[SECTION]" or "KEY=VALUE"''',
-        BAD_SYNTAX_NO_SECTIONS: '''expecting "KEY=VALUE"'''
+        BAD_CHAR: 'unexpected character or end of value',
+        BAD_SYNTAX: 'expecting "[SECTION]" or "KEY=VALUE"',
+        BAD_SYNTAX_NO_SECTIONS: 'expecting "KEY=VALUE"',
+        SECTIONS_NOT_ALLOWED: 'sections not permitted in this configuration'
     }
 
     def __init__(self, code, file_name, line_num, col_num, line):

--- a/lib/python/rosie/db_create.py
+++ b/lib/python/rosie/db_create.py
@@ -30,6 +30,7 @@ from rose.reporter import Reporter, Event
 from rose.resource import ResourceLocator
 from rosie.db import (
     LATEST_TABLE_NAME, MAIN_TABLE_NAME, META_TABLE_NAME, OPTIONAL_TABLE_NAME)
+from rosie.svn_hook import InfoFileError
 from rosie.svn_post_commit import RosieSvnPostCommitHook
 
 from rose.config import ConfigSyntaxError
@@ -203,7 +204,7 @@ class RosieDatabaseInitiator(object):
             try:
                 self.post_commit_hook.run(
                     repos_path, str(revision), no_notification=True)
-            except (ConfigSyntaxError, DatabaseError) as err:
+            except (ConfigSyntaxError, DatabaseError, InfoFileError) as err:
                 if sys.stdout.isatty():
                     sys.stdout.write("\r")
                     sys.stdout.flush()

--- a/lib/python/rosie/db_create.py
+++ b/lib/python/rosie/db_create.py
@@ -56,7 +56,13 @@ class RosieDatabaseCreateSkipEvent(Event):
 
 class RosieDatabaseLoadEvent(Event):
 
-    """Event raised when a Rosie database has loaded with I of N revisions."""
+    """Event raised when a Rosie database has loaded with I of N revisions.
+
+    Args:
+        repos_path (str)
+        revision (int) - Ith revision
+        youngest (int) - Nth revision
+    """
 
     LEVEL = Event.V
 
@@ -66,12 +72,17 @@ class RosieDatabaseLoadEvent(Event):
 
 class RosieDatabaseLoadSkipEvent(Event):
 
-    """Event raised when a Rosie database load is skipped."""
+    """Event raised when a Rosie database load is skipped.
+
+    Args:
+        repos_path (str)
+        message (str)
+    """
 
     KIND = Event.KIND_ERR
 
     def __str__(self):
-        return "%s: DB not loaded." % (self.args[0])
+        return "%s: DB not loaded: %s" % self.args
 
 
 class RosieDatabaseInitiator(object):
@@ -177,7 +188,8 @@ class RosieDatabaseInitiator(object):
     def load(self, repos_path):
         """Load database contents from a repository."""
         if not repos_path or not os.path.exists(repos_path):
-            self.handle_event(RosieDatabaseLoadSkipEvent(repos_path))
+            message = "Path not found"
+            self.handle_event(RosieDatabaseLoadSkipEvent(repos_path, message))
             return
         repos_path = os.path.abspath(repos_path)
         youngest = int(self.popen("svnlook", "youngest", repos_path)[0])
@@ -200,8 +212,7 @@ class RosieDatabaseInitiator(object):
                 message = ("Could not load revision {0} of {1} as the post-"
                            "commit hook failed:\r{2}\r".format(
                                 revision, youngest, err_msg))
-                self.handle_event(message, kind=Event.KIND_ERR)
-                event = RosieDatabaseLoadSkipEvent(repos_path)
+                event = RosieDatabaseLoadSkipEvent(repos_path, message)
             else:
                 event = RosieDatabaseLoadEvent(repos_path, revision, youngest)
             if revision == youngest:

--- a/lib/python/rosie/db_create.py
+++ b/lib/python/rosie/db_create.py
@@ -32,6 +32,9 @@ from rosie.db import (
     LATEST_TABLE_NAME, MAIN_TABLE_NAME, META_TABLE_NAME, OPTIONAL_TABLE_NAME)
 from rosie.svn_post_commit import RosieSvnPostCommitHook
 
+from rose.config import ConfigSyntaxError
+from sqlalchemy.exc import DatabaseError
+
 
 class RosieDatabaseCreateEvent(Event):
 
@@ -185,9 +188,22 @@ class RosieDatabaseInitiator(object):
                     "\r%s... loading revision %d of %d" %
                     (Reporter.PREFIX_INFO, revision, youngest))
                 sys.stdout.flush()
-            self.post_commit_hook.run(
-                repos_path, str(revision), no_notification=True)
-            event = RosieDatabaseLoadEvent(repos_path, revision, youngest)
+            try:
+                self.post_commit_hook.run(
+                    repos_path, str(revision), no_notification=True)
+            except (ConfigSyntaxError, DatabaseError) as err:
+                if sys.stdout.isatty():
+                    sys.stdout.write("\r")
+                    sys.stdout.flush()
+                err_msg = "Exception occurred: {0} - {1}".format(
+                    type(err).__name__, str(err))
+                message = ("Could not load revision {0} of {1} as the post-"
+                           "commit hook failed:\r{2}\r".format(
+                                revision, youngest, err_msg))
+                self.handle_event(message, kind=Event.KIND_ERR)
+                event = RosieDatabaseLoadSkipEvent(repos_path)
+            else:
+                event = RosieDatabaseLoadEvent(repos_path, revision, youngest)
             if revision == youngest:
                 # Check if any new revisions have been added.
                 youngest = self.popen("svnlook", "youngest", repos_path)[0]

--- a/lib/python/rosie/db_create.py
+++ b/lib/python/rosie/db_create.py
@@ -211,7 +211,7 @@ class RosieDatabaseInitiator(object):
                 err_msg = "Exception occurred: {0} - {1}".format(
                     type(err).__name__, str(err))
                 message = ("Could not load revision {0} of {1} as the post-"
-                           "commit hook failed:\r{2}\r".format(
+                           "commit hook failed:\n{2}\n".format(
                                 revision, youngest, err_msg))
                 event = RosieDatabaseLoadSkipEvent(repos_path, message)
             else:

--- a/lib/python/rosie/svn_hook.py
+++ b/lib/python/rosie/svn_hook.py
@@ -74,7 +74,7 @@ class RosieSvnHook(object):
             allow_popen_err (bool): If True, return None if a RosePopenError
                 occurs during svnlook command.
         """
-        if branch is None:
+        if not branch:
             branch = self.TRUNK
         commit_opts = []
         # TODO: warn or raise if both supplied?

--- a/lib/python/rosie/svn_hook.py
+++ b/lib/python/rosie/svn_hook.py
@@ -135,7 +135,6 @@ class RosieSvnHook(object):
         if not branch:
             branch = self.TRUNK
         commit_opts = []
-        # TODO: warn or raise if both supplied?
         if transaction is not None:
             if revision is not None:
                 raise ValueError(

--- a/lib/python/rosie/svn_hook.py
+++ b/lib/python/rosie/svn_hook.py
@@ -154,6 +154,6 @@ class RosieSvnHook(object):
                 return None
             raise err
         t_handle.seek(0)
-        config_node = ConfigLoader(allow_sections=False)(t_handle)
+        config_node = ConfigLoader(allow_sections=False).load(t_handle)
         t_handle.close()
         return config_node

--- a/lib/python/rosie/svn_hook.py
+++ b/lib/python/rosie/svn_hook.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python2
+# -----------------------------------------------------------------------------
+# Copyright (C) 2012-2020 British Crown (Met Office) & Contributors.
+#
+# This file is part of Rose, a framework for meteorological suites.
+#
+# Rose is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Rose is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Rose. If not, see <http://www.gnu.org/licenses/>.
+# -----------------------------------------------------------------------------
+
+import os
+import sys
+import rose
+from rose.popen import RosePopener, RosePopenError
+from rose.reporter import Reporter
+from tempfile import TemporaryFile
+
+
+class RosieSvnHook(object):
+    """A parent class for hooks on a Rosie Subversion repository."""
+
+    DATE_FMT = "%Y-%m-%d %H:%M:%S %Z"
+    ID_CHARS_LIST = ["abcdefghijklmnopqrstuvwxyz"] * 2 + ["0123456789"] * 3
+    LEN_ID = len(ID_CHARS_LIST)
+    TRUNK = "trunk"
+    INFO_FILE = "rose-suite.info"
+    TRUNK_INFO_FILE = "trunk/rose-suite.info"
+    ST_ADDED = "A"
+    ST_DELETED = "D"
+    ST_MODIFIED = "M"
+    ST_UPDATED = "U"
+    ST_EMPTY = " "
+
+    def __init__(self, event_handler=None, popen=None):
+        if event_handler is None:
+            event_handler = Reporter()
+        self.event_handler = event_handler
+        if popen is None:
+            popen = RosePopener(self.event_handler)
+        self.popen = popen
+        self.path = os.path.dirname(
+            os.path.dirname(sys.modules["rosie"].__file__))
+
+    def _svnlook(self, *args):
+        """Return the standard output from "svnlook"."""
+        command = ["svnlook"] + list(args)
+        return self.popen(*command)[0]
+
+    def _load_info(self, repos, sid, branch=None, revision=None,
+                   transaction=None, allow_popen_err=False):
+        """Load info file from branch_path in repos @revision.
+
+        Returns a ConfigNode for the "rose-suite.info" of a suite at a
+        particular revision or transaction.
+
+        Args:
+            repos (str): The path of the repository.
+            sid (str): The Rosie suite unique identifier, e.g. "ay327".
+            branch (str): The branch that the info file is under.
+            revision (int, str): A commit revision number. Cannot be used with
+                transaction.
+            transaction (str): A commit transaction identifer. Cannot be used
+                with revision.
+            allow_popen_err (bool): If True, return None if a RosePopenError
+                occurs during svnlook command.
+        """
+        if branch is None:
+            branch = self.TRUNK
+        commit_opts = []
+        # TODO: warn or raise if both supplied?
+        if transaction is not None:
+            commit_opts = ["-t", transaction]
+        if revision is not None:
+            commit_opts = ["-r", str(revision)]
+        info_file_path = "%s/%s/%s" % ("/".join(sid), branch, self.INFO_FILE)
+        t_handle = TemporaryFile()
+        try:
+            t_handle.write(
+                self._svnlook("cat", repos, info_file_path, *commit_opts))
+        except RosePopenError as err:
+            if allow_popen_err:
+                return None
+            raise err
+        t_handle.seek(0)
+        config_node = rose.config.load(t_handle)
+        t_handle.close()
+        return config_node

--- a/lib/python/rosie/svn_hook.py
+++ b/lib/python/rosie/svn_hook.py
@@ -20,7 +20,7 @@
 
 import os
 import sys
-import rose
+from rose.config import ConfigLoader
 from rose.popen import RosePopener, RosePopenError
 from rose.reporter import Reporter
 from tempfile import TemporaryFile
@@ -92,6 +92,6 @@ class RosieSvnHook(object):
                 return None
             raise err
         t_handle.seek(0)
-        config_node = rose.config.load(t_handle)
+        config_node = ConfigLoader(allow_sections=False)(t_handle)
         t_handle.close()
         return config_node

--- a/lib/python/rosie/svn_hook.py
+++ b/lib/python/rosie/svn_hook.py
@@ -137,6 +137,10 @@ class RosieSvnHook(object):
         commit_opts = []
         # TODO: warn or raise if both supplied?
         if transaction is not None:
+            if revision is not None:
+                raise ValueError(
+                    "Cannot load transaction {0} and revision {1} at the "
+                    "same time".format(transaction, revision))
             commit_opts = ["-t", transaction]
         if revision is not None:
             commit_opts = ["-r", str(revision)]

--- a/lib/python/rosie/svn_hook.py
+++ b/lib/python/rosie/svn_hook.py
@@ -26,6 +26,64 @@ from rose.reporter import Reporter
 from tempfile import TemporaryFile
 
 
+class BadChange(Exception):
+    """An error representing a bad change in a commit transaction."""
+
+    FMT_HEAD = "%s: %-4s%s"
+    FMT_TAIL_1 = ": %s"
+    FMT_TAIL_M = ":\n%s"
+    NO_INFO = "SUITE MUST HAVE INFO FILE"
+    NO_OWNER = "SUITE MUST HAVE OWNER SPECIFIED IN INFO FILE"
+    NO_TRUNK = "SUITE MUST HAVE TRUNK"
+    PERM = "PERMISSION DENIED"
+    USER = "NO SUCH USER"
+    VALUE = "BAD VALUE IN FILE"
+
+    def __init__(self, status, path, reason=PERM, content=""):
+        Exception.__init__(self, status, path, reason, content)
+        self.status = status
+        self.path = path
+        self.reason = reason
+        self.content = content
+
+    def __str__(self):
+        tail = ""
+        if self.content and "\n" in self.content:
+            tail = self.FMT_TAIL_M % self.content
+        elif self.content:
+            tail = self.FMT_TAIL_1 % self.content
+        return self.FMT_HEAD % (self.reason, self.status, self.path) + tail
+
+
+class InfoFileError(BadChange):
+    """Error representing a bad or missing info file.
+
+    Args:
+        reason (str): a user-friendly message.
+        exception (Exception): the exception encountered in loading the
+            bad info file.
+    """
+
+    VALUE = "BAD VALUE IN INFO FILE"
+
+    def __init__(self, reason=BadChange.PERM, exception=None):
+        self.reason = reason
+        self.exc = exception
+
+    def __str__(self):
+        if self.exc:
+            return "{0}: {1}".format(self.reason, self.exc)
+        return self.reason
+
+
+class BadChanges(Exception):
+    """An error representing bad changes in a commit transaction."""
+
+    def __str__(self):
+        bad_changes = self.args[0]
+        return "\n".join([str(bad_change) for bad_change in bad_changes])
+
+
 class RosieSvnHook(object):
     """A parent class for hooks on a Rosie Subversion repository."""
 

--- a/lib/python/rosie/svn_post_commit.py
+++ b/lib/python/rosie/svn_post_commit.py
@@ -220,6 +220,7 @@ class RosieSvnPostCommitHook(RosieSvnHook):
                     branch_attribs["info"] = self._load_info(
                         repos, sid, branch, revision=revision,
                         allow_popen_err=True)
+                    # Note: if (allowed) popen err, no DB entry will be created
                 if (branch_attribs["old_info"] is None and
                         branch_attribs["status"] == self.ST_DELETED):
                     branch_attribs["old_info"] = self._load_info(
@@ -381,7 +382,7 @@ class RosieSvnPostCommitHook(RosieSvnHook):
             "author": changeset_attribs["author"],
             "date": changeset_attribs["date"]})
         for name in ["owner", "project", "title"]:
-            cols[name] = branch_attribs[info_key].get_value([name])
+            cols[name] = branch_attribs[info_key].get_value([name], "null")
         if branch_attribs["from_path"] and vc_attrs["branch"] == u"trunk":
             from_names = branch_attribs["from_path"].split("/")[:self.LEN_ID]
             cols["from_idx"] = "{0}-{1}".format(

--- a/lib/python/rosie/svn_post_commit.py
+++ b/lib/python/rosie/svn_post_commit.py
@@ -350,11 +350,13 @@ class RosieSvnPostCommitHook(RosieSvnHook):
 
     def _update_info_db(self, dao, changeset_attribs, branch_attribs):
         """Update the suite info database for a suite branch."""
-        idx = changeset_attribs["prefix"] + "-" + branch_attribs["sid"]
+        idx = "{0}-{1}".format(
+            changeset_attribs["prefix"], branch_attribs["sid"])
         vc_attrs = {
             "idx": idx,
             "branch": branch_attribs["branch"],
-            "revision": changeset_attribs["revision"]}
+            "revision": changeset_attribs["revision"]
+        }
         for key in vc_attrs:
             vc_attrs[key] = vc_attrs[key].decode("utf-8")
         # Latest table
@@ -382,8 +384,8 @@ class RosieSvnPostCommitHook(RosieSvnHook):
             cols[name] = branch_attribs[info_key].get_value([name])
         if branch_attribs["from_path"] and vc_attrs["branch"] == u"trunk":
             from_names = branch_attribs["from_path"].split("/")[:self.LEN_ID]
-            cols["from_idx"] = (
-                changeset_attribs["prefix"] + "-" + "".join(from_names))
+            cols["from_idx"] = "{0}-{1}".format(
+                changeset_attribs["prefix"], "".join(from_names))
         cols["status"] = (
             branch_attribs["status"] + branch_attribs["status_info_file"])
         for key in cols:
@@ -401,7 +403,9 @@ class RosieSvnPostCommitHook(RosieSvnHook):
                 continue
             cols = dict(vc_attrs)
             cols.update({
-                "name": name.decode("utf-8"), "value": value.decode("utf-8")})
+                "name": name.decode("utf-8"),
+                "value": value.decode("utf-8")
+            })
             dao.insert(OPTIONAL_TABLE_NAME, **cols)
 
     def _update_known_keys(self, dao, changeset_attribs):

--- a/lib/python/rosie/svn_pre_commit.py
+++ b/lib/python/rosie/svn_pre_commit.py
@@ -207,6 +207,15 @@ class RosieSvnPreCommitHook(RosieSvnHook):
                 if sid not in txn_info_map:
                     txn_info_map[sid] = self._load_info(
                         repos, sid, branch=branch, transaction=txn)
+
+                # Suite must have an owner
+                txn_owner, txn_access_list = self._get_access_info(
+                    txn_info_map[sid])
+                if not txn_owner:
+                    bad_changes.append(
+                        BadChange(status, path, BadChange.NO_OWNER))
+                    continue
+
             # No need to check other non-trunk changes (?)
             if branch and branch != "trunk":
                 continue
@@ -221,7 +230,6 @@ class RosieSvnPreCommitHook(RosieSvnHook):
                         BadChange(status, path, BadChange.VALUE))
                     continue
 
-            # Suite trunk information file must have an owner
             # User IDs of owner and access list must be real
             if (status != self.ST_DELETED and
                     path_tail == self.TRUNK_INFO_FILE):
@@ -230,10 +238,6 @@ class RosieSvnPreCommitHook(RosieSvnHook):
                         repos, sid, branch=branch, transaction=txn)
                 txn_owner, txn_access_list = self._get_access_info(
                     txn_info_map[sid])
-                if not txn_owner:
-                    bad_changes.append(
-                        BadChange(status, path, BadChange.NO_OWNER))
-                    continue
                 if self._verify_users(
                         status, path, txn_owner, txn_access_list, bad_changes):
                     continue
@@ -294,16 +298,6 @@ class RosieSvnPreCommitHook(RosieSvnHook):
                     continue
             else:
                 bad_changes.append(BadChange(status, path))
-                continue
-
-            # The owner must not be deleted
-            if sid not in txn_info_map:
-                txn_info_map[sid] = self._load_info(
-                    repos, sid, branch=branch, transaction=txn)
-            txn_owner, txn_access_list = self._get_access_info(
-                txn_info_map[sid])
-            if not txn_owner:
-                bad_changes.append(BadChange(status, path, BadChange.NO_OWNER))
                 continue
 
             # Only the admin users can change owner and access list

--- a/lib/python/rosie/svn_pre_commit.py
+++ b/lib/python/rosie/svn_pre_commit.py
@@ -186,10 +186,6 @@ class RosieSvnPreCommitHook(RosieSvnHook):
                 bad_changes.append(BadChange(status, path))
                 continue
 
-            # No need to check non-trunk changes  # Why?
-            # if len(names) > self.LEN_ID and names[self.LEN_ID] != "trunk":
-            #     continue
-
             # New suite should have an info file
             if status[0] == self.ST_ADDED and len(names) == self.LEN_ID:
                 if (self.ST_ADDED, path + "trunk/") not in changes:
@@ -202,6 +198,10 @@ class RosieSvnPreCommitHook(RosieSvnHook):
                          path_trunk_info_file) not in changes):
                     bad_changes.append(
                         BadChange(status, path, BadChange.NO_INFO))
+                continue
+
+            # No need to check non-trunk changes  # Why?
+            if len(names) > self.LEN_ID and names[self.LEN_ID] != "trunk":
                 continue
 
             # The rest are trunk changes in a suite

--- a/lib/python/rosie/svn_pre_commit.py
+++ b/lib/python/rosie/svn_pre_commit.py
@@ -275,7 +275,7 @@ class RosieSvnPreCommitHook(RosieSvnHook):
                         break
             if sid not in rev_info_map:
                 rev_info_map[sid] = self._load_info(
-                    repos, sid, branch=branch, transaction=txn)
+                    repos, sid, branch=branch)
             owner, access_list = self._get_access_info(rev_info_map[sid])
             admin_users = super_users + [owner]
 

--- a/lib/python/rosie/svn_pre_commit.py
+++ b/lib/python/rosie/svn_pre_commit.py
@@ -189,7 +189,7 @@ class RosieSvnPreCommitHook(RosieSvnHook):
                             InfoFileError(InfoFileError.NO_OWNER))
                         continue
 
-            # No need to check other non-trunk changes (?)
+            # No need to check other non-trunk changes
             if branch and branch != "trunk":
                 continue
 

--- a/lib/python/rosie/svn_pre_commit.py
+++ b/lib/python/rosie/svn_pre_commit.py
@@ -35,71 +35,10 @@ from rose.resource import ResourceLocator
 from rose.scheme_handler import SchemeHandlersManager
 from rose.config import ConfigSyntaxError
 from rose.popen import RosePopenError
-from rosie.svn_hook import RosieSvnHook
+from rosie.svn_hook import RosieSvnHook, BadChange, InfoFileError, BadChanges
 import shlex
 import sys
 import traceback
-
-
-class BadChange(Exception):
-
-    """An error representing a bad change in a commit transaction."""
-
-    FMT_HEAD = "%s: %-4s%s"
-    FMT_TAIL_1 = ": %s"
-    FMT_TAIL_M = ":\n%s"
-    NO_INFO = "SUITE MUST HAVE INFO FILE"
-    NO_OWNER = "SUITE MUST HAVE OWNER SPECIFIED IN INFO FILE"
-    NO_TRUNK = "SUITE MUST HAVE TRUNK"
-    PERM = "PERMISSION DENIED"
-    USER = "NO SUCH USER"
-    VALUE = "BAD VALUE IN FILE"
-
-    def __init__(self, status, path, reason=PERM, content=""):
-        Exception.__init__(self, status, path, reason, content)
-        self.status = status
-        self.path = path
-        self.reason = reason
-        self.content = content
-
-    def __str__(self):
-        tail = ""
-        if self.content and "\n" in self.content:
-            tail = self.FMT_TAIL_M % self.content
-        elif self.content:
-            tail = self.FMT_TAIL_1 % self.content
-        return self.FMT_HEAD % (self.reason, self.status, self.path) + tail
-
-
-class BadChanges(Exception):
-
-    """An error representing bad changes in a commit transaction."""
-
-    def __str__(self):
-        bad_changes = self.args[0]
-        return "\n".join([str(bad_change) for bad_change in bad_changes])
-
-
-class InfoFileError(BadChange):
-
-    """Error representing a bad or missing info file.
-
-    Args:
-        reason (str): a user-friendly message.
-        exception (Exception): the exception encountered in loading the
-            bad info file.
-    """
-
-    VALUE = "BAD VALUE IN '{0}'".format(RosieSvnHook.INFO_FILE)
-
-    def __init__(self, reason=BadChange.PERM, exception=None):
-        self.reason = reason
-        self.exc = exception
-
-    def __str__(self):
-        if self.exc:
-            return "{0}: {1}".format(self.reason, self.exc)
-        return self.reason
 
 
 class RosieSvnPreCommitHook(RosieSvnHook):

--- a/lib/python/rosie/svn_pre_commit.py
+++ b/lib/python/rosie/svn_pre_commit.py
@@ -260,6 +260,7 @@ class RosieSvnPreCommitHook(RosieSvnHook):
                 continue
 
             # Can only remove trunk with suite
+            # (Don't allow replacing trunk with a copy from elsewhere, either)
             if status == self.ST_DELETED and path_tail == "trunk/":
                 if (self.ST_DELETED, path_head) not in changes:
                     bad_changes.append(

--- a/lib/python/rosie/svn_pre_commit.py
+++ b/lib/python/rosie/svn_pre_commit.py
@@ -49,7 +49,7 @@ class BadChange(Exception):
     FMT_TAIL_1 = ": %s"
     FMT_TAIL_M = ":\n%s"
     NO_INFO = "SUITE MUST HAVE INFO FILE"
-    NO_OWNER = "SUITE MUST HAVE OWNER"
+    NO_OWNER = "SUITE MUST HAVE OWNER SPECIFIED IN INFO FILE"
     NO_TRUNK = "SUITE MUST HAVE TRUNK"
     PERM = "PERMISSION DENIED"
     USER = "NO SUCH USER"
@@ -236,7 +236,7 @@ class RosieSvnPreCommitHook(RosieSvnHook):
                     except ConfigSyntaxError as exc:
                         err = InfoFileError(InfoFileError.VALUE, exc)
                     except RosePopenError as exc:
-                        err = InfoFileError(InfoFileError.NO_INFO, exc)
+                        err = InfoFileError(InfoFileError.NO_INFO, exc.stderr)
                     if err:
                         bad_changes.append(err)
                         txn_info_map[sid] = err
@@ -247,7 +247,7 @@ class RosieSvnPreCommitHook(RosieSvnHook):
                         txn_info_map[sid])
                     if not txn_owner:
                         bad_changes.append(
-                            BadChange(status, path, BadChange.NO_OWNER))
+                            InfoFileError(InfoFileError.NO_OWNER))
                         continue
 
             # No need to check other non-trunk changes (?)

--- a/lib/python/rosie/svn_pre_commit.py
+++ b/lib/python/rosie/svn_pre_commit.py
@@ -158,8 +158,6 @@ class RosieSvnPreCommitHook(RosieSvnHook):
 
             names = path.split("/", self.LEN_ID + 1)
             tail = None
-            sid = "".join(names[0:self.LEN_ID])
-            branch = names[self.LEN_ID]
             if not names[-1]:
                 tail = names.pop()
 
@@ -173,21 +171,19 @@ class RosieSvnPreCommitHook(RosieSvnHook):
                 bad_changes.append(BadChange(status, path))
                 continue
 
-            # Can only add directories at levels above the suites
+            # At levels above the suites, can only add directories
             if len(names) < self.LEN_ID:
                 if status[0] != self.ST_ADDED:
                     bad_changes.append(BadChange(status, path))
                 continue
-            else:
-                is_meta_suite = "".join(names[0:self.LEN_ID]) == "ROSIE"
 
-            # A file at the branch level
+            # Cannot have a file at the branch level
             if len(names) == self.LEN_ID + 1 and tail is None:
                 bad_changes.append(BadChange(status, path))
                 continue
 
             # New suite should have an info file
-            if status[0] == self.ST_ADDED and len(names) == self.LEN_ID:
+            if len(names) == self.LEN_ID and status == self.ST_ADDED:
                 if (self.ST_ADDED, path + "trunk/") not in changes:
                     bad_changes.append(
                         BadChange(status, path, BadChange.NO_TRUNK))
@@ -200,13 +196,20 @@ class RosieSvnPreCommitHook(RosieSvnHook):
                         BadChange(status, path, BadChange.NO_INFO))
                 continue
 
-            # No need to check non-trunk changes  # Why?
-            if len(names) > self.LEN_ID and names[self.LEN_ID] != "trunk":
-                continue
-
-            # The rest are trunk changes in a suite
+            sid = "".join(names[0:self.LEN_ID])
+            branch = names[self.LEN_ID] if len(names) > self.LEN_ID else None
             path_head = "/".join(sid) + "/"
             path_tail = path[len(path_head):]
+            is_meta_suite = (sid == "ROSIE")
+
+            if status != self.ST_DELETED:
+                # Check info file
+                if sid not in txn_info_map:
+                    txn_info_map[sid] = self._load_info(
+                        repos, sid, branch=branch, transaction=txn)
+            # No need to check other non-trunk changes (?)
+            if branch and branch != "trunk":
+                continue
 
             # For meta suite, make sure keys in keys file can be parsed
             if is_meta_suite and path_tail == self.TRUNK_KNOWN_KEYS_FILE:
@@ -220,7 +223,7 @@ class RosieSvnPreCommitHook(RosieSvnHook):
 
             # Suite trunk information file must have an owner
             # User IDs of owner and access list must be real
-            if (status not in self.ST_DELETED and
+            if (status != self.ST_DELETED and
                     path_tail == self.TRUNK_INFO_FILE):
                 if sid not in txn_info_map:
                     txn_info_map[sid] = self._load_info(

--- a/t/rosa-svn-post-commit/03-unicode.t
+++ b/t/rosa-svn-post-commit/03-unicode.t
@@ -24,7 +24,7 @@
 if ! python2 -c 'import sqlalchemy' 2>'/dev/null'; then
     skip_all '"sqlalchemy" not installed'
 fi
-tests 10
+tests 15
 #-------------------------------------------------------------------------------
 set -e
 mkdir 'repos'
@@ -117,4 +117,34 @@ foo-aa000|trunk|2|access-list|*
 foo-aa000|trunk|2|more-title|We will lose € if we can't handle unicode
 __OUT__
 #-------------------------------------------------------------------------------
+TEST_KEY="${TEST_KEY_BASE}-western"
+INFO_FILE="${PWD}/roses/foo-aa000/rose-suite.info"
+cat > "$INFO_FILE" <<'__ROSE_SUITE_INFO'
+access-list=*
+owner=ivy
+project=euro
+title=What if we éñçöde the info file in latin-1/western?
+more-title=Foo â bar
+__ROSE_SUITE_INFO
+iconv -f UTF-8 -t LATIN1 "$INFO_FILE" -o "$INFO_FILE"
+set -e
+svn commit -q -m 't' "${PWD}/roses/foo-aa000"
+svn update -q "${PWD}/roses/foo-aa000"
+set +e
+file_cmp "${TEST_KEY}-hook.out" "${PWD}/rosa-svn-post-commit.out" <'/dev/null'
+file_cmp "${TEST_KEY}-hook.err" "${PWD}/rosa-svn-post-commit.err" <'/dev/null'
+file_cmp "${TEST_KEY}-hook.rc" "${PWD}/rosa-svn-post-commit.rc" <<<'0'
+
+TEST_KEY="${TEST_KEY}-db-select"
+sqlite3 "${PWD}/repos/foo.db" "${Q_MAIN} WHERE idx=='foo-aa000' AND revision=='3'" \
+    >"${TEST_KEY}-main.out"
+file_cmp "${TEST_KEY}-main.out" "${TEST_KEY}-main.out" <<__OUT__
+foo-aa000|trunk|3|ivy|euro|What if we éñçöde the info file in latin-1/western?|${USER}| M|
+__OUT__
+sqlite3 "${PWD}/repos/foo.db" "${Q_OPTIONAL} WHERE idx=='foo-aa000' AND revision=='3'" \
+    >"${TEST_KEY}-optional.out"
+file_cmp "${TEST_KEY}-optional.out" "${TEST_KEY}-optional.out" <<'__OUT__'
+foo-aa000|trunk|3|access-list|*
+foo-aa000|trunk|3|more-title|Foo â bar
+__OUT__
 exit 0

--- a/t/rosa-svn-pre-commit/00-basic.t
+++ b/t/rosa-svn-pre-commit/00-basic.t
@@ -71,6 +71,7 @@ file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
 sed -i '/^\[FAIL\]/!d' "$TEST_KEY.err"
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" <<'__ERR__'
 [FAIL] SUITE MUST HAVE TRUNK: A   a/a/0/0/0/
+[FAIL] SUITE MUST HAVE INFO FILE: svnlook: E160013: Path 'a/a/0/0/0/0/rose-suite.info' does not exist
 __ERR__
 #-------------------------------------------------------------------------------
 TEST_KEY=$TEST_KEY_BASE-create-no-info
@@ -80,6 +81,7 @@ file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
 sed -i '/^\[FAIL\]/!d' "$TEST_KEY.err"
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" <<'__ERR__'
 [FAIL] SUITE MUST HAVE INFO FILE: A   a/a/0/0/0/
+[FAIL] SUITE MUST HAVE INFO FILE: svnlook: E160013: Path 'a/a/0/0/0/trunk/rose-suite.info' does not exist
 __ERR__
 #-------------------------------------------------------------------------------
 TEST_KEY=$TEST_KEY_BASE-create-empty-info
@@ -90,7 +92,15 @@ run_fail "$TEST_KEY" \
 file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
 sed -i '/^\[FAIL\]/!d' "$TEST_KEY.err"
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" <<'__ERR__'
-[FAIL] SUITE MUST HAVE OWNER: A   a/a/0/0/0/trunk/rose-suite.info
+[FAIL] SUITE MUST HAVE OWNER SPECIFIED IN INFO FILE
+[FAIL] BAD VALUE IN FILE: A   a/a/0/0/0/trunk/rose-suite.info:
+[FAIL] a/a/0/0/0/trunk/rose-suite.info: issues: 3
+[FAIL]     =owner=None
+[FAIL]         Variable set as compulsory, but not in configuration.
+[FAIL]     =project=None
+[FAIL]         Variable set as compulsory, but not in configuration.
+[FAIL]     =title=None
+[FAIL]         Variable set as compulsory, but not in configuration.
 __ERR__
 #-------------------------------------------------------------------------------
 TEST_KEY=$TEST_KEY_BASE-create-empty-owner
@@ -103,7 +113,15 @@ run_fail "$TEST_KEY" \
 file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
 sed -i '/^\[FAIL\]/!d' "$TEST_KEY.err"
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" <<'__ERR__'
-[FAIL] SUITE MUST HAVE OWNER: A   a/a/0/0/0/trunk/rose-suite.info
+[FAIL] SUITE MUST HAVE OWNER SPECIFIED IN INFO FILE
+[FAIL] BAD VALUE IN FILE: A   a/a/0/0/0/trunk/rose-suite.info:
+[FAIL] a/a/0/0/0/trunk/rose-suite.info: issues: 3
+[FAIL]     =project=None
+[FAIL]         Variable set as compulsory, but not in configuration.
+[FAIL]     =title=None
+[FAIL]         Variable set as compulsory, but not in configuration.
+[FAIL]     =owner=
+[FAIL]         Value  does not contain the pattern: ^.+(?# Must not be empty)
 __ERR__
 #-------------------------------------------------------------------------------
 TEST_KEY=$TEST_KEY_BASE-create-good-1
@@ -195,7 +213,7 @@ run_fail "$TEST_KEY" svn ci -q -m't' --username=daisy work/aa000
 file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
 sed -i '/^\[FAIL\]/!d' "$TEST_KEY.err"
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" <<'__ERR__'
-[FAIL] SUITE MUST HAVE OWNER: U   a/a/0/0/0/trunk/rose-suite.info
+[FAIL] SUITE MUST HAVE OWNER SPECIFIED IN INFO FILE
 __ERR__
 svn revert -q -R work/aa000
 #-------------------------------------------------------------------------------

--- a/t/rose-config/02-self.py
+++ b/t/rose-config/02-self.py
@@ -222,6 +222,31 @@ bar=BAR BAR BAR
         self.assertEqual(node.value, "hi")
         self.assertEqual(node.state, "!!")
 
+    def test_load_bad_syntax(self):
+        """Test loading a configuration with bad syntax present"""
+        loader = rose.config.ConfigLoader()
+        source = StringIO("""# test
+foo=bar
+baz
+""")
+        with self.assertRaises(rose.config.ConfigSyntaxError) as cm:
+            loader.load(source)
+        assert cm.exception.code == 'BAD_SYNTAX'
+        assert cm.exception.line_num == 3
+
+    def test_load_info_config_bad_syntax(self):
+        """Test loading a configuration in which sections are not allowed"""
+        loader = rose.config.ConfigLoader(allow_sections=False)
+        source = StringIO("""# test
+stuff=stuffing
+[egg]
+boiled=false
+""")
+        with self.assertRaises(rose.config.ConfigSyntaxError) as cm:
+            loader.load(source)
+        assert cm.exception.code == 'SECTIONS_NOT_ALLOWED'
+        assert cm.exception.line_num == 3
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes several bugs.

Pre-commit hook:
- Check validity of rose-suite.info in branches, not just trunk, for each transaction (this includes whether the file is present, whether the owner, title, project are specified)
- Ensure sections are not permitted in the info file

Post-commit hook:
- If the info file fail is not encoded in UTF-8, try latin-1 aka ISO 8859-1 for decoding (this decoding is necessary to store the info files values in the database)
- If owner, project or title missing in a historical commit, insert the string `'null'` into the database instead of no entry at all

`db_create.py`:
- Instead of returning if the post-commit hook fails, skip the revision and continue