### PR TITLE
conf: remove legacy rose-doc configuration

### DIFF
--- a/etc/rose.conf.example
+++ b/etc/rose.conf.example
@@ -16,10 +16,6 @@
 checksum-method=md5|sha1|...
 # Paths to locate configuration metadata e.g. ``meta-path=/opt/rose-meta``.
 meta-path=DIR1[:DIR2[:...]]
-# :default: *file://${ROSE_HOME}/doc/*
-#
-# URL to Rose documentation.
-rose-doc=http://metomi.github.io/rose/
 # Site name, used by suite configuration for portability.
 site=SITE-NAME
 

--- a/etc/rose.conf.example
+++ b/etc/rose.conf.example
@@ -236,18 +236,6 @@ host=NAME
 title=TITLE
 
 
-# Configuration related to the :ref:`command-rosie-go` GUI.
-[rosie-go]
-# :default: /opt/cylc/images/icon.svg
-#
-# Path to an image containing the suite engine icon.
-icon-path-scheduler=
-# :default: https://github.com/metomi/rose/
-#
-# Hyperlink to the Rose project page.
-project-url=https://host/rose/
-
-
 # Configuration related to Rosie client commands.
 [rosie-id]
 # :default: $HOME/roses

--- a/metomi/rose/resource.py
+++ b/metomi/rose/resource.py
@@ -124,11 +124,6 @@ class ResourceLocator:
 
         return self.conf
 
-    def get_doc_url(self):
-        """Return the URL of Rose documentation."""
-        default = f"file://{ROSE_INSTALL_ROOT}/doc/"
-        return self.get_conf().get_value(["rose-doc"], default=default)
-
     def get_synopsis(self):
         """Return line 1 of SYNOPSIS in $ROSE_HOME_BIN/$ROSE_NS-$ROSE_UTIL."""
         try:


### PR DESCRIPTION
Remove unused `rose-doc` configuration (used to be used to point at locally built docs, nowadays we just use the internet 😄)