### PR TITLE
Fix broken checkbox in rosie suites discovery

### DIFF
--- a/lib/html/static/js/rosie-disco.js
+++ b/lib/html/static/js/rosie-disco.js
@@ -63,7 +63,7 @@ Rosie.query = function() {
         q += "q=" + filter_list.join("+");
         var suffix = row.attr("id").substr(1);
     });
-    if ($("#query-all").attr("checked")) {
+    if ($("#query-all").prop("checked")) {
         q += "&all_revs=1"
     }
     if (q_open_groups != 0) {


### PR DESCRIPTION
In the query page of Rosie Suites Discovery, the "all revisions" checkbox wasn't working