### PR TITLE
Fix broken checkbox in rosie suites discovery (master branch)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ dist
 .coverage.*
 coverage.xml
 htmlcov/
+
+.vscode/
+.pytest_cache/

--- a/metomi/rosie/lib/html/static/js/rosie-disco.js
+++ b/metomi/rosie/lib/html/static/js/rosie-disco.js
@@ -62,7 +62,7 @@ Rosie.query = function() {
         }
         q += "q=" + filter_list.join("+");
     });
-    if ($("#query-all").attr("checked")) {
+    if ($("#query-all").prop("checked")) {
         q += "&all_revs=1"
     }
     if (q_open_groups != 0) {


### PR DESCRIPTION
Cherry-picked #2418 - In the query page of Rosie Suites Discovery, the "all revisions" checkbox wasn't working