### PR TITLE
mypy: configure rose to use mypy

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -153,6 +153,11 @@ jobs:
           etc/bin/shellchecker
           yarn run lint
 
+      - name: MyPy
+        working-directory: rose
+        run: |
+          mypy --explicit-package-bases
+
       - name: Unit Tests
         working-directory: rose
         run: |

--- a/metomi/rose/app_run.py
+++ b/metomi/rose/app_run.py
@@ -22,6 +22,7 @@ import shlex
 import sys
 from time import localtime, sleep, strftime, time
 import traceback
+from typing import Optional
 
 from metomi.isodatetime.data import get_timepoint_for_now
 from metomi.isodatetime.parsers import ISO8601SyntaxError
@@ -293,7 +294,7 @@ class BuiltinApp:
 
     """
 
-    SCHEME = None
+    SCHEME: Optional[str] = None
 
     def __init__(self, *args, **kwargs):
         manager = kwargs.pop("manager")

--- a/metomi/rose/apps/rose_arch.py
+++ b/metomi/rose/apps/rose_arch.py
@@ -230,10 +230,17 @@ class RoseArchApp(BuiltinApp):
                 is_compulsory_source = False
             paths = glob(source_prefix + source_glob)
             if not paths:
-                exc = OSError(errno.ENOENT, os.strerror(errno.ENOENT),
-                              source_prefix + source_glob)
-                app_runner.handle_event(ConfigValueError(
-                    [t_key, "source"], source_glob, exc))
+                app_runner.handle_event(
+                    ConfigValueError(
+                        [t_key, "source"],
+                        source_glob,
+                        OSError(
+                            errno.ENOENT,
+                            os.strerror(errno.ENOENT),
+                            source_prefix + source_glob
+                        )
+                    )
+                )
                 if is_compulsory_source:
                     target.status = target.ST_BAD
                 continue

--- a/metomi/rose/config_diff.py
+++ b/metomi/rose/config_diff.py
@@ -23,6 +23,7 @@ import shlex
 import io
 import sys
 import tempfile
+from typing import List, Tuple
 
 import metomi.rose.config
 import metomi.rose.fs_util
@@ -41,7 +42,7 @@ class ConfigDiffDefaults:
         [metomi.rose.META_PROP_TITLE, metomi.rose.META_PROP_NS,
          metomi.rose.META_PROP_DESCRIPTION, metomi.rose.META_PROP_HELP]
     )
-    SHORTHAND = []
+    SHORTHAND: List[Tuple[str]] = []
 
 
 _DEFAULTS = ConfigDiffDefaults()

--- a/metomi/rose/config_processor.py
+++ b/metomi/rose/config_processor.py
@@ -17,11 +17,13 @@
 """Process named settings in metomi.rose.config.ConfigTree."""
 
 import os
+import sys
+from typing import Optional
+
 from metomi.rose.env import UnboundEnvironmentVariableError
 from metomi.rose.fs_util import FileSystemUtil
 from metomi.rose.popen import RosePopener
 from metomi.rose.scheme_handler import SchemeHandlersManager
-import sys
 
 
 class UnknownContentError(Exception):
@@ -68,8 +70,8 @@ class ConfigProcessorBase:
 
     """Base class for a config processor."""
 
-    SCHEME = None
-    PREFIX = None
+    SCHEME: Optional[str] = None
+    PREFIX: Optional[str] = None
 
     def __init__(self, *args, **kwargs):
         self.manager = kwargs.pop("manager")

--- a/metomi/rose/config_processors/fileinstall.py
+++ b/metomi/rose/config_processors/fileinstall.py
@@ -117,8 +117,11 @@ class ConfigProcessorForFile(ConfigProcessorBase):
             except UnboundEnvironmentVariableError as exc:
                 raise ConfigProcessError([key], key, exc)
             if os.path.exists(name) and kwargs.get("no_overwrite_mode"):
-                exc = FileOverwriteError(name)
-                raise ConfigProcessError([key], None, exc)
+                raise ConfigProcessError(
+                    [key],
+                    None,
+                    FileOverwriteError(name)
+                )
             self.manager.fs_util.makedirs(self.manager.fs_util.dirname(name))
         # Gets a list of sources and targets
         sources = {}
@@ -376,8 +379,11 @@ class ConfigProcessorForFile(ConfigProcessorBase):
                     if algorithm:
                         checksum = get_checksum_func(algorithm)(target.name)
                 if checksum_expected != checksum:
-                    exc = ChecksumError(checksum_expected, checksum)
-                    raise ConfigProcessError(keys, checksum_expected, exc)
+                    raise ConfigProcessError(
+                        keys,
+                        checksum_expected,
+                        ChecksumError(checksum_expected, checksum)
+                    )
             event = ChecksumEvent(target.name, target.paths[0].checksum)
             self.handle_event(event)
 

--- a/metomi/rose/host_select.py
+++ b/metomi/rose/host_select.py
@@ -33,6 +33,7 @@ from socket import (
 import sys
 from time import sleep, time
 import traceback
+from typing import Optional
 
 from metomi.rose.opt_parse import RoseOptionParser
 from metomi.rose.popen import RosePopener
@@ -537,11 +538,11 @@ class RandomScorer:
 
     """
 
-    ARG = None
-    KEY = "random"
-    CMD = ['cpu_count']  # fetch an arbitrary metric
-    CMD_IS_FORMAT = False
-    SIGN = 1  # Positive
+    ARG: Optional[str] = None
+    KEY: str = "random"
+    CMD: list = ['cpu_count']  # fetch an arbitrary metric
+    CMD_IS_FORMAT: bool = False
+    SIGN: int = 1  # Positive
 
     def get_command(self, method_arg=None):
         """Return a shell command to get the info for scoring a host."""

--- a/metomi/rose/macros/trigger.py
+++ b/metomi/rose/macros/trigger.py
@@ -16,6 +16,7 @@
 # -----------------------------------------------------------------------------
 
 import copy
+from typing import Dict, Any
 
 import metomi.rose.config
 import metomi.rose.config_tree
@@ -41,7 +42,7 @@ class TriggerMacro(metomi.rose.macro.MacroBaseRoseEdit):
     IGNORED_STATUS_VALUES = ('from parent value: {0} with {1} '
                              'is not in the allowed values: {2}')
     PARENT_VALUE = 'value {0}'
-    _evaluated_rule_checks = {}
+    _EVALUATED_RULE_CHECKS: Dict[tuple, Any] = {}
     MAX_STORED_RULE_CHECKS = 10000
 
     def _setup_triggers(self, meta_config):
@@ -510,7 +511,7 @@ class TriggerMacro(metomi.rose.macro.MacroBaseRoseEdit):
     def evaluate_trig_rule(self, rule, setting_id, value):
         """Launch an evaluation of a custom trigger expression."""
         try:
-            return self._evaluated_rule_checks[(rule, value)]
+            return self._EVALUATED_RULE_CHECKS[(rule, value)]
         except KeyError:
             section, option = self._get_section_option_from_id(setting_id)
             tiny_config = metomi.rose.config.ConfigNode()
@@ -518,9 +519,9 @@ class TriggerMacro(metomi.rose.macro.MacroBaseRoseEdit):
             tiny_meta_config = metomi.rose.config.ConfigNode()
             check_failed = self.evaluator.evaluate_rule(
                 rule, setting_id, tiny_config, tiny_meta_config)
-            if len(self._evaluated_rule_checks) > self.MAX_STORED_RULE_CHECKS:
-                self._evaluated_rule_checks.popitem()
-            self._evaluated_rule_checks[(rule, value)] = check_failed
+            if len(self._EVALUATED_RULE_CHECKS) > self.MAX_STORED_RULE_CHECKS:
+                self._EVALUATED_RULE_CHECKS.popitem()
+            self._EVALUATED_RULE_CHECKS[(rule, value)] = check_failed
             return check_failed
 
     def get_all_ids(self):

--- a/metomi/rose/meta_type.py
+++ b/metomi/rose/meta_type.py
@@ -18,6 +18,8 @@
 import ast
 import inspect
 import re
+from typing import Optional, Dict, Any, Type
+
 import metomi.rose.variable
 
 REC_CHARACTER = re.compile(r"'(?:[^']|'')*'$")
@@ -25,8 +27,8 @@ REC_CHARACTER = re.compile(r"'(?:[^']|'')*'$")
 
 class MetaType:
 
-    KEY = None
-    meta_type_classes = {}
+    KEY: Optional[str] = None
+    meta_type_classes: Dict[Any, Type] = {}
 
     @classmethod
     def get_meta_type(cls, key):

--- a/metomi/rose/reporter.py
+++ b/metomi/rose/reporter.py
@@ -19,6 +19,7 @@
 
 import sys
 import time
+from typing import Optional
 
 
 class Reporter:
@@ -269,8 +270,8 @@ class Event:
     KIND_ERR = Reporter.KIND_ERR
     KIND_OUT = Reporter.KIND_OUT
 
-    LEVEL = None
-    KIND = None
+    LEVEL: Optional[int] = None
+    KIND: Optional[str] = None
 
     def __init__(self, *args, **kwargs):
         self.args = args

--- a/metomi/rose/run.py
+++ b/metomi/rose/run.py
@@ -17,15 +17,17 @@
 """Shared utilities for app/task run."""
 
 import os
+import shlex
+import shutil
+from typing import Optional, List
+from uuid import uuid4
+
 from metomi.rose.config_processor import ConfigProcessorsManager
 from metomi.rose.config_tree import ConfigTreeLoader
 from metomi.rose.fs_util import FileSystemUtil
 from metomi.rose.popen import RosePopener
 from metomi.rose.reporter import Event
 from metomi.rose.suite_engine_proc import SuiteEngineProcessor
-import shlex
-import shutil
-from uuid import uuid4
 
 
 class RunConfigLoadEvent(Event):
@@ -93,9 +95,9 @@ class Runner:
 
     """Invoke a Rose application."""
 
-    CONF_NAME = None
-    NAME = None
-    OPTIONS = []
+    CONF_NAME: Optional[str] = None
+    NAME: Optional[str] = None
+    OPTIONS: List[str] = []
 
     def __init__(self, event_handler=None, popen=None, config_pm=None,
                  fs_util=None, suite_engine_proc=None):

--- a/metomi/rose/suite_engine_proc.py
+++ b/metomi/rose/suite_engine_proc.py
@@ -19,6 +19,7 @@
 import os
 import re
 import sys
+from typing import Optional
 
 from metomi.isodatetime.data import Duration
 from metomi.isodatetime.parsers import DurationParser, ISO8601SyntaxError
@@ -260,8 +261,8 @@ class SuiteEngineProcessor:
     """An abstract suite engine processor."""
 
     TASK_NAME_DELIM = {"prefix": "_", "suffix": "_"}
-    SCHEME = None
-    SCHEME_HANDLER_MANAGER = None
+    SCHEME: Optional[str] = None
+    SCHEME_HANDLER_MANAGER: Optional[str] = None
     SCHEME_DEFAULT = "cylc"  # TODO: site configuration?
     TIMEOUT = 5  # seconds
 

--- a/metomi/rose/suite_engine_procs/cylc.py
+++ b/metomi/rose/suite_engine_procs/cylc.py
@@ -29,10 +29,10 @@ from typing import Union, List, Tuple, Any
 from time import sleep
 from uuid import uuid4
 
-from metomi.rose.fs_util import FileSystemEvent  
-from metomi.rose.popen import RosePopenError  
-from metomi.rose.reporter import Reporter  
-from metomi.rose.suite_engine_proc import (   
+from metomi.rose.fs_util import FileSystemEvent
+from metomi.rose.popen import RosePopenError
+from metomi.rose.reporter import Reporter
+from metomi.rose.suite_engine_proc import (
     SuiteEngineProcessor,
     TaskProps
 )

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,11 @@
+[mypy]
+python_version = 3.7
+ignore_missing_imports = True
+files = metomi/rose
+exclude = metomi/rose/etc/
+
+# Enable PEP 420 style namespace packages, which we use.
+# Needed for associating "import foo.bar" with foo/bar.py
+namespace_packages = True
+
+strict_equality = True

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,8 @@ EXTRAS_REQUIRE = {
 }
 TESTS_REQUIRE = [
     'pytest',
-    'flake8'
+    'flake8>=3.0.0',
+    'mypy>=0.800',
 ]
 EXTRAS_REQUIRE['all'] = list(set(
     [y for x in EXTRAS_REQUIRE.values() for y in x] + TESTS_REQUIRE


### PR DESCRIPTION
built on: https://github.com/metomi/rose/pull/2461

Done whilst validating the type hints added in #2461

Minimal changes required to allow mypy to pass, allowing future development of type checking.