### PR TITLE
Auto update copyright year

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,5 +1,5 @@
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2012-8 Met Office.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/.github/workflows/update_copyright.yml
+++ b/.github/workflows/update_copyright.yml
@@ -1,0 +1,69 @@
+# Copyright (C) British Crown (Met Office) & Contributors.
+#
+# This file is part of Rose, a framework for meteorological suites.
+#
+# Rose is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Rose is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Rose. If not, see <http://www.gnu.org/licenses/>.
+
+name: Update copyright year
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '35 3 1 1 *' # Every Jan 1st @ 03:35 UTC
+
+jobs:
+  update-copyright:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+
+      - name: Checkout repo
+        uses: actions/checkout@v2
+
+      - name: Checkout PR branch
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          year=$(date '+%Y' --utc)
+          branch_name="copyright-${year}"
+          git checkout -b "$branch_name"
+          echo "YEAR=$year" >> $GITHUB_ENV
+          echo "BRANCH_NAME=$branch_name" >> $GITHUB_ENV
+
+      - name: Update copyright year
+        env:
+          README_FILE: 'README.md'
+        run: |
+          pattern="(<span actions:bind='current-year'>).*(<\/span>)"
+          sed -i -E "s/${pattern}/\1${YEAR}\2/" "$README_FILE"
+
+      - name: Commit & push
+        run : |
+          git commit -a -m "Update copyright year" -m "Workflow: ${{ github.workflow }}, run: ${{ github.run_number }}"
+          git push origin "$BRANCH_NAME"
+
+      - name: Create pull request
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          curl -X POST \
+            https://api.github.com/repos/${{ github.repository }}/pulls \
+            -H "authorization: Bearer ${GH_TOKEN}" \
+            -H 'content-type: application/json' \
+            --data '{
+              "title": "Auto PR: update copyright year",
+              "head": "${{ env.BRANCH_NAME }}",
+              "base": "master",
+              "body": "Happy new year!"
+            }'

--- a/.travis/cover.py
+++ b/.travis/cover.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2012-8 Met Office.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/.travis/now
+++ b/.travis/now
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/.travis/shellchecker
+++ b/.travis/shellchecker
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/.travis/sitecustomize.py
+++ b/.travis/sitecustomize.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# (C) British Crown Copyright 2012-8 Met Office.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ release for production use.
 
 ## Copyright and Terms of Use
 
-Copyright (C) 2012-2019 British Crown (Met Office) &amp; Contributors
+Copyright (C) 2012-<span actions:bind='current-year'>2020</span> British Crown (Met Office) &amp; Contributors
 
 Rose is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/bin/rose
+++ b/bin/rose
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/bin/rose-app-run
+++ b/bin/rose-app-run
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/bin/rose-app-upgrade
+++ b/bin/rose-app-upgrade
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #-------------------------------------------------------------------------------
 # NAME
 #     rose app-upgrade

--- a/bin/rose-check-software
+++ b/bin/rose-check-software
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #-----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/bin/rose-config
+++ b/bin/rose-config
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/bin/rose-config-diff
+++ b/bin/rose-config-diff
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/bin/rose-config-dump
+++ b/bin/rose-config-dump
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/bin/rose-config-edit
+++ b/bin/rose-config-edit
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #-----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/bin/rose-date
+++ b/bin/rose-date
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/bin/rose-edit
+++ b/bin/rose-edit
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/bin/rose-env-cat
+++ b/bin/rose-env-cat
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/bin/rose-host-select
+++ b/bin/rose-host-select
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/bin/rose-macro
+++ b/bin/rose-macro
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/bin/rose-metadata-check
+++ b/bin/rose-metadata-check
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/bin/rose-metadata-gen
+++ b/bin/rose-metadata-gen
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/bin/rose-metadata-graph
+++ b/bin/rose-metadata-graph
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/bin/rose-mpi-launch
+++ b/bin/rose-mpi-launch
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/bin/rose-namelist-dump
+++ b/bin/rose-namelist-dump
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/bin/rose-slv
+++ b/bin/rose-slv
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/bin/rose-stem
+++ b/bin/rose-stem
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #
@@ -41,9 +41,9 @@
 #         Specify a source tree to include in a rose-stem suite. The first
 #         source tree must be a working copy as the location of the suite and
 #         fcm-make config files are taken from it. Further source trees can be
-#         added with additional `--source` arguments. The project which is 
+#         added with additional `--source` arguments. The project which is
 #         associated with a given source is normally automatically determined
-#         using FCM, however the project can be specified by putting the 
+#         using FCM, however the project can be specified by putting the
 #         project name as the first part of this argument separated by an
 #         equals sign as in the third example above.
 #         Defaults to `.` if not specified.
@@ -64,17 +64,17 @@
 #         in this list have their hostname prefixed, e.g. `host:/path/wc`.
 #     HOST_SOURCE_<project>_BASE
 #         The base of the project specified on the command line. This is
-#         intended to specify the location of `fcm-make` config files. Working 
+#         intended to specify the location of `fcm-make` config files. Working
 #         copies in this list have their hostname prefixed.
 #     RUN_NAMES
 #         A list of groups to run in the rose-stem suite.
 #     SOURCE_<project>
-#         The complete list of source trees for a given project. Unlike the 
-#         `HOST_` variable of similar name, paths to working copies do NOT 
+#         The complete list of source trees for a given project. Unlike the
+#         `HOST_` variable of similar name, paths to working copies do NOT
 #         include the host name.
 #     SOURCE_<project>_BASE
 #         The base of the project specified on the command line. This is
-#         intended to specify the location of `fcm-make` config files. Unlike 
+#         intended to specify the location of `fcm-make` config files. Unlike
 #         the `HOST_` variable of similar name, paths to working copies do NOT
 #         include the host name.
 #     SOURCE_<project>_REV

--- a/bin/rose-suite-clean
+++ b/bin/rose-suite-clean
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #
@@ -40,7 +40,7 @@
 #         If one or more `--only=ITEM` option is specified, only files and/or
 #         directories matching an `ITEM` will be removed. An `ITEM` should be a
 #         glob pattern (bash extglob) for matching a relative path in the run
-#         directory of the suite(s). 
+#         directory of the suite(s).
 #     --quiet, -q
 #         Decrement verbosity.
 #     --verbose, -v

--- a/bin/rose-suite-cmp-vc
+++ b/bin/rose-suite-cmp-vc
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #
@@ -44,7 +44,7 @@
 #
 # OPTIONS
 #     --name=NAME, -n NAME
-#         Specify the suite NAME. 
+#         Specify the suite NAME.
 #     --quiet, -q
 #         Decrement verbosity.
 #     --verbose, -v

--- a/bin/rose-suite-hook
+++ b/bin/rose-suite-hook
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/bin/rose-suite-init
+++ b/bin/rose-suite-init
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/bin/rose-suite-log
+++ b/bin/rose-suite-log
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/bin/rose-suite-log-view
+++ b/bin/rose-suite-log-view
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/bin/rose-suite-restart
+++ b/bin/rose-suite-restart
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/bin/rose-suite-run
+++ b/bin/rose-suite-run
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/bin/rose-suite-scan
+++ b/bin/rose-suite-scan
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/bin/rose-suite-shutdown
+++ b/bin/rose-suite-shutdown
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #
@@ -51,7 +51,7 @@
 #     --verbose, -v
 #         Increment verbosity.
 #     -- --EXTRA-ARGS
-#         See the cylc documentation, cylc shutdown for options and details on 
+#         See the cylc documentation, cylc shutdown for options and details on
 #         `EXTRA-ARGS`.
 #-------------------------------------------------------------------------------
 exec python3 -m metomi.rose.suite_control shutdown "$@"

--- a/bin/rose-suite-stop
+++ b/bin/rose-suite-stop
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/bin/rose-task-env
+++ b/bin/rose-task-env
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/bin/rose-task-hook
+++ b/bin/rose-task-hook
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/bin/rose-task-run
+++ b/bin/rose-task-run
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/bin/rose-tutorial
+++ b/bin/rose-tutorial
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/bin/rosie-checkout
+++ b/bin/rosie-checkout
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/bin/rosie-co
+++ b/bin/rosie-co
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/bin/rosie-copy
+++ b/bin/rosie-copy
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/bin/rosie-create
+++ b/bin/rosie-create
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/bin/rosie-delete
+++ b/bin/rosie-delete
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/bin/rosie-disco
+++ b/bin/rosie-disco
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #-----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/bin/rosie-go
+++ b/bin/rosie-go
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #-----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/bin/rosie-graph
+++ b/bin/rosie-graph
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/bin/rosie-hello
+++ b/bin/rosie-hello
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/bin/rosie-id
+++ b/bin/rosie-id
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/bin/rosie-lookup
+++ b/bin/rosie-lookup
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/bin/rosie-ls
+++ b/bin/rosie-ls
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/demo/rose-config-edit/demo_meta/app/04-transform/meta/lib/python/macros/badenvswitch.py
+++ b/demo/rose-config-edit/demo_meta/app/04-transform/meta/lib/python/macros/badenvswitch.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 # -----------------------------------------------------------------------------
 
 import rose.macro

--- a/demo/rose-config-edit/demo_meta/app/04-transform/meta/lib/python/macros/envswitch.py
+++ b/demo/rose-config-edit/demo_meta/app/04-transform/meta/lib/python/macros/envswitch.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 # -----------------------------------------------------------------------------
 
 import rose.macro

--- a/demo/rose-config-edit/demo_meta/app/04-transform/meta/lib/python/macros/nl_add_remove.py
+++ b/demo/rose-config-edit/demo_meta/app/04-transform/meta/lib/python/macros/nl_add_remove.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 # -----------------------------------------------------------------------------
 
 import rose.macro

--- a/demo/rose-config-edit/demo_meta/app/04-transform/meta/lib/python/macros/nl_ignore.py
+++ b/demo/rose-config-edit/demo_meta/app/04-transform/meta/lib/python/macros/nl_ignore.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 # -----------------------------------------------------------------------------
 
 import rose.macro

--- a/demo/rose-config-edit/demo_meta/app/04-transform/meta/lib/python/macros/null.py
+++ b/demo/rose-config-edit/demo_meta/app/04-transform/meta/lib/python/macros/null.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 # -----------------------------------------------------------------------------
 
 import rose.macro

--- a/demo/rose-config-edit/demo_meta/app/05-validate/meta/lib/python/macros/fib.py
+++ b/demo/rose-config-edit/demo_meta/app/05-validate/meta/lib/python/macros/fib.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 # -----------------------------------------------------------------------------
 
 import rose.macro

--- a/demo/rose-config-edit/demo_meta/app/05-validate/meta/lib/python/macros/null.py
+++ b/demo/rose-config-edit/demo_meta/app/05-validate/meta/lib/python/macros/null.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 # -----------------------------------------------------------------------------
 
 import rose.macro

--- a/demo/rose-config-edit/demo_meta/app/05-validate/meta/lib/python/macros/url.py
+++ b/demo/rose-config-edit/demo_meta/app/05-validate/meta/lib/python/macros/url.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 # -----------------------------------------------------------------------------
 
 import http.client

--- a/etc/bin/rose-make-docs
+++ b/etc/bin/rose-make-docs
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #-----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #
@@ -284,7 +284,7 @@ fi
 if "${USING_VENV}"; then
     if ! "${DEV_MODE}"; then
         venv-destroy
-    fi 
+    fi
 fi
 
 exit ${RET}

--- a/etc/bin/rose-test-battery
+++ b/etc/bin/rose-test-battery
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/etc/deploy-docs
+++ b/etc/deploy-docs
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/etc/rose-bash-completion
+++ b/etc/rose-bash-completion
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #
@@ -72,7 +72,7 @@ _rose() {
     fi
     if [[ -n $subcommand && -L $ROSE_DIR/bin/rose-$subcommand ]]; then
         subcommand=$(readlink $subcommand)
-    fi          
+    fi
 
     # Determine option or option argument completion.
     current_option_line=$(printf "%s\n" "${COMP_WORDS[@]}" | grep -n "^-" | \
@@ -213,7 +213,7 @@ _rose_macro_ARGS() {
     meta_path_option="--meta-path=$meta_path"
     if [[ -z $meta_path ]]; then
         meta_path_option=
-    fi  
+    fi
     rose macro -q $meta_path_option --config=$config_dir 2>/dev/null | \
         sed "s/^\[.*\] //g"
 }
@@ -418,7 +418,7 @@ __rose_get_rose_dir() {
 __rose_get_users() {
     getent passwd | cut -d: -f1 | LANG=C sort -u
 }
-    
+
 __rose_help() {
     local subcommand
     subcommand=$1

--- a/etc/tutorial/cylc-forecasting-suite/bin/consolidate-observations
+++ b/etc/tutorial/cylc-forecasting-suite/bin/consolidate-observations
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors - GNU V3+.
+# Copyright (C) British Crown (Met Office) & Contributors - GNU V3+.
 # This is illustrative code developed for tutorial purposes, it is not
 # intended for scientific use and is not guarantied to be accurate or correct.
 # -----------------------------------------------------------------------------

--- a/etc/tutorial/cylc-forecasting-suite/bin/forecast
+++ b/etc/tutorial/cylc-forecasting-suite/bin/forecast
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors - GNU V3+.
+# Copyright (C) British Crown (Met Office) & Contributors - GNU V3+.
 # This is illustrative code developed for tutorial purposes, it is not
 # intended for scientific use and is not guarantied to be accurate or correct.
 # -----------------------------------------------------------------------------

--- a/etc/tutorial/cylc-forecasting-suite/bin/get-observations
+++ b/etc/tutorial/cylc-forecasting-suite/bin/get-observations
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors - GNU V3+.
+# Copyright (C) British Crown (Met Office) & Contributors - GNU V3+.
 # This is illustrative code developed for tutorial purposes, it is not
 # intended for scientific use and is not guarantied to be accurate or correct.
 # -----------------------------------------------------------------------------

--- a/etc/tutorial/cylc-forecasting-suite/bin/get-rainfall
+++ b/etc/tutorial/cylc-forecasting-suite/bin/get-rainfall
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors - GNU V3+.
+# Copyright (C) British Crown (Met Office) & Contributors - GNU V3+.
 # This is illustrative code developed for tutorial purposes, it is not
 # intended for scientific use and is not guarantied to be accurate or correct.
 # -----------------------------------------------------------------------------

--- a/etc/tutorial/cylc-forecasting-suite/bin/post-process
+++ b/etc/tutorial/cylc-forecasting-suite/bin/post-process
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors - GNU V3+.
+# Copyright (C) British Crown (Met Office) & Contributors - GNU V3+.
 # This is illustrative code developed for tutorial purposes, it is not
 # intended for scientific use and is not guarantied to be accurate or correct.
 # -----------------------------------------------------------------------------

--- a/etc/tutorial/cylc-forecasting-suite/lib/python/mecator.py
+++ b/etc/tutorial/cylc-forecasting-suite/lib/python/mecator.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors - GNU V3+.
+# Copyright (C) British Crown (Met Office) & Contributors - GNU V3+.
 # This is illustrative code developed for tutorial purposes, it is not
 # intended for scientific use and is not guarantied to be accurate or correct.
 # -----------------------------------------------------------------------------

--- a/etc/tutorial/cylc-forecasting-suite/lib/python/util.py
+++ b/etc/tutorial/cylc-forecasting-suite/lib/python/util.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors - GNU V3+.
+# Copyright (C) British Crown (Met Office) & Contributors - GNU V3+.
 # This is illustrative code developed for tutorial purposes, it is not
 # intended for scientific use and is not guarantied to be accurate or correct.
 # -----------------------------------------------------------------------------

--- a/lib/bash/rose_init
+++ b/lib/bash/rose_init
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/lib/bash/rose_init_site.example
+++ b/lib/bash/rose_init_site.example
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/lib/bash/rose_log
+++ b/lib/bash/rose_log
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/lib/bash/rose_usage
+++ b/lib/bash/rose_usage
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/metomi/rose/__init__.py
+++ b/metomi/rose/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/metomi/rose/app_run.py
+++ b/metomi/rose/app_run.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/metomi/rose/apps/__init__.py
+++ b/metomi/rose/apps/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/metomi/rose/apps/ana_builtin/grepper.py
+++ b/metomi/rose/apps/ana_builtin/grepper.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/metomi/rose/apps/comparisons/cumf.py
+++ b/metomi/rose/apps/comparisons/cumf.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/metomi/rose/apps/comparisons/exact.py
+++ b/metomi/rose/apps/comparisons/exact.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/metomi/rose/apps/comparisons/mandatory.py
+++ b/metomi/rose/apps/comparisons/mandatory.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/metomi/rose/apps/comparisons/output_grepper.py
+++ b/metomi/rose/apps/comparisons/output_grepper.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/metomi/rose/apps/comparisons/prohibited.py
+++ b/metomi/rose/apps/comparisons/prohibited.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/metomi/rose/apps/comparisons/within.py
+++ b/metomi/rose/apps/comparisons/within.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/metomi/rose/apps/fcm_make.py
+++ b/metomi/rose/apps/fcm_make.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # ----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/metomi/rose/apps/rose_ana.py
+++ b/metomi/rose/apps/rose_ana.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/metomi/rose/apps/rose_ana_v1.py
+++ b/metomi/rose/apps/rose_ana_v1.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/metomi/rose/apps/rose_arch.py
+++ b/metomi/rose/apps/rose_arch.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # ----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/metomi/rose/apps/rose_arch_compressions/__init__.py
+++ b/metomi/rose/apps/rose_arch_compressions/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/metomi/rose/apps/rose_arch_compressions/rose_arch_gzip.py
+++ b/metomi/rose/apps/rose_arch_compressions/rose_arch_gzip.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/metomi/rose/apps/rose_arch_compressions/rose_arch_tar.py
+++ b/metomi/rose/apps/rose_arch_compressions/rose_arch_tar.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/metomi/rose/apps/rose_bunch.py
+++ b/metomi/rose/apps/rose_bunch.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # ----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/metomi/rose/apps/rose_prune.py
+++ b/metomi/rose/apps/rose_prune.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # ----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/metomi/rose/bush_dao.py
+++ b/metomi/rose/bush_dao.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/metomi/rose/c3.py
+++ b/metomi/rose/c3.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/metomi/rose/checksum.py
+++ b/metomi/rose/checksum.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/metomi/rose/cmp_source_vc.py
+++ b/metomi/rose/cmp_source_vc.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/metomi/rose/config.py
+++ b/metomi/rose/config.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/metomi/rose/config_cli.py
+++ b/metomi/rose/config_cli.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/metomi/rose/config_diff.py
+++ b/metomi/rose/config_diff.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # ----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/metomi/rose/config_dump.py
+++ b/metomi/rose/config_dump.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/metomi/rose/config_processor.py
+++ b/metomi/rose/config_processor.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/metomi/rose/config_processors/__init__.py
+++ b/metomi/rose/config_processors/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/metomi/rose/config_processors/empy.py
+++ b/metomi/rose/config_processors/empy.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/metomi/rose/config_processors/env.py
+++ b/metomi/rose/config_processors/env.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/metomi/rose/config_processors/fileinstall.py
+++ b/metomi/rose/config_processors/fileinstall.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # ----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/metomi/rose/config_processors/jinja2.py
+++ b/metomi/rose/config_processors/jinja2.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/metomi/rose/config_tree.py
+++ b/metomi/rose/config_tree.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/metomi/rose/date.py
+++ b/metomi/rose/date.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/metomi/rose/env.py
+++ b/metomi/rose/env.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # ----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/metomi/rose/env_cat.py
+++ b/metomi/rose/env_cat.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/metomi/rose/etc/rose-demo-baked-alaska-sponge/vn1.0/lib/python/macros/desoggy.py
+++ b/metomi/rose/etc/rose-demo-baked-alaska-sponge/vn1.0/lib/python/macros/desoggy.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/metomi/rose/etc/rose-demo-upgrade-null/versions.py
+++ b/metomi/rose/etc/rose-demo-upgrade-null/versions.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 # -----------------------------------------------------------------------------
 """Module containing test upgrade macros"""
 

--- a/metomi/rose/etc/rose-demo-upgrade/versions.py
+++ b/metomi/rose/etc/rose-demo-upgrade/versions.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 # -----------------------------------------------------------------------------
 """Module containing example macros for using rose app-upgrade.
 

--- a/metomi/rose/etc/rose-meta/rose-demo-baked-alaska-sponge/vn1.0/lib/python/macros/desoggy.py
+++ b/metomi/rose/etc/rose-meta/rose-demo-baked-alaska-sponge/vn1.0/lib/python/macros/desoggy.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/metomi/rose/etc/rose-meta/rose-demo-upgrade-null/versions.py
+++ b/metomi/rose/etc/rose-meta/rose-demo-upgrade-null/versions.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 # -----------------------------------------------------------------------------
 """Module containing test upgrade macros"""
 

--- a/metomi/rose/etc/rose-meta/rose-demo-upgrade/versions.py
+++ b/metomi/rose/etc/rose-meta/rose-demo-upgrade/versions.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 # -----------------------------------------------------------------------------
 """Module containing example macros for using rose app-upgrade.
 

--- a/metomi/rose/external.py
+++ b/metomi/rose/external.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/metomi/rose/formats/__init__.py
+++ b/metomi/rose/formats/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # ----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/metomi/rose/formats/namelist.py
+++ b/metomi/rose/formats/namelist.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/metomi/rose/fs_util.py
+++ b/metomi/rose/fs_util.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/metomi/rose/host_select.py
+++ b/metomi/rose/host_select.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/metomi/rose/job_runner.py
+++ b/metomi/rose/job_runner.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/metomi/rose/loc_handlers/__init__.py
+++ b/metomi/rose/loc_handlers/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/metomi/rose/loc_handlers/fs.py
+++ b/metomi/rose/loc_handlers/fs.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/metomi/rose/loc_handlers/namelist.py
+++ b/metomi/rose/loc_handlers/namelist.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/metomi/rose/loc_handlers/rsync.py
+++ b/metomi/rose/loc_handlers/rsync.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/metomi/rose/loc_handlers/svn.py
+++ b/metomi/rose/loc_handlers/svn.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/metomi/rose/macro.py
+++ b/metomi/rose/macro.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/metomi/rose/macros/__init__.py
+++ b/metomi/rose/macros/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/metomi/rose/macros/compulsory.py
+++ b/metomi/rose/macros/compulsory.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/metomi/rose/macros/duplicate.py
+++ b/metomi/rose/macros/duplicate.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/metomi/rose/macros/format.py
+++ b/metomi/rose/macros/format.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 # -----------------------------------------------------------------------------
 
 import inspect

--- a/metomi/rose/macros/rule.py
+++ b/metomi/rose/macros/rule.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/metomi/rose/macros/trigger.py
+++ b/metomi/rose/macros/trigger.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/metomi/rose/macros/value.py
+++ b/metomi/rose/macros/value.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/metomi/rose/meta_type.py
+++ b/metomi/rose/meta_type.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/metomi/rose/metadata_check.py
+++ b/metomi/rose/metadata_check.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/metomi/rose/metadata_gen.py
+++ b/metomi/rose/metadata_gen.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/metomi/rose/metadata_graph.py
+++ b/metomi/rose/metadata_graph.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/metomi/rose/namelist_dump.py
+++ b/metomi/rose/namelist_dump.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/metomi/rose/opt_parse.py
+++ b/metomi/rose/opt_parse.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/metomi/rose/popen.py
+++ b/metomi/rose/popen.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/metomi/rose/reporter.py
+++ b/metomi/rose/reporter.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/metomi/rose/resource.py
+++ b/metomi/rose/resource.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/metomi/rose/run.py
+++ b/metomi/rose/run.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/metomi/rose/run_source_vc.py
+++ b/metomi/rose/run_source_vc.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/metomi/rose/scheme_handler.py
+++ b/metomi/rose/scheme_handler.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/metomi/rose/section.py
+++ b/metomi/rose/section.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/metomi/rose/stem.py
+++ b/metomi/rose/stem.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/metomi/rose/suite_clean.py
+++ b/metomi/rose/suite_clean.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # ----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/metomi/rose/suite_control.py
+++ b/metomi/rose/suite_control.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/metomi/rose/suite_engine_proc.py
+++ b/metomi/rose/suite_engine_proc.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/metomi/rose/suite_engine_procs/__init__.py
+++ b/metomi/rose/suite_engine_procs/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/metomi/rose/suite_engine_procs/cylc.py
+++ b/metomi/rose/suite_engine_procs/cylc.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/metomi/rose/suite_hook.py
+++ b/metomi/rose/suite_hook.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/metomi/rose/suite_log.py
+++ b/metomi/rose/suite_log.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/metomi/rose/suite_restart.py
+++ b/metomi/rose/suite_restart.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/metomi/rose/suite_run.py
+++ b/metomi/rose/suite_run.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/metomi/rose/task_env.py
+++ b/metomi/rose/task_env.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/metomi/rose/task_run.py
+++ b/metomi/rose/task_run.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/metomi/rose/tests/config.py
+++ b/metomi/rose/tests/config.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/metomi/rose/tests/env.py
+++ b/metomi/rose/tests/env.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/metomi/rose/tests/popen.py
+++ b/metomi/rose/tests/popen.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/metomi/rose/tests/trigger_file.py
+++ b/metomi/rose/tests/trigger_file.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/metomi/rose/tests/unicode_utils.py
+++ b/metomi/rose/tests/unicode_utils.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/metomi/rose/unicode_utils.py
+++ b/metomi/rose/unicode_utils.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/metomi/rose/upgrade.py
+++ b/metomi/rose/upgrade.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/metomi/rose/variable.py
+++ b/metomi/rose/variable.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/metomi/rosie/__init__.py
+++ b/metomi/rosie/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/metomi/rosie/db.py
+++ b/metomi/rosie/db.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/metomi/rosie/db_create.py
+++ b/metomi/rosie/db_create.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/metomi/rosie/graph.py
+++ b/metomi/rosie/graph.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/metomi/rosie/lib/html/static/js/rosie-disco.js
+++ b/metomi/rosie/lib/html/static/js/rosie-disco.js
@@ -1,5 +1,5 @@
 /******************************************************************************
- * Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+ * Copyright (C) British Crown (Met Office) & Contributors.
  *
  * This file is part of Rose, a framework for scientific suites.
  *

--- a/metomi/rosie/suite_id.py
+++ b/metomi/rosie/suite_id.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/metomi/rosie/svn_post_commit.py
+++ b/metomi/rosie/svn_post_commit.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/metomi/rosie/svn_pre_commit.py
+++ b/metomi/rosie/svn_pre_commit.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/metomi/rosie/usertools/__init__.py
+++ b/metomi/rosie/usertools/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/metomi/rosie/usertools/ldaptool.py
+++ b/metomi/rosie/usertools/ldaptool.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/metomi/rosie/usertools/passwdtool.py
+++ b/metomi/rosie/usertools/passwdtool.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/metomi/rosie/vc.py
+++ b/metomi/rosie/vc.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/metomi/rosie/ws.py
+++ b/metomi/rosie/ws.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/metomi/rosie/ws_client.py
+++ b/metomi/rosie/ws_client.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/metomi/rosie/ws_client_auth.py
+++ b/metomi/rosie/ws_client_auth.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/metomi/rosie/ws_client_cli.py
+++ b/metomi/rosie/ws_client_cli.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/sbin/rosa-db-create
+++ b/sbin/rosa-db-create
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/sbin/rosa-rpmbuild
+++ b/sbin/rosa-rpmbuild
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #
@@ -85,7 +85,7 @@ python3 -m compileall %{buildroot}/opt/$NAME/lib
 cp -p %_sourcedir/$NAME-$REV_BASE_DOT/usr/bin/rose %{buildroot}/usr/bin/rose
 cp -p %_sourcedir/$NAME-$REV_BASE_DOT/usr/bin/rose %{buildroot}/usr/bin/rosie
 
-%clean 
+%clean
 rm -fr %{buildroot}
 
 %files

--- a/sbin/rosa-svn-post-commit
+++ b/sbin/rosa-svn-post-commit
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/sbin/rosa-svn-pre-commit
+++ b/sbin/rosa-svn-pre-commit
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/sbin/rosa-ws
+++ b/sbin/rosa-ws
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #-----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,7 @@
 [metadata]
 name = metomi-rose
 description = Rose, a framework for meteorological suites.
-author = 2012-2019 British Crown (Met Office) & Contributors
+author = British Crown (Met Office) & Contributors
 author_email = metomi@metoffice.gov.uk
 url=https://metomi.github.io/rose/doc/html/index.html
 license = GPL

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 #!/usr/ bin/env python3
 # coding=utf-8
 
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/sphinx/conf.py
+++ b/sphinx/conf.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #
@@ -103,7 +103,7 @@ master_doc = 'index'
 # General information about the project.
 project = 'Rose Documentation'
 copyright = (
-    ': Copyright (C) 2012-2019 British Crown (Met Office) & Contributors. '
+    ': Copyright (C) British Crown (Met Office) & Contributors. '
     'See Terms of Use. '
     'This document is released under the Open Government Licence')
 

--- a/sphinx/ext/auto_cli_doc.py
+++ b/sphinx/ext/auto_cli_doc.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/sphinx/ext/rose_domain.py
+++ b/sphinx/ext/rose_domain.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/sphinx/ext/rose_lang.py
+++ b/sphinx/ext/rose_lang.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/sphinx/ext/script_include.py
+++ b/sphinx/ext/script_include.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/sphinx/extract-pdf-documents.py
+++ b/sphinx/extract-pdf-documents.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/docs/01-doctest.t
+++ b/t/docs/01-doctest.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/docs/02-tutorial-suites.t
+++ b/t/docs/02-tutorial-suites.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/lib/bash/test_header
+++ b/t/lib/bash/test_header
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #
@@ -310,7 +310,7 @@ bad_smtpd_kill() {
 
 mock_smtpd_init() {
     local SMTPD_PORT=
-    for SMTPD_PORT in 8025 8125 8225 8325 8425 8525 8625 8725 8825 8925; do 
+    for SMTPD_PORT in 8025 8125 8225 8325 8425 8525 8625 8725 8825 8925; do
         local SMTPD_HOST=localhost:$SMTPD_PORT
         local SMTPD_LOG="$TEST_DIR/smtpd.log"
         python3 -u -m smtpd -n -c DebuggingServer -d -n "$SMTPD_HOST" \

--- a/t/rosa-db-create/00-basic.t
+++ b/t/rosa-db-create/00-basic.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rosa-svn-post-commit/00-basic.t
+++ b/t/rosa-svn-post-commit/00-basic.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rosa-svn-post-commit/01-mail-passwd.t
+++ b/t/rosa-svn-post-commit/01-mail-passwd.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rosa-svn-post-commit/03-unicode.t
+++ b/t/rosa-svn-post-commit/03-unicode.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rosa-svn-pre-commit/00-basic.t
+++ b/t/rosa-svn-pre-commit/00-basic.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rosa-svn-pre-commit/01-rosie-create.t
+++ b/t/rosa-svn-pre-commit/01-rosie-create.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rosa-svn-pre-commit/02-passwd.t
+++ b/t/rosa-svn-pre-commit/02-passwd.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rosa-svn-pre-commit/03-meta.t
+++ b/t/rosa-svn-pre-commit/03-meta.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-ana/00-run-basic.t
+++ b/t/rose-ana/00-run-basic.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-ana/01-run-basic-v1.t
+++ b/t/rose-ana/01-run-basic-v1.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-app-run/00-null.t
+++ b/t/rose-app-run/00-null.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-app-run/01-basic.t
+++ b/t/rose-app-run/01-basic.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-app-run/02-command.t
+++ b/t/rose-app-run/02-command.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #
@@ -76,7 +76,7 @@ __CONTENT__
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
 test_teardown
 #-------------------------------------------------------------------------------
-# Normal mode, command key provided via ROSE_APP_COMMAND_KEY, 
+# Normal mode, command key provided via ROSE_APP_COMMAND_KEY,
 # command-key=hello-user.
 TEST_KEY=$TEST_KEY_BASE-hello-from-env
 test_setup

--- a/t/rose-app-run/03-env.t
+++ b/t/rose-app-run/03-env.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-app-run/04-stdin.t
+++ b/t/rose-app-run/04-stdin.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-app-run/05-file.t
+++ b/t/rose-app-run/05-file.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-app-run/06-namelist.t
+++ b/t/rose-app-run/06-namelist.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-app-run/07-opt.t
+++ b/t/rose-app-run/07-opt.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-app-run/08-poll.t
+++ b/t/rose-app-run/08-poll.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-app-run/09-file-incr-0.t
+++ b/t/rose-app-run/09-file-incr-0.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-app-run/10-file-incr-1.t
+++ b/t/rose-app-run/10-file-incr-1.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-app-run/11-file-incr-2.t
+++ b/t/rose-app-run/11-file-incr-2.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-app-run/12-file-incr-3.t
+++ b/t/rose-app-run/12-file-incr-3.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-app-run/13-file-source-tilde.t
+++ b/t/rose-app-run/13-file-source-tilde.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-app-run/14-file-source-optional.t
+++ b/t/rose-app-run/14-file-source-optional.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-app-run/15-file-permission.t
+++ b/t/rose-app-run/15-file-permission.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-app-run/16-file-mode-bad.t
+++ b/t/rose-app-run/16-file-mode-bad.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-app-run/17-file-db-bad.t
+++ b/t/rose-app-run/17-file-db-bad.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-app-run/18-access-mode-change.t
+++ b/t/rose-app-run/18-access-mode-change.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-app-run/19-file-unchanged.t
+++ b/t/rose-app-run/19-file-unchanged.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-app-run/20-file-symlink-no-source.t
+++ b/t/rose-app-run/20-file-symlink-no-source.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-app-run/21-run-config-load-event.t
+++ b/t/rose-app-run/21-run-config-load-event.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-app-run/22-opt-conf-key-missing.t
+++ b/t/rose-app-run/22-opt-conf-key-missing.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-app-run/23-file-both.t
+++ b/t/rose-app-run/23-file-both.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-app-run/24-app-unicode.t
+++ b/t/rose-app-run/24-app-unicode.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-app-run/25-file-symlink-plus.t
+++ b/t/rose-app-run/25-file-symlink-plus.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-app-run/26-define-overrides.t
+++ b/t/rose-app-run/26-define-overrides.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-app-run/test_header
+++ b/t/rose-app-run/test_header
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-app-upgrade/00-null.t
+++ b/t/rose-app-upgrade/00-null.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-app-upgrade/01-upgrade-basic.t
+++ b/t/rose-app-upgrade/01-upgrade-basic.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-app-upgrade/02-downgrade-basic.t
+++ b/t/rose-app-upgrade/02-downgrade-basic.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-app-upgrade/03-complex.t
+++ b/t/rose-app-upgrade/03-complex.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-app-upgrade/04-upgrade-trigger.t
+++ b/t/rose-app-upgrade/04-upgrade-trigger.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-app-upgrade/05-cwd.t
+++ b/t/rose-app-upgrade/05-cwd.t
@@ -1,19 +1,19 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
-# 
+# Copyright (C) British Crown (Met Office) & Contributors.
+#
 # This file is part of Rose, a framework for scientific suites.
-# 
+#
 # Rose is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-# 
+#
 # Rose is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License
 # along with Rose. If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------

--- a/t/rose-app-upgrade/06-broken.t
+++ b/t/rose-app-upgrade/06-broken.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-app-upgrade/07-add-existing.t
+++ b/t/rose-app-upgrade/07-add-existing.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-app-upgrade/08-category-is-package.t
+++ b/t/rose-app-upgrade/08-category-is-package.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-app-upgrade/09-opt.t
+++ b/t/rose-app-upgrade/09-opt.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-app-upgrade/10-prettify-trigger-bug.t
+++ b/t/rose-app-upgrade/10-prettify-trigger-bug.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-app-upgrade/11-upgrade-basic-tree.t
+++ b/t/rose-app-upgrade/11-upgrade-basic-tree.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-app-upgrade/12-downgrade-basic-tree.t
+++ b/t/rose-app-upgrade/12-downgrade-basic-tree.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-app-upgrade/13-bad-upgrade-macro.t
+++ b/t/rose-app-upgrade/13-bad-upgrade-macro.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #
@@ -43,9 +43,9 @@ import metomi.rose.upgrade
 
 
 class Upgrade01to02(metomi.rose.upgrade.MacroUpgrade):
-    
+
     """Test class to upgrade the macro with a bad change and fail on save."""
-    
+
     BEFORE_TAG = "0.1"
     AFTER_TAG = "0.2"
 

--- a/t/rose-app-upgrade/test_header
+++ b/t/rose-app-upgrade/test_header
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-cli-bash-completion/00-static.t
+++ b/t/rose-cli-bash-completion/00-static.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-cli-bash-completion/01-suite-running.t
+++ b/t/rose-cli-bash-completion/01-suite-running.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-cli-bash-completion/test_header
+++ b/t/rose-cli-bash-completion/test_header
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-config-diff/00-basic.t
+++ b/t/rose-config-diff/00-basic.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #
@@ -288,7 +288,7 @@ file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
 TEST_KEY=$TEST_KEY_BASE-custom-diff-tool
 echo >conf/rose.conf
 run_pass "$TEST_KEY" rose config-diff --diff-tool='cat -n' \
-    $TEST_DIR/app{1,2}/rose-app.conf 
+    $TEST_DIR/app{1,2}/rose-app.conf
 file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<'__DIFF__'
      1	# description=Environment variable configuration
      2	[env]
@@ -318,7 +318,7 @@ cat >conf/rose.conf <<__ROSE_CONF__
 [external]
 diff_tool=cat -n
 __ROSE_CONF__
-run_pass "$TEST_KEY" rose config-diff $TEST_DIR/app{1,2}/rose-app.conf 
+run_pass "$TEST_KEY" rose config-diff $TEST_DIR/app{1,2}/rose-app.conf
 file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<'__DIFF__'
      1	# description=Environment variable configuration
      2	[env]

--- a/t/rose-config-diff/test_header
+++ b/t/rose-config-diff/test_header
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #
@@ -37,7 +37,7 @@ function init_meta() {
 
 function init_rose_meta() {
     local category=$1
-    local version=$2    
+    local version=$2
     mkdir -p $TEST_DIR/rose-meta/$category/$version
     cat >$TEST_DIR/rose-meta/$category/$version/rose-meta.conf
 }

--- a/t/rose-config-dump/00-basic.t
+++ b/t/rose-config-dump/00-basic.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-config-dump/01-indices.t
+++ b/t/rose-config-dump/01-indices.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-config-dump/02-files.t
+++ b/t/rose-config-dump/02-files.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-config-dump/03-prettyprint.t
+++ b/t/rose-config-dump/03-prettyprint.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose,a framework for scientific suites.
 #

--- a/t/rose-config-dump/test_header
+++ b/t/rose-config-dump/test_header
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-config/00-basic.t
+++ b/t/rose-config/00-basic.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-config/01-opt.t
+++ b/t/rose-config/01-opt.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-config/03-syntax-error.t
+++ b/t/rose-config/03-syntax-error.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-config/04-meta.t
+++ b/t/rose-config/04-meta.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-config/05-opt-opt.t
+++ b/t/rose-config/05-opt-opt.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-config/test_header
+++ b/t/rose-config/test_header
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-date/00-basic.t
+++ b/t/rose-date/00-basic.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-date/00-reference-time.t
+++ b/t/rose-date/00-reference-time.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-date/01-calendar.t
+++ b/t/rose-date/01-calendar.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-env-cat/00-null.t
+++ b/t/rose-env-cat/00-null.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-env-cat/01-basic.t
+++ b/t/rose-env-cat/01-basic.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-env-cat/02-braced.t
+++ b/t/rose-env-cat/02-braced.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-env-cat/test_header
+++ b/t/rose-env-cat/test_header
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-help/00-alias.t
+++ b/t/rose-help/00-alias.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-host-select/00-basic.t
+++ b/t/rose-host-select/00-basic.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-host-select/01-timeout.t
+++ b/t/rose-host-select/01-timeout.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-host-select/02-localhost.t
+++ b/t/rose-host-select/02-localhost.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-macro/00-null.t
+++ b/t/rose-macro/00-null.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-macro/01-value-type-check-ok.t
+++ b/t/rose-macro/01-value-type-check-ok.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-macro/02-value-type-check-err.t
+++ b/t/rose-macro/02-value-type-check-err.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-macro/03-value-range-check-ok.t
+++ b/t/rose-macro/03-value-range-check-ok.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-macro/04-value-range-check-err.t
+++ b/t/rose-macro/04-value-range-check-err.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-macro/05-value-values-check.t
+++ b/t/rose-macro/05-value-values-check.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-macro/06-value-pattern-check.t
+++ b/t/rose-macro/06-value-pattern-check.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-macro/07-value-change.t
+++ b/t/rose-macro/07-value-change.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-macro/08-compulsory-check.t
+++ b/t/rose-macro/08-compulsory-check.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-macro/09-rule-check.t
+++ b/t/rose-macro/09-rule-check.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-macro/10-trigger-check.t
+++ b/t/rose-macro/10-trigger-check.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-macro/11-trigger-change.t
+++ b/t/rose-macro/11-trigger-change.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-macro/12-custom-change.t
+++ b/t/rose-macro/12-custom-change.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-macro/13-custom-check.t
+++ b/t/rose-macro/13-custom-check.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-macro/14-duplicate-check.t
+++ b/t/rose-macro/14-duplicate-check.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-macro/15-bad-custom-change.t
+++ b/t/rose-macro/15-bad-custom-change.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-macro/16-cwd.t
+++ b/t/rose-macro/16-cwd.t
@@ -1,19 +1,19 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
-# 
+# Copyright (C) British Crown (Met Office) & Contributors.
+#
 # This file is part of Rose, a framework for scientific suites.
-# 
+#
 # Rose is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-# 
+#
 # Rose is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License
 # along with Rose. If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------

--- a/t/rose-macro/17-import.t
+++ b/t/rose-macro/17-import.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-macro/18-opt-conf-check.t
+++ b/t/rose-macro/18-opt-conf-check.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #
@@ -44,7 +44,7 @@ init_opt colour <<'__OPT_CONFIG__'
 paint_job=sparkly
 __OPT_CONFIG__
 TEST_KEY=$TEST_KEY_BASE-bad-single-opt
-run_fail "$TEST_KEY" rose macro --config=../config -V 
+run_fail "$TEST_KEY" rose macro --config=../config -V
 file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" <<'__ERR__'
 [V] metomi.rose.macros.DefaultValidators: issues: 1

--- a/t/rose-macro/19-opt-conf-change-add.t
+++ b/t/rose-macro/19-opt-conf-change-add.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #
@@ -45,7 +45,7 @@ init_macro add.py <<'__MACRO__'
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #-----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #-----------------------------------------------------------------------------
 
 import metomi.rose.macro

--- a/t/rose-macro/20-opt-conf-change-modify.t
+++ b/t/rose-macro/20-opt-conf-change-modify.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #
@@ -48,7 +48,7 @@ init_macro modify.py <<'__MACRO__'
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #-----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #-----------------------------------------------------------------------------
 
 import metomi.rose.macro

--- a/t/rose-macro/21-opt-conf-change-remove.t
+++ b/t/rose-macro/21-opt-conf-change-remove.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #
@@ -50,7 +50,7 @@ init_macro remove.py <<'__MACRO__'
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #-----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #-----------------------------------------------------------------------------
 
 import metomi.rose.macro

--- a/t/rose-macro/22-repeats.t
+++ b/t/rose-macro/22-repeats.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-macro/23-import-tree.t
+++ b/t/rose-macro/23-import-tree.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-macro/24-optional-config-name.t
+++ b/t/rose-macro/24-optional-config-name.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-macro/25-suite-level.t
+++ b/t/rose-macro/25-suite-level.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-macro/26-optional-config-name-2.t
+++ b/t/rose-macro/26-optional-config-name-2.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-macro/lib/custom_macro_change.py
+++ b/t/rose-macro/lib/custom_macro_change.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-macro/lib/custom_macro_change_arg.py
+++ b/t/rose-macro/lib/custom_macro_change_arg.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-macro/lib/custom_macro_change_bad.py
+++ b/t/rose-macro/lib/custom_macro_change_bad.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-macro/lib/custom_macro_check.py
+++ b/t/rose-macro/lib/custom_macro_check.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-macro/test_header
+++ b/t/rose-macro/test_header
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-metadata-check/00-null.t
+++ b/t/rose-metadata-check/00-null.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-metadata-check/01-type-length.t
+++ b/t/rose-metadata-check/01-type-length.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-metadata-check/02-range.t
+++ b/t/rose-metadata-check/02-range.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-metadata-check/03-values.t
+++ b/t/rose-metadata-check/03-values.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-metadata-check/04-pattern.t
+++ b/t/rose-metadata-check/04-pattern.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-metadata-check/05-compulsory.t
+++ b/t/rose-metadata-check/05-compulsory.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-metadata-check/06-rule.t
+++ b/t/rose-metadata-check/06-rule.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-metadata-check/07-trigger.t
+++ b/t/rose-metadata-check/07-trigger.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-metadata-check/08-duplicate.t
+++ b/t/rose-metadata-check/08-duplicate.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-metadata-check/09-custom-macro.t
+++ b/t/rose-metadata-check/09-custom-macro.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-metadata-check/11-invalid-settings.t
+++ b/t/rose-metadata-check/11-invalid-settings.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-metadata-check/lib/custom_macro.py
+++ b/t/rose-metadata-check/lib/custom_macro.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-metadata-check/lib/custom_macro_corrupt.py
+++ b/t/rose-metadata-check/lib/custom_macro_corrupt.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-metadata-check/test_header
+++ b/t/rose-metadata-check/test_header
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-metadata-gen/00-null.t
+++ b/t/rose-metadata-gen/00-null.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-metadata-gen/01-basic.t
+++ b/t/rose-metadata-gen/01-basic.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-metadata-gen/02-autotype.t
+++ b/t/rose-metadata-gen/02-autotype.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-metadata-gen/03-propset.t
+++ b/t/rose-metadata-gen/03-propset.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-metadata-gen/test_header
+++ b/t/rose-metadata-gen/test_header
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-metadata-graph/00-null.t
+++ b/t/rose-metadata-graph/00-null.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-metadata-graph/01-data.t
+++ b/t/rose-metadata-graph/01-data.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #
@@ -35,7 +35,7 @@ init_meta < $TEST_SOURCE_DIR/lib/rose-meta.conf
 CONFIG_PATH=$(cd ../config && pwd -P)
 run_pass "$TEST_KEY" rose metadata-graph --debug --config=../config
 filter_graphviz <"$TEST_KEY.out" >"$TEST_KEY.filtered.out"
-sort "$TEST_KEY.filtered.out" >"$TEST_KEY.filtered.out.sorted" 
+sort "$TEST_KEY.filtered.out" >"$TEST_KEY.filtered.out.sorted"
 sort >"$TEST_KEY.filtered.out.expected" <<__OUTPUT__
 "env=CONTROL" -> "env=CONTROL=None" [color=green, label=foo
 "env=CONTROL" -> "env=CONTROL=bar" [color=red, label=foo
@@ -98,7 +98,7 @@ file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
 TEST_KEY=$TEST_KEY_BASE-ok-sub-section
 run_pass "$TEST_KEY" rose metadata-graph --debug --config=../config namelist:qux
 filter_graphviz <"$TEST_KEY.out" >"$TEST_KEY.filtered.out"
-sort "$TEST_KEY.filtered.out" >"$TEST_KEY.filtered.out.sorted" 
+sort "$TEST_KEY.filtered.out" >"$TEST_KEY.filtered.out.sorted"
 sort >"$TEST_KEY.filtered.out.expected" <<__OUTPUT__
 "env=CONTROL_NAMELIST_QUX" -> "env=CONTROL_NAMELIST_QUX=bar" [color=red, label=foo
 "env=CONTROL_NAMELIST_QUX" [color=green, shape=rectangle
@@ -122,7 +122,7 @@ TEST_KEY=$TEST_KEY_BASE-ok-property
 run_pass "$TEST_KEY" rose metadata-graph --debug --config=../config \
     --property=trigger
 filter_graphviz <"$TEST_KEY.out" >"$TEST_KEY.filtered.out"
-sort "$TEST_KEY.filtered.out" >"$TEST_KEY.filtered.out.sorted" 
+sort "$TEST_KEY.filtered.out" >"$TEST_KEY.filtered.out.sorted"
 sort >"$TEST_KEY.filtered.out.expected" <<__OUTPUT__
 "env=CONTROL" -> "env=CONTROL=None" [color=green, label=foo
 "env=CONTROL" -> "env=CONTROL=bar" [color=red, label=foo
@@ -186,7 +186,7 @@ TEST_KEY=$TEST_KEY_BASE-ok-property-sub-section
 run_pass "$TEST_KEY" rose metadata-graph --debug --config=../config \
     --property=trigger env
 filter_graphviz <"$TEST_KEY.out" >"$TEST_KEY.filtered.out"
-sort "$TEST_KEY.filtered.out" >"$TEST_KEY.filtered.out.sorted" 
+sort "$TEST_KEY.filtered.out" >"$TEST_KEY.filtered.out.sorted"
 sort >"$TEST_KEY.filtered.out.expected" <<__OUTPUT__
 "env=CONTROL" -> "env=CONTROL=None" [color=green, label=foo
 "env=CONTROL" -> "env=CONTROL=bar" [color=red, label=foo

--- a/t/rose-metadata-graph/02-just-metadata.t
+++ b/t/rose-metadata-graph/02-just-metadata.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #
@@ -36,7 +36,7 @@ init_meta < $TEST_SOURCE_DIR/lib/rose-meta.conf
 META_CONFIG_PATH=$(cd ../config/meta && pwd -P)
 run_pass "$TEST_KEY" rose metadata-graph --debug --config=../config/meta
 filter_graphviz <"$TEST_KEY.out" >"$TEST_KEY.filtered.out"
-sort "$TEST_KEY.filtered.out" >"$TEST_KEY.filtered.out.sorted" 
+sort "$TEST_KEY.filtered.out" >"$TEST_KEY.filtered.out.sorted"
 sort >"$TEST_KEY.filtered.out.expected" <<__OUTPUT__
 "env=CONTROL" -> "env=CONTROL=None" [color=grey
 "env=CONTROL" -> "env=CONTROL=bar" [color=grey

--- a/t/rose-metadata-graph/test_header
+++ b/t/rose-metadata-graph/test_header
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-metadata-graph/test_header_extra
+++ b/t/rose-metadata-graph/test_header_extra
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-mpi-launch/00-command.t
+++ b/t/rose-mpi-launch/00-command.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-mpi-launch/01-command-inner.t
+++ b/t/rose-mpi-launch/01-command-inner.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-mpi-launch/02-file.t
+++ b/t/rose-mpi-launch/02-file.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-mpi-launch/bin/my-launcher
+++ b/t/rose-mpi-launch/bin/my-launcher
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-mpi-launch/etc/rose.conf
+++ b/t/rose-mpi-launch/etc/rose.conf
@@ -1,5 +1,5 @@
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-mpi-launch/test_header
+++ b/t/rose-mpi-launch/test_header
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-namelist-dump/00-null.t
+++ b/t/rose-namelist-dump/00-null.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-namelist-dump/01-empty.t
+++ b/t/rose-namelist-dump/01-empty.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-namelist-dump/02-type.t
+++ b/t/rose-namelist-dump/02-type.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-namelist-dump/test_header
+++ b/t/rose-namelist-dump/test_header
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-stem/00-run-basic.t
+++ b/t/rose-stem/00-run-basic.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #
@@ -226,7 +226,7 @@ TEST_KEY=$TEST_KEY_BASE-incompatible_versions
 run_fail "$TEST_KEY" \
    rose stem --group=earl_grey --task=milk,sugar --group=spoon,cup,milk \
              --source=$WORKINGCOPY --source=fcm:foo.x_tr@head \
-             --name $SUITENAME -- --no-detach --debug 
+             --name $SUITENAME -- --no-detach --debug
 OUTPUT=$TEST_DIR/${TEST_KEY}.err
 TEST_KEY=$TEST_KEY_BASE-incompatible-versions-correct_error
 file_grep $TEST_KEY "Running metomi.rose-stem version 1 but suite is at version 0" $OUTPUT
@@ -239,7 +239,7 @@ TEST_KEY=$TEST_KEY_BASE-project-not-in-keywords
 run_fail "$TEST_KEY" \
    rose stem --group=earl_grey --task=milk,sugar --group=spoon,cup,milk \
              --source=$WORKINGCOPY --source=fcm:foo.x_tr@head \
-             --name $SUITENAME -- --no-detach --debug 
+             --name $SUITENAME -- --no-detach --debug
 OUTPUT=$TEST_DIR/${TEST_KEY}.err
 TEST_KEY=$TEST_KEY_BASE-project-not-in-keywords-correct_error
 file_grep $TEST_KEY "Cannot ascertain project for source tree" $OUTPUT

--- a/t/rose-suite-clean/00-normal.t
+++ b/t/rose-suite-clean/00-normal.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #
@@ -31,7 +31,7 @@ install_suite() {
         ssh "$JOB_HOST" "ls -d cylc-run/$NAME 1>/dev/null"
     else
         rose suite-run --new -q \
-            -C $TEST_SOURCE_DIR/$TEST_KEY_BASE -i --name=$NAME 
+            -C $TEST_SOURCE_DIR/$TEST_KEY_BASE -i --name=$NAME
     fi
     ls -d $HOME/cylc-run/$NAME 1>/dev/null
     set +e

--- a/t/rose-suite-clean/01-running.t
+++ b/t/rose-suite-clean/01-running.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-suite-clean/02-only-1.t
+++ b/t/rose-suite-clean/02-only-1.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-suite-clean/03-only-2.t
+++ b/t/rose-suite-clean/03-only-2.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-suite-clean/04-only-3.t
+++ b/t/rose-suite-clean/04-only-3.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-suite-clean/05-only-4.t
+++ b/t/rose-suite-clean/05-only-4.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-suite-clean/06-only-5.t
+++ b/t/rose-suite-clean/06-only-5.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-suite-clean/07-only-6.t
+++ b/t/rose-suite-clean/07-only-6.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-suite-clean/08-rmdir.t
+++ b/t/rose-suite-clean/08-rmdir.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-suite-clean/09-rmdir-2.t
+++ b/t/rose-suite-clean/09-rmdir-2.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-suite-clean/10-only-7.t
+++ b/t/rose-suite-clean/10-only-7.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-suite-cmp-vc/00-basic.t
+++ b/t/rose-suite-cmp-vc/00-basic.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-suite-cmp-vc/01-no-vc.t
+++ b/t/rose-suite-cmp-vc/01-no-vc.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-suite-log/00-update-task.t
+++ b/t/rose-suite-log/00-update-task.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-suite-log/01-update-cycle.t
+++ b/t/rose-suite-log/01-update-cycle.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-suite-log/02-update-force.t
+++ b/t/rose-suite-log/02-update-force.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-suite-log/06-archive-star.t
+++ b/t/rose-suite-log/06-archive-star.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-suite-log/07-uninstalled.t
+++ b/t/rose-suite-log/07-uninstalled.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-suite-restart/00-no-run.t
+++ b/t/rose-suite-restart/00-no-run.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-suite-restart/01-running.t
+++ b/t/rose-suite-restart/01-running.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-suite-restart/02-basic.t
+++ b/t/rose-suite-restart/02-basic.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-suite-restart/03-host.t
+++ b/t/rose-suite-restart/03-host.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-suite-run/00-run-basic.t
+++ b/t/rose-suite-run/00-run-basic.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #
@@ -46,7 +46,7 @@ RUND="$(mktemp -d --tmpdir="${HOME}/cylc-run" 'rose-test-battery.XXXXXX')"
 NAME="$(basename "${RUND}")"
 run_pass "${TEST_KEY}" \
     rose suite-run -C "${TEST_SOURCE_DIR}/${TEST_KEY_BASE}" --name="${NAME}" \
-    
+
 CONTACT="${HOME}/cylc-run/${NAME}/.service/contact"
 SUITE_HOST="$(sed -n 's/CYLC_SUITE_HOST=//p' "${CONTACT}")"
 SUITE_OWNER="$(sed -n 's/CYLC_SUITE_OWNER=//p' "${CONTACT}")"
@@ -59,7 +59,7 @@ poll ! test -e "${RUND}/log/job/20130101T0000Z/my_task_1/01"
 for OPTION in -i -l '' --restart; do
     TEST_KEY="${TEST_KEY_BASE}-running${OPTION}"
     run_fail "${TEST_KEY}" rose suite-run "${OPTION}" \
-        -C "${TEST_SOURCE_DIR}/${TEST_KEY_BASE}" --name="${NAME}" 
+        -C "${TEST_SOURCE_DIR}/${TEST_KEY_BASE}" --name="${NAME}"
     file_cmp "${TEST_KEY}.err" "${TEST_KEY}.err" <<__ERR__
 [FAIL] Suite "${NAME}" appears to be running:
 [FAIL] Contact info from: "${CONTACT}"

--- a/t/rose-suite-run/02-install.t
+++ b/t/rose-suite-run/02-install.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #
@@ -63,7 +63,7 @@ if [[ -n "${JOB_HOST}" ]]; then
 else
     run_pass "${TEST_KEY}" rose suite-run --debug \
         -C "${TEST_KEY_BASE}" "${OPTION}" \
-        --name="${NAME}" 
+        --name="${NAME}"
 fi
 #-------------------------------------------------------------------------------
 TEST_KEY="${TEST_KEY_BASE}-port-file"

--- a/t/rose-suite-run/05-log.t
+++ b/t/rose-suite-run/05-log.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-suite-run/06-opt-conf.t
+++ b/t/rose-suite-run/06-opt-conf.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-suite-run/10-import-1.t
+++ b/t/rose-suite-run/10-import-1.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-suite-run/11-import-2.t
+++ b/t/rose-suite-run/11-import-2.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-suite-run/12-run-dir-root.t
+++ b/t/rose-suite-run/12-run-dir-root.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-suite-run/13-ignore-cylc-version.t
+++ b/t/rose-suite-run/13-ignore-cylc-version.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #
@@ -28,7 +28,7 @@ cp -r $TEST_SOURCE_DIR/$TEST_KEY_BASE/* .
 mkdir -p $HOME/cylc-run
 SUITE_RUN_DIR=$(mktemp -d --tmpdir=$HOME/cylc-run 'rose-test-battery.XXXXXX')
 NAME=$(basename $SUITE_RUN_DIR)
-rose suite-run -q -n $NAME 
+rose suite-run -q -n $NAME
 # Wait for the only task to fail, before reload
 ST_FILE=$SUITE_RUN_DIR/log/job/1/t1/01/job.status
 TIMEOUT=$(($(date +%s) + 60)) # wait 1 minute
@@ -39,7 +39,7 @@ do
 done
 #-------------------------------------------------------------------------------
 TEST_KEY=$TEST_KEY_BASE
-run_pass "$TEST_KEY" rose suite-run --reload -q -n $NAME 
+run_pass "$TEST_KEY" rose suite-run --reload -q -n $NAME
 #-------------------------------------------------------------------------------
 rose suite-stop -q -y -n $NAME -- --max-polls=12 --interval=5
 rose suite-clean -q -y $NAME

--- a/t/rose-suite-run/14-reload-null.t
+++ b/t/rose-suite-run/14-reload-null.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-suite-run/15-reload-rc.t
+++ b/t/rose-suite-run/15-reload-rc.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-suite-run/16-suite-rc-not-writable.t
+++ b/t/rose-suite-run/16-suite-rc-not-writable.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-suite-run/17-install-overlap.t
+++ b/t/rose-suite-run/17-install-overlap.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-suite-run/18-restart-init-dir.t
+++ b/t/rose-suite-run/18-restart-init-dir.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #
@@ -39,9 +39,9 @@ run_pass "$TEST_KEY" \
     -- --no-detach --debug
 #-------------------------------------------------------------------------------
 TEST_KEY="$TEST_KEY_BASE-dir"
-run_pass "$TEST_KEY" test -d "$SUITE_RUN_DIR" 
+run_pass "$TEST_KEY" test -d "$SUITE_RUN_DIR"
 TEST_KEY="$TEST_KEY_BASE-symlink"
-run_fail "$TEST_KEY" test -L "$SUITE_RUN_DIR" 
+run_fail "$TEST_KEY" test -L "$SUITE_RUN_DIR"
 #-------------------------------------------------------------------------------
 rose suite-clean -q -y $NAME
 exit

--- a/t/rose-suite-run/19-restart-init-dir-remote.t
+++ b/t/rose-suite-run/19-restart-init-dir-remote.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #
@@ -74,9 +74,9 @@ run_pass "$TEST_KEY" \
     -- --no-detach --debug
 #-------------------------------------------------------------------------------
 TEST_KEY="$TEST_KEY_BASE-dir"
-run_pass "$TEST_KEY" ssh -oBatchMode=yes $T_HOST test -d "cylc-run/$NAME" 
+run_pass "$TEST_KEY" ssh -oBatchMode=yes $T_HOST test -d "cylc-run/$NAME"
 TEST_KEY="$TEST_KEY_BASE-symlink"
-run_fail "$TEST_KEY" ssh -oBatchMode=yes $T_HOST test -L "cylc-run/$NAME" 
+run_fail "$TEST_KEY" ssh -oBatchMode=yes $T_HOST test -L "cylc-run/$NAME"
 #-------------------------------------------------------------------------------
 rose suite-clean -q -y $NAME
 $SSH $T_HOST "rm -fr '$T_HOST_ROSE_HOME'"

--- a/t/rose-suite-run/21-sharecycle-back-compat.t
+++ b/t/rose-suite-run/21-sharecycle-back-compat.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-suite-run/22-sharecycle.t
+++ b/t/rose-suite-run/22-sharecycle.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-suite-run/23-reload-host.t
+++ b/t/rose-suite-run/23-reload-host.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-suite-run/24-host-log-timestamp.t
+++ b/t/rose-suite-run/24-host-log-timestamp.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-suite-run/26-jinja2-insert.t
+++ b/t/rose-suite-run/26-jinja2-insert.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-suite-run/27-empy-insert.t
+++ b/t/rose-suite-run/27-empy-insert.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-suite-run/28-rose-site-env.t
+++ b/t/rose-suite-run/28-rose-site-env.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-suite-shutdown/00-run-basic.t
+++ b/t/rose-suite-shutdown/00-run-basic.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #
@@ -36,7 +36,7 @@ tests $N_TESTS
 mkdir -p $HOME/cylc-run
 SUITE_RUN_DIR=$(mktemp -d --tmpdir=$HOME/cylc-run 'rose-test-battery.XXXXXX')
 NAME=$(basename $SUITE_RUN_DIR)
-rose suite-run -q -C $TEST_SOURCE_DIR/$TEST_KEY_BASE --name=$NAME 
+rose suite-run -q -C $TEST_SOURCE_DIR/$TEST_KEY_BASE --name=$NAME
 #-------------------------------------------------------------------------------
 TEST_KEY=$TEST_KEY_BASE
 sleep 1

--- a/t/rose-suite-shutdown/02-rose-stem-name.t
+++ b/t/rose-suite-shutdown/02-rose-stem-name.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #
@@ -28,7 +28,7 @@ export ROSE_CONF_PATH=
 mkdir -p $HOME/cylc-run
 SUITE_RUN_DIR=$(mktemp -d --tmpdir=$HOME/cylc-run 'rose-test-battery.XXXXXX')
 NAME=$(basename $SUITE_RUN_DIR)
-rose suite-run -q -C $TEST_SOURCE_DIR/$TEST_KEY_BASE --name=$NAME 
+rose suite-run -q -C $TEST_SOURCE_DIR/$TEST_KEY_BASE --name=$NAME
 #-------------------------------------------------------------------------------
 TEST_KEY=$TEST_KEY_BASE
 mkdir -p $NAME

--- a/t/rose-suite-shutdown/03-normal-name.t
+++ b/t/rose-suite-shutdown/03-normal-name.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #
@@ -28,7 +28,7 @@ export ROSE_CONF_PATH=
 mkdir -p $HOME/cylc-run
 SUITE_RUN_DIR=$(mktemp -d --tmpdir=$HOME/cylc-run 'rose-test-battery.XXXXXX')
 NAME=$(basename $SUITE_RUN_DIR)
-rose suite-run -q -C $TEST_SOURCE_DIR/$TEST_KEY_BASE --name=$NAME 
+rose suite-run -q -C $TEST_SOURCE_DIR/$TEST_KEY_BASE --name=$NAME
 HOST="$(awk -F= '$1 == "CYLC_SUITE_HOST" {print $2}' "${SUITE_RUN_DIR}/.service/contact")"
 #-------------------------------------------------------------------------------
 TEST_KEY=$TEST_KEY_BASE

--- a/t/rose-task-env/00-non-cycle.t
+++ b/t/rose-task-env/00-non-cycle.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-task-env/01-integer-cycling.t
+++ b/t/rose-task-env/01-integer-cycling.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-task-env/02-360day-cycling.t
+++ b/t/rose-task-env/02-360day-cycling.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-task-run/00-run-basic.t
+++ b/t/rose-task-run/00-run-basic.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-task-run/01-run-basic-iso.t
+++ b/t/rose-task-run/01-run-basic-iso.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-task-run/04-run-path-empty.t
+++ b/t/rose-task-run/04-run-path-empty.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-task-run/06-app-prune-iso.t
+++ b/t/rose-task-run/06-app-prune-iso.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-task-run/07-app-arch.t
+++ b/t/rose-task-run/07-app-arch.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-task-run/07-app-arch/bin/foo
+++ b/t/rose-task-run/07-app-arch/bin/foo
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-task-run/08-app-fcm-make.t
+++ b/t/rose-task-run/08-app-fcm-make.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-task-run/09-app-prune-work.t
+++ b/t/rose-task-run/09-app-prune-work.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-task-run/10-specify-cycle.t
+++ b/t/rose-task-run/10-specify-cycle.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-task-run/11-specify-cycle-iso.t
+++ b/t/rose-task-run/11-specify-cycle-iso.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-task-run/12-app-prune-integer.t
+++ b/t/rose-task-run/12-app-prune-integer.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-task-run/13-app-arch-cmd-out.t
+++ b/t/rose-task-run/13-app-arch-cmd-out.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-task-run/13-app-arch-cmd-out/bin/foo
+++ b/t/rose-task-run/13-app-arch-cmd-out/bin/foo
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-task-run/14-app-prune-remove.t
+++ b/t/rose-task-run/14-app-prune-remove.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-task-run/15-app-prune-extglob.t
+++ b/t/rose-task-run/15-app-prune-extglob.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-task-run/16-app-prune-point.t
+++ b/t/rose-task-run/16-app-prune-point.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-task-run/17-app-prune-glob-as-cycle-fmt.t
+++ b/t/rose-task-run/17-app-prune-glob-as-cycle-fmt.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-task-run/18-app-fcm-make-ctx-name.t
+++ b/t/rose-task-run/18-app-fcm-make-ctx-name.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-task-run/20-app-fcm-make-dest.t
+++ b/t/rose-task-run/20-app-fcm-make-dest.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-task-run/24-app-fcm-make-fast.t
+++ b/t/rose-task-run/24-app-fcm-make-fast.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-task-run/25-app-fcm-make-new-mode.t
+++ b/t/rose-task-run/25-app-fcm-make-new-mode.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-task-run/26-app-fcm-make-new-mode-with-cont.t
+++ b/t/rose-task-run/26-app-fcm-make-new-mode-with-cont.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-task-run/28-env-path-run-path.t
+++ b/t/rose-task-run/28-env-path-run-path.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-task-run/29-app-prune-extglob-remote.t
+++ b/t/rose-task-run/29-app-prune-extglob-remote.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-task-run/30-app-arch-opt-source.t
+++ b/t/rose-task-run/30-app-arch-opt-source.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-task-run/30-app-arch-opt-source/bin/foo
+++ b/t/rose-task-run/30-app-arch-opt-source/bin/foo
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-task-run/31-app-bunch.t
+++ b/t/rose-task-run/31-app-bunch.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-task-run/32-app-arch-compressed.t
+++ b/t/rose-task-run/32-app-arch-compressed.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-task-run/33-app-prune-cycle-format.t
+++ b/t/rose-task-run/33-app-prune-cycle-format.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-task-run/34-app-prune-hosts-sharing-fs.t
+++ b/t/rose-task-run/34-app-prune-hosts-sharing-fs.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-task-run/35-app-prune-log-on-hosts-sharing-fs.t
+++ b/t/rose-task-run/35-app-prune-log-on-hosts-sharing-fs.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-task-run/36-app-arch-interrupted.t
+++ b/t/rose-task-run/36-app-arch-interrupted.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-task-run/37-app-bunch-rm-old.t
+++ b/t/rose-task-run/37-app-bunch-rm-old.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-task-run/38-app-bunch-counts.t
+++ b/t/rose-task-run/38-app-bunch-counts.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-task-run/39-app-prune-cycle-host.t
+++ b/t/rose-task-run/39-app-prune-cycle-host.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-task-run/40-app-arch-duplicate.t
+++ b/t/rose-task-run/40-app-arch-duplicate.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose-task-run/41-app-bunch-default-command.t
+++ b/t/rose-task-run/41-app-bunch-default-command.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose.c3/00-self.t
+++ b/t/rose.c3/00-self.t
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose.config_tree/00-self.t
+++ b/t/rose.config_tree/00-self.t
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose.env/00-export.t
+++ b/t/rose.env/00-export.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose.popen/00-self.t
+++ b/t/rose.popen/00-self.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose.variable/00-trigger.py
+++ b/t/rose.variable/00-trigger.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose.variable/00-trigger.t
+++ b/t/rose.variable/00-trigger.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose.variable/01-array-split.t
+++ b/t/rose.variable/01-array-split.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose.variable/t_array_split.py
+++ b/t/rose.variable/t_array_split.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rose.variable/test_header
+++ b/t/rose.variable/test_header
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rosie-checkout/00-basic.t
+++ b/t/rosie-checkout/00-basic.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rosie-create/00-basic-edit
+++ b/t/rosie-create/00-basic-edit
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rosie-create/00-basic.t
+++ b/t/rosie-create/00-basic.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rosie-create/01-suite-info-meta.t
+++ b/t/rosie-create/01-suite-info-meta.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #
@@ -112,7 +112,7 @@ title=this should never fail
 unknown=I am an unknow field but do include me
 __INFO__
 file_cmp "$TEST_KEY_BASE-info-copy-mode.out" \
-    "$TEST_KEY_BASE-info-copy-mode.out" "$TEST_KEY-copy-mode-edit.out" 
+    "$TEST_KEY_BASE-info-copy-mode.out" "$TEST_KEY-copy-mode-edit.out"
 file_cmp "${TEST_KEY}-rose-suite.info" \
     "${PWD}/roses/foo-aa001/rose-suite.info" <<__INFO__
 description=Copy of foo-aa000/trunk@1

--- a/t/rosie-create/02-copy-inter.t
+++ b/t/rosie-create/02-copy-inter.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rosie-delete/00-basic.t
+++ b/t/rosie-delete/00-basic.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rosie-disco/00-basic.t
+++ b/t/rosie-disco/00-basic.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rosie-graph/00-basic.t
+++ b/t/rosie-graph/00-basic.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rosie-hello/00-null.t
+++ b/t/rosie-hello/00-null.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rosie-id/00-basic.t
+++ b/t/rosie-id/00-basic.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rosie-id/01-final.t
+++ b/t/rosie-id/01-final.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rosie-lookup/00-basic.t
+++ b/t/rosie-lookup/00-basic.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rosie-lookup/01-multi.t
+++ b/t/rosie-lookup/01-multi.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rosie-lookup/02-unicode.t
+++ b/t/rosie-lookup/02-unicode.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rosie-ls/00-basic.t
+++ b/t/rosie-ls/00-basic.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rosie-ls/01-many.t
+++ b/t/rosie-ls/01-many.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rosie.db/00-query.py
+++ b/t/rosie.db/00-query.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/rosie.db/00-query.t
+++ b/t/rosie.db/00-query.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/t/syntax/00-eslint.t
+++ b/t/syntax/00-eslint.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
 #

--- a/usr/bin/rose
+++ b/usr/bin/rose
@@ -1,6 +1,6 @@
 #!/bin/bash
 #-------------------------------------------------------------------------------
-# Copyright (C) 2012-2019 British Crown (Met Office) & Contributors.
+# Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, tools for managing and building source code.
 #


### PR DESCRIPTION
Sorry, this is getting repetitive!

The middle commit contains the 400-odd removals of years from copyright notices in the code