### PR TITLE
prevent rsync failure.

### DIFF
--- a/metomi/rose/loc_handlers/rsync.py
+++ b/metomi/rose/loc_handlers/rsync.py
@@ -22,7 +22,11 @@
 from pathlib import Path
 from tempfile import TemporaryFile
 from time import sleep, time
+
 from metomi.rose.popen import RosePopenError
+from metomi.rose.loc_handlers.rsync_remote_check import (
+    __file__ as rsync_remote_check_file
+)
 
 class RsyncLocHandler(object):
     """Handler of locations on remote hosts."""
@@ -63,9 +67,7 @@ class RsyncLocHandler(object):
         cmd = self.manager.popen.get_cmd(
             "ssh", host, "python3", "-", path, loc.TYPE_BLOB, loc.TYPE_TREE)
         temp_file = TemporaryFile()
-        temp_file.write(
-            (Path(__file__).parent / 'rsync_remote_check.py').read_bytes()
-        )
+        temp_file.write(Path(rsync_remote_check_file).read_bytes())
         temp_file.seek(0)
         out = self.manager.popen(*cmd, stdin=temp_file)[0].decode()
         lines = out.splitlines()

--- a/metomi/rose/loc_handlers/rsync.py
+++ b/metomi/rose/loc_handlers/rsync.py
@@ -64,7 +64,7 @@ class RsyncLocHandler(object):
             "ssh", host, "python3", "-", path, loc.TYPE_BLOB, loc.TYPE_TREE)
         temp_file = TemporaryFile()
         temp_file.write(
-            (Path(__file__).parent / 'rsync_remote_check').read_bytes()
+            (Path(__file__).parent / 'rsync_remote_check.py').read_bytes()
         )
         temp_file.seek(0)
         out = self.manager.popen(*cmd, stdin=temp_file)[0].decode()

--- a/metomi/rose/loc_handlers/rsync.py
+++ b/metomi/rose/loc_handlers/rsync.py
@@ -61,7 +61,7 @@ class RsyncLocHandler(object):
         # Attempt to obtain the checksum(s) via "ssh"
         host, path = loc.name.split(":", 1)
         cmd = self.manager.popen.get_cmd(
-            "ssh", host, "python2", "-", path, loc.TYPE_BLOB, loc.TYPE_TREE)
+            "ssh", host, "python3", "-", path, loc.TYPE_BLOB, loc.TYPE_TREE)
         temp_file = TemporaryFile()
         temp_file.write(
             (Path(__file__).parent / 'rsync_remote_check').read_bytes()
@@ -77,7 +77,7 @@ class RsyncLocHandler(object):
             access_mode, mtime, size, name = line.split(None, 3)
             fake_sum = "source=%s:mtime=%s:size=%s" % (
                 name, mtime, size)
-            loc.add_path(loc.BLOB, fake_sum, int(access_mode))
+            loc.add_path(loc.BLOB, fake_sum, int(access_mode, base=8))
         else:  # if loc.loc_type == loc.TYPE_TREE:
             for line in lines:
                 access_mode, mtime, size, name = line.split(None, 3)

--- a/metomi/rose/loc_handlers/rsync.py
+++ b/metomi/rose/loc_handlers/rsync.py
@@ -61,7 +61,7 @@ class RsyncLocHandler(object):
         # Attempt to obtain the checksum(s) via "ssh"
         host, path = loc.name.split(":", 1)
         cmd = self.manager.popen.get_cmd(
-            "ssh", host, "python3", "-", path, loc.TYPE_BLOB, loc.TYPE_TREE)
+            "ssh", host, "python2", "-", path, loc.TYPE_BLOB, loc.TYPE_TREE)
         temp_file = TemporaryFile()
         temp_file.write(br"""
 import os
@@ -87,10 +87,10 @@ if os.path.isdir(path):
 elif os.path.isfile(path):
     print(str_blob)
     stat = os.stat(path)
-    print(oct(stat.st_mode), stat.st_mtime, stat.st_size, path)
+    print oct(stat.st_mode), stat.st_mtime, stat.st_size, path
 """)
         temp_file.seek(0)
-        out = self.manager.popen(*cmd, stdin=temp_file)[0]
+        out = self.manager.popen(*cmd, stdin=temp_file)[0].decode()
         lines = out.splitlines()
         if not lines or lines[0] not in [loc.TYPE_BLOB, loc.TYPE_TREE]:
             raise ValueError(loc.name)

--- a/metomi/rose/loc_handlers/rsync.py
+++ b/metomi/rose/loc_handlers/rsync.py
@@ -28,6 +28,7 @@ from metomi.rose.loc_handlers.rsync_remote_check import (
     __file__ as rsync_remote_check_file
 )
 
+
 class RsyncLocHandler(object):
     """Handler of locations on remote hosts."""
 

--- a/metomi/rose/loc_handlers/rsync_remote_check
+++ b/metomi/rose/loc_handlers/rsync_remote_check
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# Copyright (C) British Crown (Met Office) & Contributors.
+#
+# This file is part of Rose, a framework for meteorological suites.
+#
+# Rose is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Rose is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Rose. If not, see <http://www.gnu.org/licenses/>.
+# -----------------------------------------------------------------------------
+"""
+A script for running over ssh to establish whether a file
+is available for installation.
+
+This is a Python file but we read it and pass it to stdout
+to avoid reliance on remote platforms having rose installed.
+"""
+import os
+import sys
+path, str_blob, str_tree = sys.argv[1:]
+if os.path.isdir(path):
+    print str_tree
+    os.chdir(path)
+    for dirpath, dirnames, filenames in os.walk(path):
+        good_dirnames = []
+        for dirname in dirnames:
+            if not dirname.startswith("."):
+                good_dirnames.append(dirname)
+                name = os.path.join(dirpath, dirname)
+                print("-", "-", "-", name)
+        dirnames[:] = good_dirnames
+        for filename in filenames:
+            if filename.startswith("."):
+                continue
+            name = os.path.join(dirpath, filename)
+            stat = os.stat(name)
+            print(oct(stat.st_mode), stat.st_mtime, stat.st_size, name)
+elif os.path.isfile(path):
+    print str_blob
+    stat = os.stat(path)
+    print oct(stat.st_mode), stat.st_mtime, stat.st_size, path

--- a/metomi/rose/loc_handlers/rsync_remote_check
+++ b/metomi/rose/loc_handlers/rsync_remote_check
@@ -31,7 +31,7 @@ import sys
 def main():
     path, str_blob, str_tree = sys.argv[1:]
     if os.path.isdir(path):
-        print str_tree
+        print(str_tree)
         os.chdir(path)
         for dirpath, dirnames, filenames in os.walk(path):
             good_dirnames = []
@@ -39,18 +39,18 @@ def main():
                 if not dirname.startswith("."):
                     good_dirnames.append(dirname)
                     name = os.path.join(dirpath, dirname)
-                    print("-", "-", "-", name)
+                    print(("-", "-", "-", name))
             dirnames[:] = good_dirnames
             for filename in filenames:
                 if filename.startswith("."):
                     continue
                 name = os.path.join(dirpath, filename)
                 stat = os.stat(name)
-                print(oct(stat.st_mode), stat.st_mtime, stat.st_size, name)
+                print((oct(stat.st_mode), stat.st_mtime, stat.st_size, name))
     elif os.path.isfile(path):
-        print str_blob
+        print(str_blob)
         stat = os.stat(path)
-        print oct(stat.st_mode), stat.st_mtime, stat.st_size, path
+        print(oct(stat.st_mode), stat.st_mtime, stat.st_size, path)
 
 if __name__ == '__main__':
     main()

--- a/metomi/rose/loc_handlers/rsync_remote_check
+++ b/metomi/rose/loc_handlers/rsync_remote_check
@@ -26,25 +26,31 @@ to avoid reliance on remote platforms having rose installed.
 """
 import os
 import sys
-path, str_blob, str_tree = sys.argv[1:]
-if os.path.isdir(path):
-    print str_tree
-    os.chdir(path)
-    for dirpath, dirnames, filenames in os.walk(path):
-        good_dirnames = []
-        for dirname in dirnames:
-            if not dirname.startswith("."):
-                good_dirnames.append(dirname)
-                name = os.path.join(dirpath, dirname)
-                print("-", "-", "-", name)
-        dirnames[:] = good_dirnames
-        for filename in filenames:
-            if filename.startswith("."):
-                continue
-            name = os.path.join(dirpath, filename)
-            stat = os.stat(name)
-            print(oct(stat.st_mode), stat.st_mtime, stat.st_size, name)
-elif os.path.isfile(path):
-    print str_blob
-    stat = os.stat(path)
-    print oct(stat.st_mode), stat.st_mtime, stat.st_size, path
+
+
+def main():
+    path, str_blob, str_tree = sys.argv[1:]
+    if os.path.isdir(path):
+        print str_tree
+        os.chdir(path)
+        for dirpath, dirnames, filenames in os.walk(path):
+            good_dirnames = []
+            for dirname in dirnames:
+                if not dirname.startswith("."):
+                    good_dirnames.append(dirname)
+                    name = os.path.join(dirpath, dirname)
+                    print("-", "-", "-", name)
+            dirnames[:] = good_dirnames
+            for filename in filenames:
+                if filename.startswith("."):
+                    continue
+                name = os.path.join(dirpath, filename)
+                stat = os.stat(name)
+                print(oct(stat.st_mode), stat.st_mtime, stat.st_size, name)
+    elif os.path.isfile(path):
+        print str_blob
+        stat = os.stat(path)
+        print oct(stat.st_mode), stat.st_mtime, stat.st_size, path
+
+if __name__ == '__main__':
+    main()

--- a/metomi/rose/loc_handlers/rsync_remote_check.py
+++ b/metomi/rose/loc_handlers/rsync_remote_check.py
@@ -29,6 +29,13 @@ import sys
 
 
 def main():
+    """Check file exists and print some info:
+
+    1. Octal protection bits.
+    2. Last modified time.
+    3. Filesize.
+    4. Path, which has been checked.
+    """
     path, str_blob, str_tree = sys.argv[1:]
     if os.path.isdir(path):
         print(str_tree)
@@ -51,6 +58,7 @@ def main():
         print(str_blob)
         stat = os.stat(path)
         print(oct(stat.st_mode), stat.st_mtime, stat.st_size, path)
+
 
 if __name__ == '__main__':
     main()

--- a/metomi/rose/loc_handlers/rsync_remote_check.py
+++ b/metomi/rose/loc_handlers/rsync_remote_check.py
@@ -21,7 +21,7 @@
 A script for running over ssh to establish whether a file
 is available for installation.
 
-This is a Python file but we read it and pass it to stdout
+This is a Python file but we read it and pass it to stdin
 to avoid reliance on remote platforms having rose installed.
 """
 import os

--- a/metomi/rose/popen.py
+++ b/metomi/rose/popen.py
@@ -76,7 +76,7 @@ class RosePopenEvent(Event):
                 # FIXME: Is this safe?
                 pos = self.stdin.tell()
                 ret += " <<'__STDIN__'\n" +\
-                       self.stdin.read() + "\n'__STDIN__'"
+                       self.stdin.read().decode() + "\n'__STDIN__'"
                 self.stdin.seek(pos)
             except IOError:
                 pass

--- a/metomi/rose/tests/test_loc_handlers_rsync_remote_check.py
+++ b/metomi/rose/tests/test_loc_handlers_rsync_remote_check.py
@@ -60,6 +60,6 @@ def test_check_folder(
     captured = capsys.readouterr()
     assert captured.out.splitlines()[0] == 'tree'
     mode, _, size, path = literal_eval(captured.out.splitlines()[1])
-    assert path == str((dirpath/'more.stuff'))
+    assert path == str(dirpath / 'more.stuff')
     assert mode == '0o100633'
     assert size == 2

--- a/metomi/rose/tests/test_loc_handlers_rsync_remote_check.py
+++ b/metomi/rose/tests/test_loc_handlers_rsync_remote_check.py
@@ -27,7 +27,7 @@ from metomi.rose.loc_handlers.rsync_remote_check import main
 
 def test_check_file(monkeypatch, capsys, tmp_path):
     content = 'blah'
-    permission_level = '0o100777'
+    permission_level = '0o100644'
     filepath = tmp_path / 'stuff'
     filepath.write_text(content)
     filepath.chmod(int(permission_level, base=8))
@@ -46,7 +46,7 @@ def test_check_file(monkeypatch, capsys, tmp_path):
 def test_check_folder(
     monkeypatch, capsys, tmp_path
 ):
-    folder_permission_level = '0o100777'
+    folder_permission_level = '0o100700'
     dirpath = tmp_path / 'stuff'
     dirpath.mkdir()
     (dirpath / 'more.stuff').write_text('Hi')

--- a/metomi/rose/tests/test_loc_handlers_rsync_remote_check.py
+++ b/metomi/rose/tests/test_loc_handlers_rsync_remote_check.py
@@ -50,6 +50,7 @@ def test_check_folder(
     dirpath = tmp_path / 'stuff'
     dirpath.mkdir()
     (dirpath / 'more.stuff').write_text('Hi')
+    (dirpath / 'more.stuff').chmod(int('0o100633', base=8))
     (dirpath / 'even.more.stuff').write_text('Hi')
     dirpath.chmod(int(folder_permission_level, base=8))
     monkeypatch.setattr(
@@ -60,5 +61,5 @@ def test_check_folder(
     assert captured.out.splitlines()[0] == 'tree'
     mode, _, size, path = literal_eval(captured.out.splitlines()[1])
     assert path == str((dirpath/'more.stuff'))
-    assert mode == '0o100644'
+    assert mode == '0o100633'
     assert size == 2

--- a/metomi/rose/tests/test_loc_handlers_rsync_remote_check.py
+++ b/metomi/rose/tests/test_loc_handlers_rsync_remote_check.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# Copyright (C) British Crown (Met Office) & Contributors.
+#
+# This file is part of Rose, a framework for meteorological suites.
+#
+# Rose is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Rose is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Rose. If not, see <http://www.gnu.org/licenses/>.
+# -----------------------------------------------------------------------------
+
+import sys
+
+from ast import literal_eval
+
+from metomi.rose.loc_handlers.rsync_remote_check import main
+
+
+def test_check_file(monkeypatch, capsys, tmp_path):
+    content = 'blah'
+    permission_level = '0o100777'
+    filepath = tmp_path / 'stuff'
+    filepath.write_text(content)
+    filepath.chmod(int(permission_level, base=8))
+    monkeypatch.setattr(
+        sys, 'argv', ['ignored', str(filepath), 'blob', 'tree']
+    )
+    main()
+    captured = capsys.readouterr()
+    assert captured.out.splitlines()[0] == 'blob'
+    mode, mtime, size, path = captured.out.splitlines()[1].split()
+    assert path == str(filepath)
+    assert mode == permission_level
+    assert size == str(filepath.stat().st_size)
+
+
+def test_check_folder(
+    monkeypatch, capsys, tmp_path
+):
+    folder_permission_level = '0o100777'
+    dirpath = tmp_path / 'stuff'
+    dirpath.mkdir()
+    (dirpath / 'more.stuff').write_text('Hi')
+    (dirpath / 'even.more.stuff').write_text('Hi')
+    dirpath.chmod(int(folder_permission_level, base=8))
+    monkeypatch.setattr(
+        sys, 'argv', ['ignored', str(dirpath), 'blob', 'tree']
+    )
+    main()
+    captured = capsys.readouterr()
+    assert captured.out.splitlines()[0] == 'tree'
+    mode, _, size, path = literal_eval(captured.out.splitlines()[1])
+    assert path == str((dirpath/'more.stuff'))
+    assert mode == '0o100644'
+    assert size == 2


### PR DESCRIPTION
Fixes #2442 .

A script written in python2 and unconverted (bc it was a raw script) was being run with python 3. As a result it was returning a tuple when it shouldn't have been.

The script created by metomi/rose/2019.01.x:lib/python/rose/loc_handlers/rsync.py::lines 67-92 should be:
- [x] Stored somewhere in the codebase and read into the stdin at line 94.
- [x] Tested.
- [x] Run using Python3