### PR TITLE
Fix db-create, pre-/post-commit hooks

### DIFF
--- a/metomi/rose/config.py
+++ b/metomi/rose/config.py
@@ -1359,6 +1359,8 @@ class ConfigLoader(object):
         if node is None:
             node = ConfigNode()
         handle, file_name = self._get_file_and_name(source)
+        if isinstance(file_name, int):  # Probably a temporary file
+            file_name = ""
         keys = []  # Currently position under root node
         type_ = None  # Type of current node, section or option?
         comments = None  # Comments associated with next node
@@ -1583,12 +1585,10 @@ class ConfigSyntaxError(ConfigError):
         self.line = line
 
     def __str__(self):
-        return "%s(%d): %s\n%s%s^" % (
-            self.file_name,
-            self.line_num,
-            self.MESSAGES[self.code],
-            self.line,
-            " " * self.col_num)
+        msg = self.MESSAGES[self.code]
+        return (
+            f"{self.file_name}(line {self.line_num}): {msg}\n"
+            f"{self.line}{' ' * self.col_num}^")
 
 
 class ConfigDecodeError(ConfigError):

--- a/metomi/rose/config.py
+++ b/metomi/rose/config.py
@@ -1175,7 +1175,8 @@ class ConfigLoader(object):
     TYPE_OPTION = "TYPE_OPTION"
     UNKNOWN_NAME = "<???>"
 
-    def __init__(self, char_assign=CHAR_ASSIGN, char_comment=CHAR_COMMENT):
+    def __init__(self, char_assign=CHAR_ASSIGN, char_comment=CHAR_COMMENT,
+                 allow_sections=True):
         """Initialise the configuration utility.
 
         Arguments:
@@ -1187,6 +1188,7 @@ class ConfigLoader(object):
         """
         self.char_assign = char_assign
         self.char_comment = char_comment
+        self.allow_sections = allow_sections
         self.re_option = re.compile(
             r"^(?P<state>!?!?)(?P<option>[^\s" +
             char_assign + r"]+)\s*" +
@@ -1386,41 +1388,46 @@ class ConfigLoader(object):
                     value_cont = value_cont[1:]
                 node.set(keys[:], value + "\n" + value_cont)
                 continue
-            # Match a section header?
-            match = self.RE_SECTION.match(line)
-            if match:
-                head, section, state = match.group("head", "section", "state")
-                bad_index = self._check_section_value(section)
-                if bad_index > -1:
-                    raise ConfigSyntaxError(
-                        ConfigSyntaxError.BAD_CHAR,
-                        file_name, line_num, len(head) + bad_index, line)
-                # Find position under root node
-                if type_ == self.TYPE_OPTION:
-                    keys.pop()
-                if keys:
-                    keys.pop()
-                section = section.strip()
-                if section:
-                    keys.append(section)
-                    type_ = self.TYPE_SECTION
-                else:
-                    keys = []
-                    type_ = None
-                section_node = node.get(keys[:])
-                if section_node is None:
-                    node.set(keys[:], {}, state, comments)
-                else:
-                    section_node.state = state
-                    if comments:
-                        section_node.comments += comments
-                comments = []
-                continue
+            if self.allow_sections:
+                # Match a section header?
+                match = self.RE_SECTION.match(line)
+                if match:
+                    head, section, state = match.group(
+                        "head", "section", "state")
+                    bad_index = self._check_section_value(section)
+                    if bad_index > -1:
+                        raise ConfigSyntaxError(
+                            ConfigSyntaxError.BAD_CHAR,
+                            file_name, line_num, len(head) + bad_index, line)
+                    # Find position under root node
+                    if type_ == self.TYPE_OPTION:
+                        keys.pop()
+                    if keys:
+                        keys.pop()
+                    section = section.strip()
+                    if section:
+                        keys.append(section)
+                        type_ = self.TYPE_SECTION
+                    else:
+                        keys = []
+                        type_ = None
+                    section_node = node.get(keys[:])
+                    if section_node is None:
+                        node.set(keys[:], {}, state, comments)
+                    else:
+                        section_node.state = state
+                        if comments:
+                            section_node.comments += comments
+                    comments = []
+                    continue
             # Match the start of an option setting?
             match = self.re_option.match(line)
             if not match:
-                raise ConfigSyntaxError(
-                    ConfigSyntaxError.BAD_SYNTAX, file_name, line_num, 0, line)
+                if self.allow_sections:
+                    err = ConfigSyntaxError.BAD_SYNTAX
+                else:
+                    err = ConfigSyntaxError.BAD_SYNTAX_NO_SECTIONS
+                raise ConfigSyntaxError(err, file_name, line_num, 0, line)
             option, value, state = match.group("option", "value", "state")
             if type_ == self.TYPE_OPTION:
                 keys.pop()
@@ -1545,10 +1552,12 @@ class ConfigSyntaxError(Exception):
 
     BAD_CHAR = "BAD_CHAR"
     BAD_SYNTAX = "BAD_SYNTAX"
+    BAD_SYNTAX_NO_SECTIONS = "BAD_SYNTAX_NO_SECTIONS"
 
     MESSAGES = {
         BAD_CHAR: """unexpected character or end of value""",
         BAD_SYNTAX: '''expecting "[SECTION]" or "KEY=VALUE"''',
+        BAD_SYNTAX_NO_SECTIONS: '''expecting "KEY=VALUE"'''
     }
 
     def __init__(self, code, file_name, line_num, col_num, line):

--- a/metomi/rose/config.py
+++ b/metomi/rose/config.py
@@ -1388,10 +1388,10 @@ class ConfigLoader(object):
                     value_cont = value_cont[1:]
                 node.set(keys[:], value + "\n" + value_cont)
                 continue
-            if self.allow_sections:
-                # Match a section header?
-                match = self.RE_SECTION.match(line)
-                if match:
+            # Match a section header?
+            match = self.RE_SECTION.match(line)
+            if match:
+                if self.allow_sections:
                     head, section, state = match.group(
                         "head", "section", "state")
                     bad_index = self._check_section_value(section)
@@ -1420,6 +1420,10 @@ class ConfigLoader(object):
                             section_node.comments += comments
                     comments = []
                     continue
+                else:
+                    raise ConfigSyntaxError(
+                        ConfigSyntaxError.SECTIONS_NOT_ALLOWED, file_name,
+                        line_num, 0, line)
             # Match the start of an option setting?
             match = self.re_option.match(line)
             if not match:
@@ -1553,11 +1557,13 @@ class ConfigSyntaxError(Exception):
     BAD_CHAR = "BAD_CHAR"
     BAD_SYNTAX = "BAD_SYNTAX"
     BAD_SYNTAX_NO_SECTIONS = "BAD_SYNTAX_NO_SECTIONS"
+    SECTIONS_NOT_ALLOWED = "SECTIONS_NOT_ALLOWED"
 
     MESSAGES = {
-        BAD_CHAR: """unexpected character or end of value""",
-        BAD_SYNTAX: '''expecting "[SECTION]" or "KEY=VALUE"''',
-        BAD_SYNTAX_NO_SECTIONS: '''expecting "KEY=VALUE"'''
+        BAD_CHAR: 'unexpected character or end of value',
+        BAD_SYNTAX: 'expecting "[SECTION]" or "KEY=VALUE"',
+        BAD_SYNTAX_NO_SECTIONS: 'expecting "KEY=VALUE"',
+        SECTIONS_NOT_ALLOWED: 'sections not permitted in this configuration'
     }
 
     def __init__(self, code, file_name, line_num, col_num, line):

--- a/metomi/rose/config.py
+++ b/metomi/rose/config.py
@@ -1531,7 +1531,11 @@ class ConfigLoader(object):
         return (file_, file_name)
 
 
-class ConfigSyntaxError(Exception):
+class ConfigError(Exception):
+    """Base class for config errors."""
+
+
+class ConfigSyntaxError(ConfigError):
 
     """Exception raised for syntax error loading a configuration file.
 
@@ -1587,7 +1591,7 @@ class ConfigSyntaxError(Exception):
             " " * self.col_num)
 
 
-class ConfigDecodeError(Exception):
+class ConfigDecodeError(ConfigError):
     """Exception that should be raised when loading a configuration file that
     is not encoded in a UTF-8 compatible charset.
 

--- a/metomi/rose/config.py
+++ b/metomi/rose/config.py
@@ -1180,10 +1180,11 @@ class ConfigLoader(object):
         """Initialise the configuration utility.
 
         Arguments:
-        char_comment -- the character to indicate the start of a
-        comment.
-        char_assign -- the character to use to delimit a key=value
-        assignment.
+            char_assign (str): the character to use to delimit a key=value
+                assignment.
+            char_comment (str): the character to indicate the start of a
+                comment.
+            allow_sections (bool): whether to permit sections in the config.
 
         """
         self.char_assign = char_assign

--- a/metomi/rose/reporter.py
+++ b/metomi/rose/reporter.py
@@ -241,11 +241,13 @@ class ReporterContext(object):
     def write(self, message):
         """Write the message to the context's handle."""
         try:
-            return self.handle.buffer.write(message.encode("utf-8"))
+            ret_code = self.handle.buffer.write(message.encode("utf-8"))
         except TypeError:
-            return self.handle.write(message)
+            ret_code = self.handle.write(message)
         except AttributeError:
-            return self.handle.write(message.encode('UTF-8'))
+            ret_code = self.handle.write(message.encode('UTF-8'))
+        self.handle.flush()
+        return ret_code
 
     def _tty_colour_err(self, str_):
         """Colour error string for terminal."""

--- a/metomi/rose/tests/config.py
+++ b/metomi/rose/tests/config.py
@@ -18,6 +18,7 @@
 # along with Rose. If not, see <http://www.gnu.org/licenses/>.
 # -----------------------------------------------------------------------------
 import os.path
+import pytest
 import metomi.rose.config
 from io import StringIO
 
@@ -221,3 +222,30 @@ bar=BAR BAR BAR
     node = conf.get(["hello", "greet"])
     assert(node.value == "hi")
     assert(node.state == "!!")
+
+
+def test_load_bad_syntax():
+    """Test loading a configuration with bad syntax present"""
+    loader = metomi.rose.config.ConfigLoader()
+    source = StringIO("""# test
+foo=bar
+baz
+""")
+    with pytest.raises(metomi.rose.config.ConfigSyntaxError) as exc:
+        loader.load(source)
+    assert exc.value.code == 'BAD_SYNTAX'
+    assert exc.value.line_num == 3
+
+
+def test_load_info_config_bad_syntax():
+    """Test loading a configuration in which sections are not allowed"""
+    loader = metomi.rose.config.ConfigLoader(allow_sections=False)
+    source = StringIO("""# test
+stuff=stuffing
+[egg]
+boiled=false
+""")
+    with pytest.raises(metomi.rose.config.ConfigSyntaxError) as exc:
+        loader.load(source)
+    assert exc.value.code == 'SECTIONS_NOT_ALLOWED'
+    assert exc.value.line_num == 3

--- a/metomi/rosie/db_create.py
+++ b/metomi/rosie/db_create.py
@@ -30,6 +30,7 @@ from metomi.rose.reporter import Reporter, Event
 from metomi.rose.resource import ResourceLocator
 from metomi.rosie.db import (
     LATEST_TABLE_NAME, MAIN_TABLE_NAME, META_TABLE_NAME, OPTIONAL_TABLE_NAME)
+from metomi.rosie.svn_hook import InfoFileError
 from metomi.rosie.svn_post_commit import RosieSvnPostCommitHook
 from metomi.rose.config import ConfigSyntaxError
 
@@ -201,7 +202,8 @@ class RosieDatabaseInitiator(object):
             try:
                 self.post_commit_hook.run(
                     repos_path, str(revision), no_notification=True)
-            except (ConfigSyntaxError, al.exc.DatabaseError) as err:
+            except (ConfigSyntaxError, InfoFileError,
+                    al.exc.DatabaseError) as err:
                 if sys.stdout.isatty():
                     sys.stdout.write("\r")
                     sys.stdout.flush()

--- a/metomi/rosie/db_create.py
+++ b/metomi/rosie/db_create.py
@@ -32,7 +32,7 @@ from metomi.rosie.db import (
     LATEST_TABLE_NAME, MAIN_TABLE_NAME, META_TABLE_NAME, OPTIONAL_TABLE_NAME)
 from metomi.rosie.svn_hook import InfoFileError
 from metomi.rosie.svn_post_commit import RosieSvnPostCommitHook
-from metomi.rose.config import ConfigSyntaxError
+from metomi.rose.config import ConfigError
 
 
 class RosieDatabaseCreateEvent(Event):
@@ -202,8 +202,7 @@ class RosieDatabaseInitiator(object):
             try:
                 self.post_commit_hook.run(
                     repos_path, str(revision), no_notification=True)
-            except (ConfigSyntaxError, InfoFileError,
-                    al.exc.DatabaseError) as err:
+            except (ConfigError, InfoFileError, al.exc.DatabaseError) as err:
                 if sys.stdout.isatty():
                     sys.stdout.write("\r")
                     sys.stdout.flush()

--- a/metomi/rosie/db_create.py
+++ b/metomi/rosie/db_create.py
@@ -196,8 +196,8 @@ class RosieDatabaseInitiator(object):
         while revision <= youngest:
             if sys.stdout.isatty():
                 sys.stdout.write(
-                    "\r%s... loading revision %d of %d" %
-                    (Reporter.PREFIX_INFO, revision, youngest))
+                    f"\r{Reporter.PREFIX_INFO}... loading revision {revision} "
+                    f"of {youngest}")
                 sys.stdout.flush()
             try:
                 self.post_commit_hook.run(
@@ -207,11 +207,10 @@ class RosieDatabaseInitiator(object):
                 if sys.stdout.isatty():
                     sys.stdout.write("\r")
                     sys.stdout.flush()
-                err_msg = "Exception occurred: {0} - {1}".format(
-                    type(err).__name__, str(err))
-                message = ("Could not load revision {0} of {1} as the post-"
-                           "commit hook failed:\r{2}\r".format(
-                                revision, youngest, err_msg))
+                err_msg = f"Exception occurred: {type(err).__name__} - {err}"
+                message = (
+                    f"Could not load revision {revision} of {youngest} as "
+                    f"the post-commit hook failed:\n{err_msg}\n")
                 event = RosieDatabaseLoadSkipEvent(repos_path, message)
             else:
                 event = RosieDatabaseLoadEvent(repos_path, revision, youngest)

--- a/metomi/rosie/svn_hook.py
+++ b/metomi/rosie/svn_hook.py
@@ -74,7 +74,7 @@ class RosieSvnHook(object):
             allow_popen_err (bool): If True, return None if a RosePopenError
                 occurs during svnlook command.
         """
-        if branch is None:
+        if not branch:
             branch = self.TRUNK
         commit_opts = []
         # TODO: warn or raise if both supplied?

--- a/metomi/rosie/svn_hook.py
+++ b/metomi/rosie/svn_hook.py
@@ -135,7 +135,6 @@ class RosieSvnHook(object):
         if not branch:
             branch = self.TRUNK
         commit_opts = []
-        # TODO: warn or raise if both supplied?
         if transaction is not None:
             if revision is not None:
                 raise ValueError(

--- a/metomi/rosie/svn_hook.py
+++ b/metomi/rosie/svn_hook.py
@@ -156,6 +156,6 @@ class RosieSvnHook(object):
                 return None
             raise err
         t_handle.seek(0)
-        config_node = ConfigLoader(allow_sections=False)(t_handle)
+        config_node = ConfigLoader(allow_sections=False).load(t_handle)
         t_handle.close()
         return config_node

--- a/metomi/rosie/svn_hook.py
+++ b/metomi/rosie/svn_hook.py
@@ -20,7 +20,7 @@
 
 import os
 import sys
-import metomi.rose
+from metomi.rose.config import ConfigLoader
 from metomi.rose.popen import RosePopener, RosePopenError
 from metomi.rose.reporter import Reporter
 from tempfile import TemporaryFile
@@ -94,6 +94,6 @@ class RosieSvnHook(object):
                 return None
             raise err
         t_handle.seek(0)
-        config_node = metomi.rose.config.load(t_handle)
+        config_node = ConfigLoader(allow_sections=False)(t_handle)
         t_handle.close()
         return config_node

--- a/metomi/rosie/svn_hook.py
+++ b/metomi/rosie/svn_hook.py
@@ -137,6 +137,10 @@ class RosieSvnHook(object):
         commit_opts = []
         # TODO: warn or raise if both supplied?
         if transaction is not None:
+            if revision is not None:
+                raise ValueError(
+                    f"Cannot load transaction {transaction} and "
+                    f"revision {revision} at the same time")
             commit_opts = ["-t", transaction]
         if revision is not None:
             commit_opts = ["-r", str(revision)]

--- a/metomi/rosie/svn_hook.py
+++ b/metomi/rosie/svn_hook.py
@@ -112,7 +112,7 @@ class RosieSvnHook(object):
     def _svnlook(self, *args):
         """Return the standard output from "svnlook"."""
         command = ["svnlook", *args]
-        return self.popen(*command)[0].decode()
+        return self.popen(*command)[0].decode(errors='handle_decode_err')
 
     def _load_info(self, repos, sid, branch=None, revision=None,
                    transaction=None, allow_popen_err=False):

--- a/metomi/rosie/svn_hook.py
+++ b/metomi/rosie/svn_hook.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+# -----------------------------------------------------------------------------
+# Copyright (C) 2012-2020 British Crown (Met Office) & Contributors.
+#
+# This file is part of Rose, a framework for meteorological suites.
+#
+# Rose is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Rose is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Rose. If not, see <http://www.gnu.org/licenses/>.
+# -----------------------------------------------------------------------------
+
+import os
+import sys
+import metomi.rose
+from metomi.rose.popen import RosePopener, RosePopenError
+from metomi.rose.reporter import Reporter
+from tempfile import TemporaryFile
+
+
+class RosieSvnHook(object):
+    """A parent class for hooks on a Rosie Subversion repository."""
+
+    DATE_FMT = "%Y-%m-%d %H:%M:%S %Z"
+    ID_CHARS_LIST = ["abcdefghijklmnopqrstuvwxyz"] * 2 + ["0123456789"] * 3
+    LEN_ID = len(ID_CHARS_LIST)
+    TRUNK = "trunk"
+    INFO_FILE = "rose-suite.info"
+    TRUNK_INFO_FILE = "trunk/rose-suite.info"
+    ST_ADDED = "A"
+    ST_DELETED = "D"
+    ST_MODIFIED = "M"
+    ST_UPDATED = "U"
+    ST_EMPTY = " "
+
+    def __init__(self, event_handler=None, popen=None):
+        if event_handler is None:
+            event_handler = Reporter()
+        self.event_handler = event_handler
+        if popen is None:
+            popen = RosePopener(self.event_handler)
+        self.popen = popen
+        self.path = os.path.dirname(
+            os.path.dirname(sys.modules["metomi.rosie"].__file__))
+
+    def _svnlook(self, *args):
+        """Return the standard output from "svnlook"."""
+        command = ["svnlook", *args]
+        return self.popen(*command)[0].decode()
+
+    def _load_info(self, repos, sid, branch=None, revision=None,
+                   transaction=None, allow_popen_err=False):
+        """Load info file from branch_path in repos @revision.
+
+        Returns a ConfigNode for the "rose-suite.info" of a suite at a
+        particular revision or transaction.
+
+        Args:
+            repos (str): The path of the repository.
+            sid (str): The Rosie suite unique identifier, e.g. "ay327".
+            branch (str): The branch that the info file is under.
+            revision (int, str): A commit revision number. Cannot be used with
+                transaction.
+            transaction (str): A commit transaction identifer. Cannot be used
+                with revision.
+            allow_popen_err (bool): If True, return None if a RosePopenError
+                occurs during svnlook command.
+        """
+        if branch is None:
+            branch = self.TRUNK
+        commit_opts = []
+        # TODO: warn or raise if both supplied?
+        if transaction is not None:
+            commit_opts = ["-t", transaction]
+        if revision is not None:
+            commit_opts = ["-r", str(revision)]
+        info_file_path = "%s/%s/%s" % ("/".join(sid), branch, self.INFO_FILE)
+        t_handle = TemporaryFile()
+        try:
+            t_handle.write(
+                self._svnlook(
+                    "cat", repos, info_file_path, *commit_opts).encode()
+            )
+        except RosePopenError as err:
+            if allow_popen_err:
+                return None
+            raise err
+        t_handle.seek(0)
+        config_node = metomi.rose.config.load(t_handle)
+        t_handle.close()
+        return config_node

--- a/metomi/rosie/svn_hook.py
+++ b/metomi/rosie/svn_hook.py
@@ -20,7 +20,7 @@
 
 import os
 import sys
-from metomi.rose.config import ConfigLoader
+from metomi.rose.config import ConfigDecodeError, ConfigLoader
 from metomi.rose.popen import RosePopener, RosePopenError
 from metomi.rose.reporter import Reporter
 from tempfile import TemporaryFile
@@ -112,7 +112,7 @@ class RosieSvnHook(object):
     def _svnlook(self, *args):
         """Return the standard output from "svnlook"."""
         command = ["svnlook", *args]
-        return self.popen(*command)[0].decode(errors='handle_decode_err')
+        return self.popen(*command)[0].decode()
 
     def _load_info(self, repos, sid, branch=None, revision=None,
                    transaction=None, allow_popen_err=False):
@@ -150,6 +150,8 @@ class RosieSvnHook(object):
                 self._svnlook(
                     "cat", repos, info_file_path, *commit_opts).encode()
             )
+        except UnicodeDecodeError as err:
+            raise ConfigDecodeError(info_file_path, err)
         except RosePopenError as err:
             if allow_popen_err:
                 return None

--- a/metomi/rosie/svn_post_commit.py
+++ b/metomi/rosie/svn_post_commit.py
@@ -221,6 +221,7 @@ class RosieSvnPostCommitHook(RosieSvnHook):
                     branch_attribs["info"] = self._load_info(
                         repos, sid, branch, revision=revision,
                         allow_popen_err=True)
+                    # Note: if (allowed) popen err, no DB entry will be created
                 if (branch_attribs["old_info"] is None and
                         branch_attribs["status"] == self.ST_DELETED):
                     branch_attribs["old_info"] = self._load_info(
@@ -380,7 +381,7 @@ class RosieSvnPostCommitHook(RosieSvnHook):
             "author": changeset_attribs["author"],
             "date": changeset_attribs["date"]})
         for name in ["owner", "project", "title"]:
-            cols[name] = branch_attribs[info_key].get_value([name])
+            cols[name] = branch_attribs[info_key].get_value([name], "null")
         if branch_attribs["from_path"] and vc_attrs["branch"] == "trunk":
             from_names = branch_attribs["from_path"].split("/")[:self.LEN_ID]
             cols["from_idx"] = "{0}-{1}".format(

--- a/metomi/rosie/svn_post_commit.py
+++ b/metomi/rosie/svn_post_commit.py
@@ -351,11 +351,13 @@ class RosieSvnPostCommitHook(RosieSvnHook):
 
     def _update_info_db(self, dao, changeset_attribs, branch_attribs):
         """Update the suite info database for a suite branch."""
-        idx = changeset_attribs["prefix"] + "-" + branch_attribs["sid"]
+        idx = "{0}-{1}".format(
+            changeset_attribs["prefix"], branch_attribs["sid"])
         vc_attrs = {
             "idx": idx,
             "branch": branch_attribs["branch"],
-            "revision": changeset_attribs["revision"]}
+            "revision": changeset_attribs["revision"]
+        }
         # Latest table
         try:
             dao.delete(
@@ -381,8 +383,8 @@ class RosieSvnPostCommitHook(RosieSvnHook):
             cols[name] = branch_attribs[info_key].get_value([name])
         if branch_attribs["from_path"] and vc_attrs["branch"] == "trunk":
             from_names = branch_attribs["from_path"].split("/")[:self.LEN_ID]
-            cols["from_idx"] = (
-                changeset_attribs["prefix"] + "-" + "".join(from_names))
+            cols["from_idx"] = "{0}-{1}".format(
+                changeset_attribs["prefix"], "".join(from_names))
         cols["status"] = (
             branch_attribs["status"] + branch_attribs["status_info_file"])
         dao.insert(MAIN_TABLE_NAME, **cols)

--- a/metomi/rosie/svn_pre_commit.py
+++ b/metomi/rosie/svn_pre_commit.py
@@ -188,10 +188,6 @@ class RosieSvnPreCommitHook(RosieSvnHook):
                 bad_changes.append(BadChange(status, path))
                 continue
 
-            # No need to check non-trunk changes  # Why?
-            # if len(names) > self.LEN_ID and names[self.LEN_ID] != "trunk":
-            #     continue
-
             # New suite should have an info file
             if status[0] == self.ST_ADDED and len(names) == self.LEN_ID:
                 if (self.ST_ADDED, path + "trunk/") not in changes:
@@ -204,6 +200,10 @@ class RosieSvnPreCommitHook(RosieSvnHook):
                          path_trunk_info_file) not in changes):
                     bad_changes.append(
                         BadChange(status, path, BadChange.NO_INFO))
+                continue
+
+            # No need to check non-trunk changes  # Why?
+            if len(names) > self.LEN_ID and names[self.LEN_ID] != "trunk":
                 continue
 
             # The rest are trunk changes in a suite

--- a/metomi/rosie/svn_pre_commit.py
+++ b/metomi/rosie/svn_pre_commit.py
@@ -262,6 +262,7 @@ class RosieSvnPreCommitHook(RosieSvnHook):
                 continue
 
             # Can only remove trunk with suite
+            # (Don't allow replacing trunk with a copy from elsewhere, either)
             if status == self.ST_DELETED and path_tail == "trunk/":
                 if (self.ST_DELETED, path_head) not in changes:
                     bad_changes.append(

--- a/metomi/rosie/svn_pre_commit.py
+++ b/metomi/rosie/svn_pre_commit.py
@@ -192,7 +192,7 @@ class RosieSvnPreCommitHook(RosieSvnHook):
                             InfoFileError(InfoFileError.NO_OWNER))
                         continue
 
-            # No need to check other non-trunk changes (?)
+            # No need to check other non-trunk changes
             if branch and branch != "trunk":
                 continue
 

--- a/metomi/rosie/svn_pre_commit.py
+++ b/metomi/rosie/svn_pre_commit.py
@@ -37,71 +37,11 @@ from metomi.rose.popen import RosePopenError
 from metomi.rose.reporter import Reporter
 from metomi.rose.resource import ResourceLocator
 from metomi.rose.scheme_handler import SchemeHandlersManager
-from metomi.rosie.svn_hook import RosieSvnHook
+from metomi.rosie.svn_hook import (
+    RosieSvnHook, BadChange, InfoFileError, BadChanges)
 import shlex
 import sys
 import traceback
-
-
-class BadChange(Exception):
-
-    """An error representing a bad change in a commit transaction."""
-
-    FMT_HEAD = "%s: %-4s%s"
-    FMT_TAIL_1 = ": %s"
-    FMT_TAIL_M = ":\n%s"
-    NO_INFO = "SUITE MUST HAVE INFO FILE"
-    NO_OWNER = "SUITE MUST HAVE OWNER SPECIFIED IN INFO FILE"
-    NO_TRUNK = "SUITE MUST HAVE TRUNK"
-    PERM = "PERMISSION DENIED"
-    USER = "NO SUCH USER"
-    VALUE = "BAD VALUE IN FILE"
-
-    def __init__(self, status, path, reason=PERM, content=""):
-        Exception.__init__(self, status, path, reason, content)
-        self.status = status
-        self.path = path
-        self.reason = reason
-        self.content = content
-
-    def __str__(self):
-        tail = ""
-        if self.content and "\n" in self.content:
-            tail = self.FMT_TAIL_M % self.content
-        elif self.content:
-            tail = self.FMT_TAIL_1 % self.content
-        return self.FMT_HEAD % (self.reason, self.status, self.path) + tail
-
-
-class BadChanges(Exception):
-
-    """An error representing bad changes in a commit transaction."""
-
-    def __str__(self):
-        bad_changes = self.args[0]
-        return "\n".join([str(bad_change) for bad_change in bad_changes])
-
-
-class InfoFileError(BadChange):
-
-    """Error representing a bad or missing info file.
-
-    Args:
-        reason (str): a user-friendly message.
-        exception (Exception): the exception encountered in loading the
-            bad info file.
-    """
-
-    VALUE = f"BAD VALUE IN '{RosieSvnHook.INFO_FILE}'"
-
-    def __init__(self, reason=BadChange.PERM, exception=None):
-        self.reason = reason
-        self.exc = exception
-
-    def __str__(self):
-        if self.exc:
-            return f"{self.reason}: {self.exc}"
-        return self.reason
 
 
 class RosieSvnPreCommitHook(RosieSvnHook):

--- a/metomi/rosie/svn_pre_commit.py
+++ b/metomi/rosie/svn_pre_commit.py
@@ -51,7 +51,7 @@ class BadChange(Exception):
     FMT_TAIL_1 = ": %s"
     FMT_TAIL_M = ":\n%s"
     NO_INFO = "SUITE MUST HAVE INFO FILE"
-    NO_OWNER = "SUITE MUST HAVE OWNER"
+    NO_OWNER = "SUITE MUST HAVE OWNER SPECIFIED IN INFO FILE"
     NO_TRUNK = "SUITE MUST HAVE TRUNK"
     PERM = "PERMISSION DENIED"
     USER = "NO SUCH USER"
@@ -238,7 +238,7 @@ class RosieSvnPreCommitHook(RosieSvnHook):
                     except ConfigSyntaxError as exc:
                         err = InfoFileError(InfoFileError.VALUE, exc)
                     except RosePopenError as exc:
-                        err = InfoFileError(InfoFileError.NO_INFO, exc)
+                        err = InfoFileError(InfoFileError.NO_INFO, exc.stderr)
                     if err:
                         bad_changes.append(err)
                         txn_info_map[sid] = err
@@ -249,7 +249,7 @@ class RosieSvnPreCommitHook(RosieSvnHook):
                         txn_info_map[sid])
                     if not txn_owner:
                         bad_changes.append(
-                            BadChange(status, path, BadChange.NO_OWNER))
+                            InfoFileError(InfoFileError.NO_OWNER))
                         continue
 
             # No need to check other non-trunk changes (?)

--- a/metomi/rosie/svn_pre_commit.py
+++ b/metomi/rosie/svn_pre_commit.py
@@ -147,7 +147,7 @@ class RosieSvnPreCommitHook(RosieSvnHook):
         bad_changes = []
         author = None
         super_users = None
-        rev_info_map = {}  # {path-id: (owner, access-list), ...}
+        rev_info_map = {}
         txn_info_map = {}
 
         conf = ResourceLocator.default().get_conf()
@@ -160,6 +160,8 @@ class RosieSvnPreCommitHook(RosieSvnHook):
 
             names = path.split("/", self.LEN_ID + 1)
             tail = None
+            sid = "".join(names[0:self.LEN_ID])
+            branch = names[self.LEN_ID]
             if not names[-1]:
                 tail = names.pop()
 
@@ -186,9 +188,9 @@ class RosieSvnPreCommitHook(RosieSvnHook):
                 bad_changes.append(BadChange(status, path))
                 continue
 
-            # No need to check non-trunk changes
-            if len(names) > self.LEN_ID and names[self.LEN_ID] != "trunk":
-                continue
+            # No need to check non-trunk changes  # Why?
+            # if len(names) > self.LEN_ID and names[self.LEN_ID] != "trunk":
+            #     continue
 
             # New suite should have an info file
             if status[0] == self.ST_ADDED and len(names) == self.LEN_ID:
@@ -205,7 +207,7 @@ class RosieSvnPreCommitHook(RosieSvnHook):
                 continue
 
             # The rest are trunk changes in a suite
-            path_head = "/".join(names[0:self.LEN_ID]) + "/"
+            path_head = "/".join(sid) + "/"
             path_tail = path[len(path_head):]
 
             # For meta suite, make sure keys in keys file can be parsed
@@ -222,11 +224,11 @@ class RosieSvnPreCommitHook(RosieSvnHook):
             # User IDs of owner and access list must be real
             if (status not in self.ST_DELETED and
                     path_tail == self.TRUNK_INFO_FILE):
-                if path_head not in txn_info_map:
-                    txn_info_map[path_head] = self._load_info(
-                        repos, path_head, txn)
+                if sid not in txn_info_map:
+                    txn_info_map[sid] = self._load_info(
+                        repos, sid, branch=branch, transaction=txn)
                 txn_owner, txn_access_list = self._get_access_info(
-                    txn_info_map[path_head])
+                    txn_info_map[sid])
                 if not txn_owner:
                     bad_changes.append(
                         BadChange(status, path, BadChange.NO_OWNER))
@@ -235,9 +237,9 @@ class RosieSvnPreCommitHook(RosieSvnHook):
                         status, path, txn_owner, txn_access_list, bad_changes):
                     continue
                 reports = DefaultValidators().validate(
-                    txn_info_map[path_head],
+                    txn_info_map[sid],
                     load_meta_config(
-                        txn_info_map[path_head],
+                        txn_info_map[sid],
                         config_type=metomi.rose.INFO_CONFIG_NAME))
                 if reports:
                     reports_str = get_reports_as_text({None: reports}, path)
@@ -273,10 +275,10 @@ class RosieSvnPreCommitHook(RosieSvnHook):
                     if value is not None:
                         super_users = shlex.split(value)
                         break
-            if path_head not in rev_info_map:
-                rev_info_map[path_head] = self._get_info(
-                    repos, path_head)
-            owner, access_list = self._get_access_info(rev_info_map[path_head])
+            if sid not in rev_info_map:
+                rev_info_map[sid] = self._load_info(
+                    repos, sid, branch=branch, transaction=txn)
+            owner, access_list = self._get_access_info(rev_info_map[sid])
             admin_users = super_users + [owner]
 
             # Only admin users can remove the suite
@@ -294,11 +296,11 @@ class RosieSvnPreCommitHook(RosieSvnHook):
                 continue
 
             # The owner must not be deleted
-            if path_head not in txn_info_map:
-                txn_info_map[path_head] = self._get_info(
-                    repos, path_head, txn)
+            if sid not in txn_info_map:
+                txn_info_map[sid] = self._load_info(
+                    repos, sid, branch=branch, transaction=txn)
             txn_owner, txn_access_list = self._get_access_info(
-                txn_info_map[path_head])
+                txn_info_map[sid])
             if not txn_owner:
                 bad_changes.append(BadChange(status, path, BadChange.NO_OWNER))
                 continue

--- a/metomi/rosie/svn_pre_commit.py
+++ b/metomi/rosie/svn_pre_commit.py
@@ -25,22 +25,19 @@ Ensure that commits conform to the rules of Rosie.
 
 
 from fnmatch import fnmatch
-import os
 import re
 import metomi.rose
-from metomi.rose.config import ConfigLoader
 from metomi.rose.opt_parse import RoseOptionParser
 from metomi.rose.macro import (add_meta_paths,
                                get_reports_as_text,
                                load_meta_config)
 from metomi.rose.macros import DefaultValidators
-from metomi.rose.popen import RosePopener
 from metomi.rose.reporter import Reporter
 from metomi.rose.resource import ResourceLocator
 from metomi.rose.scheme_handler import SchemeHandlersManager
+from metomi.rosie.svn_hook import RosieSvnHook
 import shlex
 import sys
-import tempfile
 import traceback
 
 
@@ -83,7 +80,7 @@ class BadChanges(Exception):
         return "\n".join([str(bad_change) for bad_change in bad_changes])
 
 
-class RosieSvnPreCommitHook(object):
+class RosieSvnPreCommitHook(RosieSvnHook):
 
     """A pre-commit hook on a Rosie Subversion repository.
 
@@ -93,25 +90,12 @@ class RosieSvnPreCommitHook(object):
 
     IGNORES = "svnperms.conf"
     RE_ID_NAMES = [r"[Ra-z]", r"[Oa-z]", r"[S\d]", r"[I\d]", r"[E\d]"]
-    LEN_ID = len(RE_ID_NAMES)
-    ST_ADD = "A"
-    ST_DELETE = "D"
-    ST_UPDATE = "U"
-    TRUNK_INFO_FILE = "trunk/rose-suite.info"
     TRUNK_KNOWN_KEYS_FILE = "trunk/rosie-keys"
 
     def __init__(self, event_handler=None, popen=None):
-        if event_handler is None:
-            event_handler = Reporter()
-        self.event_handler = event_handler
-        if popen is None:
-            popen = RosePopener(self.event_handler)
-        self.popen = popen
-        path = os.path.dirname(
-            os.path.dirname(sys.modules["metomi.rosie"].__file__)
-        )
+        super(RosieSvnPreCommitHook, self).__init__(event_handler, popen)
         self.usertools_manager = SchemeHandlersManager(
-            [path], "rosie.usertools", ["verify_users"])
+            [self.path], "rosie.usertools", ["verify_users"])
 
     def _get_access_info(self, info_node):
         """Return (owner, access_list) from "info_node"."""
@@ -119,29 +103,6 @@ class RosieSvnPreCommitHook(object):
         access_list = info_node.get_value(["access-list"], "").split()
         access_list.sort()
         return owner, access_list
-
-    def _get_info(self, repos, path_head, txn=None):
-        """Return a ConfigNode for the "rose-suite.info" of a suite.
-
-        The suite is located under path_head.
-
-        """
-        opt_txn = []
-        if txn is not None:
-            opt_txn = ["-t", txn]
-        t_handle = tempfile.TemporaryFile()
-        path = path_head + self.TRUNK_INFO_FILE
-        t_handle.write(self._svnlook("cat", repos, path, *opt_txn).encode())
-        t_handle.seek(0)
-        info_node = ConfigLoader()(t_handle)
-        t_handle.close()
-        return info_node
-
-    def _svnlook(self, *args):
-        """Return the standard output from "svnlook"."""
-        command = ["svnlook"] + list(args)
-        data = self.popen(*command, stderr=sys.stderr)[0]
-        return data.decode()
 
     def _verify_users(self, status, path, txn_owner, txn_access_list,
                       bad_changes):
@@ -214,7 +175,7 @@ class RosieSvnPreCommitHook(object):
 
             # Can only add directories at levels above the suites
             if len(names) < self.LEN_ID:
-                if status[0] != self.ST_ADD:
+                if status[0] != self.ST_ADDED:
                     bad_changes.append(BadChange(status, path))
                 continue
             else:
@@ -230,14 +191,15 @@ class RosieSvnPreCommitHook(object):
                 continue
 
             # New suite should have an info file
-            if status[0] == self.ST_ADD and len(names) == self.LEN_ID:
-                if (self.ST_ADD, path + "trunk/") not in changes:
+            if status[0] == self.ST_ADDED and len(names) == self.LEN_ID:
+                if (self.ST_ADDED, path + "trunk/") not in changes:
                     bad_changes.append(
                         BadChange(status, path, BadChange.NO_TRUNK))
                     continue
                 path_trunk_info_file = path + self.TRUNK_INFO_FILE
-                if ((self.ST_ADD, path_trunk_info_file) not in changes and
-                        (self.ST_UPDATE, path_trunk_info_file) not in changes):
+                if ((self.ST_ADDED, path_trunk_info_file) not in changes and
+                        (self.ST_UPDATED,
+                         path_trunk_info_file) not in changes):
                     bad_changes.append(
                         BadChange(status, path, BadChange.NO_INFO))
                 continue
@@ -258,10 +220,10 @@ class RosieSvnPreCommitHook(object):
 
             # Suite trunk information file must have an owner
             # User IDs of owner and access list must be real
-            if (status not in self.ST_DELETE and
+            if (status not in self.ST_DELETED and
                     path_tail == self.TRUNK_INFO_FILE):
                 if path_head not in txn_info_map:
-                    txn_info_map[path_head] = self._get_info(
+                    txn_info_map[path_head] = self._load_info(
                         repos, path_head, txn)
                 txn_owner, txn_access_list = self._get_access_info(
                     txn_info_map[path_head])
@@ -284,21 +246,21 @@ class RosieSvnPreCommitHook(object):
                     continue
 
             # Can only remove trunk information file with suite
-            if status == self.ST_DELETE and path_tail == self.TRUNK_INFO_FILE:
-                if (self.ST_DELETE, path_head) not in changes:
+            if status == self.ST_DELETED and path_tail == self.TRUNK_INFO_FILE:
+                if (self.ST_DELETED, path_head) not in changes:
                     bad_changes.append(
                         BadChange(status, path, BadChange.NO_INFO))
                 continue
 
             # Can only remove trunk with suite
-            if status == self.ST_DELETE and path_tail == "trunk/":
-                if (self.ST_DELETE, path_head) not in changes:
+            if status == self.ST_DELETED and path_tail == "trunk/":
+                if (self.ST_DELETED, path_head) not in changes:
                     bad_changes.append(
                         BadChange(status, path, BadChange.NO_TRUNK))
                 continue
 
             # New suite trunk: ignore the rest
-            if (self.ST_ADD, path_head + "trunk/") in changes:
+            if (self.ST_ADDED, path_head + "trunk/") in changes:
                 continue
 
             # See whether author has permission to make changes

--- a/metomi/rosie/svn_pre_commit.py
+++ b/metomi/rosie/svn_pre_commit.py
@@ -277,7 +277,7 @@ class RosieSvnPreCommitHook(RosieSvnHook):
                         break
             if sid not in rev_info_map:
                 rev_info_map[sid] = self._load_info(
-                    repos, sid, branch=branch, transaction=txn)
+                    repos, sid, branch=branch)
             owner, access_list = self._get_access_info(rev_info_map[sid])
             admin_users = super_users + [owner]
 

--- a/t/rosa-db-create/00-basic-1.dump
+++ b/t/rosa-db-create/00-basic-1.dump
@@ -6,7 +6,7 @@ CREATE TABLE latest (
 	revision INTEGER NOT NULL, 
 	PRIMARY KEY (idx, branch, revision)
 );
-INSERT INTO "latest" VALUES('foo-aa000','trunk',1);
+INSERT INTO latest VALUES('foo-aa000','trunk',1);
 CREATE TABLE main (
 	idx VARCHAR(1024) NOT NULL, 
 	branch VARCHAR(1024) NOT NULL, 
@@ -20,7 +20,7 @@ CREATE TABLE main (
 	from_idx VARCHAR(1024), 
 	PRIMARY KEY (idx, branch, revision)
 );
-INSERT INTO "main" VALUES('foo-aa000','trunk',1,'iris','eye pad','Should have gone to ...','$USER',1234567890,'A ',NULL);
+INSERT INTO main VALUES('foo-aa000','trunk',1,'iris','eye pad','Should have gone to ...','$USER',1234567890,'A ',NULL);
 CREATE TABLE optional (
 	idx VARCHAR(1024) NOT NULL, 
 	branch VARCHAR(1024) NOT NULL, 
@@ -29,7 +29,7 @@ CREATE TABLE optional (
 	value VARCHAR(1024), 
 	PRIMARY KEY (idx, branch, revision, name)
 );
-INSERT INTO "optional" VALUES('foo-aa000','trunk',1,'access-list','*');
+INSERT INTO optional VALUES('foo-aa000','trunk',1,'access-list','*');
 CREATE TABLE meta (
 	name VARCHAR(1024) NOT NULL, 
 	value VARCHAR(1024), 

--- a/t/rosa-db-create/00-basic-2.dump
+++ b/t/rosa-db-create/00-basic-2.dump
@@ -6,8 +6,8 @@ CREATE TABLE latest (
 	revision INTEGER NOT NULL, 
 	PRIMARY KEY (idx, branch, revision)
 );
-INSERT INTO "latest" VALUES('foo-aa000','trunk',1);
-INSERT INTO "latest" VALUES('foo-aa001','trunk',3);
+INSERT INTO latest VALUES('foo-aa000','trunk',1);
+INSERT INTO latest VALUES('foo-aa001','trunk',3);
 CREATE TABLE main (
 	idx VARCHAR(1024) NOT NULL, 
 	branch VARCHAR(1024) NOT NULL, 
@@ -21,9 +21,9 @@ CREATE TABLE main (
 	from_idx VARCHAR(1024), 
 	PRIMARY KEY (idx, branch, revision)
 );
-INSERT INTO "main" VALUES('foo-aa000','trunk',1,'iris','eye pad','Should have gone to ...','$USER',1234567890,'A ',NULL);
-INSERT INTO "main" VALUES('foo-aa001','trunk',2,'roses','poetry','Roses are Red,...','$USER',1234567891,'A ',NULL);
-INSERT INTO "main" VALUES('foo-aa001','trunk',3,'roses','poetry','Roses are Red, Violets are Blue,...','$USER',1234567892,' M',NULL);
+INSERT INTO main VALUES('foo-aa000','trunk',1,'iris','eye pad','Should have gone to ...','$USER',1234567890,'A ',NULL);
+INSERT INTO main VALUES('foo-aa001','trunk',2,'roses','poetry','Roses are Red,...','$USER',1234567891,'A ',NULL);
+INSERT INTO main VALUES('foo-aa001','trunk',3,'roses','poetry','Roses are Red, Violets are Blue,...','$USER',1234567892,' M',NULL);
 CREATE TABLE optional (
 	idx VARCHAR(1024) NOT NULL, 
 	branch VARCHAR(1024) NOT NULL, 
@@ -32,9 +32,9 @@ CREATE TABLE optional (
 	value VARCHAR(1024), 
 	PRIMARY KEY (idx, branch, revision, name)
 );
-INSERT INTO "optional" VALUES('foo-aa000','trunk',1,'access-list','*');
-INSERT INTO "optional" VALUES('foo-aa001','trunk',2,'access-list','*');
-INSERT INTO "optional" VALUES('foo-aa001','trunk',3,'access-list','*');
+INSERT INTO optional VALUES('foo-aa000','trunk',1,'access-list','*');
+INSERT INTO optional VALUES('foo-aa001','trunk',2,'access-list','*');
+INSERT INTO optional VALUES('foo-aa001','trunk',3,'access-list','*');
 CREATE TABLE meta (
 	name VARCHAR(1024) NOT NULL, 
 	value VARCHAR(1024), 

--- a/t/rosa-db-create/00-basic-3.dump
+++ b/t/rosa-db-create/00-basic-3.dump
@@ -6,7 +6,7 @@ CREATE TABLE latest (
 	revision INTEGER NOT NULL, 
 	PRIMARY KEY (idx, branch, revision)
 );
-INSERT INTO "latest" VALUES('foo-aa001','trunk',3);
+INSERT INTO latest VALUES('foo-aa001','trunk',3);
 CREATE TABLE main (
 	idx VARCHAR(1024) NOT NULL, 
 	branch VARCHAR(1024) NOT NULL, 
@@ -20,10 +20,10 @@ CREATE TABLE main (
 	from_idx VARCHAR(1024), 
 	PRIMARY KEY (idx, branch, revision)
 );
-INSERT INTO "main" VALUES('foo-aa000','trunk',1,'iris','eye pad','Should have gone to ...','$USER',1234567890,'A ',NULL);
-INSERT INTO "main" VALUES('foo-aa001','trunk',2,'roses','poetry','Roses are Red,...','$USER',1234567891,'A ',NULL);
-INSERT INTO "main" VALUES('foo-aa001','trunk',3,'roses','poetry','Roses are Red, Violets are Blue,...','$USER',1234567892,' M',NULL);
-INSERT INTO "main" VALUES('foo-aa000','trunk',4,'iris','eye pad','Should have gone to ...','$USER',1234567893,'D ',NULL);
+INSERT INTO main VALUES('foo-aa000','trunk',1,'iris','eye pad','Should have gone to ...','$USER',1234567890,'A ',NULL);
+INSERT INTO main VALUES('foo-aa001','trunk',2,'roses','poetry','Roses are Red,...','$USER',1234567891,'A ',NULL);
+INSERT INTO main VALUES('foo-aa001','trunk',3,'roses','poetry','Roses are Red, Violets are Blue,...','$USER',1234567892,' M',NULL);
+INSERT INTO main VALUES('foo-aa000','trunk',4,'iris','eye pad','Should have gone to ...','$USER',1234567893,'D ',NULL);
 CREATE TABLE optional (
 	idx VARCHAR(1024) NOT NULL, 
 	branch VARCHAR(1024) NOT NULL, 
@@ -32,10 +32,10 @@ CREATE TABLE optional (
 	value VARCHAR(1024), 
 	PRIMARY KEY (idx, branch, revision, name)
 );
-INSERT INTO "optional" VALUES('foo-aa000','trunk',1,'access-list','*');
-INSERT INTO "optional" VALUES('foo-aa001','trunk',2,'access-list','*');
-INSERT INTO "optional" VALUES('foo-aa001','trunk',3,'access-list','*');
-INSERT INTO "optional" VALUES('foo-aa000','trunk',4,'access-list','*');
+INSERT INTO optional VALUES('foo-aa000','trunk',1,'access-list','*');
+INSERT INTO optional VALUES('foo-aa001','trunk',2,'access-list','*');
+INSERT INTO optional VALUES('foo-aa001','trunk',3,'access-list','*');
+INSERT INTO optional VALUES('foo-aa000','trunk',4,'access-list','*');
 CREATE TABLE meta (
 	name VARCHAR(1024) NOT NULL, 
 	value VARCHAR(1024), 

--- a/t/rosa-svn-pre-commit/00-basic.t
+++ b/t/rosa-svn-pre-commit/00-basic.t
@@ -77,6 +77,7 @@ file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
 sed -i '/^\[FAIL\]/!d' "$TEST_KEY.err"
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" <<'__ERR__'
 [FAIL] SUITE MUST HAVE TRUNK: A   a/a/0/0/0/
+[FAIL] SUITE MUST HAVE INFO FILE: svnlook: E160013: Path 'a/a/0/0/0/0/rose-suite.info' does not exist
 __ERR__
 #-------------------------------------------------------------------------------
 TEST_KEY=$TEST_KEY_BASE-create-no-info
@@ -86,6 +87,7 @@ file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
 sed -i '/^\[FAIL\]/!d' "$TEST_KEY.err"
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" <<'__ERR__'
 [FAIL] SUITE MUST HAVE INFO FILE: A   a/a/0/0/0/
+[FAIL] SUITE MUST HAVE INFO FILE: svnlook: E160013: Path 'a/a/0/0/0/trunk/rose-suite.info' does not exist
 __ERR__
 #-------------------------------------------------------------------------------
 TEST_KEY=$TEST_KEY_BASE-create-empty-info
@@ -96,7 +98,15 @@ run_fail "$TEST_KEY" \
 file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
 sed -i '/^\[FAIL\]/!d' "$TEST_KEY.err"
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" <<'__ERR__'
-[FAIL] SUITE MUST HAVE OWNER: A   a/a/0/0/0/trunk/rose-suite.info
+[FAIL] SUITE MUST HAVE OWNER SPECIFIED IN INFO FILE
+[FAIL] BAD VALUE IN FILE: A   a/a/0/0/0/trunk/rose-suite.info:
+[FAIL] a/a/0/0/0/trunk/rose-suite.info: issues: 3
+[FAIL]     =owner=None
+[FAIL]         Variable set as compulsory, but not in configuration.
+[FAIL]     =project=None
+[FAIL]         Variable set as compulsory, but not in configuration.
+[FAIL]     =title=None
+[FAIL]         Variable set as compulsory, but not in configuration.
 __ERR__
 #-------------------------------------------------------------------------------
 TEST_KEY=$TEST_KEY_BASE-create-empty-owner
@@ -109,7 +119,15 @@ run_fail "$TEST_KEY" \
 file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
 sed -i '/^\[FAIL\]/!d' "$TEST_KEY.err"
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" <<'__ERR__'
-[FAIL] SUITE MUST HAVE OWNER: A   a/a/0/0/0/trunk/rose-suite.info
+[FAIL] SUITE MUST HAVE OWNER SPECIFIED IN INFO FILE
+[FAIL] BAD VALUE IN FILE: A   a/a/0/0/0/trunk/rose-suite.info:
+[FAIL] a/a/0/0/0/trunk/rose-suite.info: issues: 3
+[FAIL]     =project=None
+[FAIL]         Variable set as compulsory, but not in configuration.
+[FAIL]     =title=None
+[FAIL]         Variable set as compulsory, but not in configuration.
+[FAIL]     =owner=
+[FAIL]         Value  does not contain the pattern: ^.+(?# Must not be empty)
 __ERR__
 #-------------------------------------------------------------------------------
 TEST_KEY=$TEST_KEY_BASE-create-good-1
@@ -201,7 +219,7 @@ run_fail "$TEST_KEY" svn ci -q -m't' --username=daisy work/aa000
 file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
 sed -i '/^\[FAIL\]/!d' "$TEST_KEY.err"
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" <<'__ERR__'
-[FAIL] SUITE MUST HAVE OWNER: U   a/a/0/0/0/trunk/rose-suite.info
+[FAIL] SUITE MUST HAVE OWNER SPECIFIED IN INFO FILE
 __ERR__
 svn revert -q -R work/aa000
 #-------------------------------------------------------------------------------

--- a/t/rosa-svn-pre-commit/04-unicode.t
+++ b/t/rosa-svn-pre-commit/04-unicode.t
@@ -1,0 +1,64 @@
+#!/bin/bash
+#-------------------------------------------------------------------------------
+# Copyright (C) British Crown (Met Office) & Contributors.
+#
+# This file is part of Rose, a framework for meteorological suites.
+#
+# Rose is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Rose is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Rose. If not, see <http://www.gnu.org/licenses/>.
+# -----------------------------------------------------------------------------
+# Test "rosa svn-pre-commit" with invalid encoded config files.
+# -----------------------------------------------------------------------------
+. $(dirname $0)/test_header
+
+export ROSE_CONF_PATH=
+mkdir conf
+cat > conf/rose.conf << '__ROSE_CONF__'
+[rosa-svn-pre-commit]
+super-users=rosie
+__ROSE_CONF__
+# -----------------------------------------------------------------------------
+tests 3
+# -----------------------------------------------------------------------------
+mkdir repos
+svnadmin create repos/foo
+SVN_URL=file://$PWD/repos/foo
+ROSE_BIN=$(dirname $(command -v rose))
+ROSE_LIB=$(dirname $(python -c "import metomi.rose; print(metomi.rose.__file__)"))
+export ROSE_LIB ROSE_BIN
+cat > repos/foo/hooks/pre-commit << __PRE_COMMIT__
+#!/bin/bash
+export ROSE_CONF_PATH=$PWD/conf
+export PATH=$PATH:${ROSE_BIN}
+export ROSE_LIB=${ROSE_LIB}
+rosa svn-pre-commit "\$@"
+__PRE_COMMIT__
+chmod +x repos/foo/hooks/pre-commit
+export LANG=C
+
+TEST_KEY="${TEST_KEY_BASE}-western"
+cat > rose-suite.info << '__INFO__'
+owner=ivy
+project=euro
+title=We should not éñçödê config files in latin-1/western
+__INFO__
+iconv -f UTF-8 -t LATIN1 rose-suite.info -o rose-suite.info
+# -----------------------------------------------------------------------------
+run_fail "$TEST_KEY" \
+    svn import rose-suite.info -q -m 't' --non-interactive \
+    "${SVN_URL}/a/a/0/0/0/trunk/rose-suite.info"
+file_cmp "${TEST_KEY}.out" "${TEST_KEY}.out" < /dev/null
+sed -i '/^\[FAIL\]/!d' "$TEST_KEY.err"
+file_cmp "${TEST_KEY}.err" "${TEST_KEY}.err" << '__ERR__'
+[FAIL] Configuration files must be encoded in UTF-8 (or a subset of UTF-8). 'utf-8' codec can't decode byte 0xe9 in position 43: invalid continuation byte
+__ERR__

--- a/t/rosa-svn-pre-commit/04-unicode.t
+++ b/t/rosa-svn-pre-commit/04-unicode.t
@@ -60,5 +60,5 @@ run_fail "$TEST_KEY" \
 file_cmp "${TEST_KEY}.out" "${TEST_KEY}.out" < /dev/null
 sed -i '/^\[FAIL\]/!d' "$TEST_KEY.err"
 file_cmp "${TEST_KEY}.err" "${TEST_KEY}.err" << '__ERR__'
-[FAIL] Configuration files must be encoded in UTF-8 (or a subset of UTF-8). 'utf-8' codec can't decode byte 0xe9 in position 43: invalid continuation byte
+[FAIL] Configuration files must be encoded in UTF-8 (or a subset of UTF-8). a/a/0/0/0/trunk/rose-suite.info: 'utf-8' codec can't decode byte 0xe9 in position 43: invalid continuation byte
 __ERR__


### PR DESCRIPTION
#2417 ported to master

> Fixes several bugs.
>
> Pre-commit hook:
> - Check validity of rose-suite.info in branches, not just trunk, for each transaction (this includes whether the file is present, whether the owner, title, project are specified)
> - Ensure sections are not permitted in the info file
>
> Post-commit hook:
> - If the info file fail is not encoded in UTF-8, <del>try latin-1 aka ISO 8859-1 for decoding</del> <ins>raise a useful error saying configuration files must be in UTF-8 (this applies to pre-commit hook too)</ins> (this decoding is necessary to store the info files values in the database)
> - If owner, project or title missing in a historical commit, insert the string `'null'` into the database instead of no entry at all
>
> `db_create.py`:
> - Instead of returning if the post-commit hook fails, skip the revision and continue