### PR TITLE
actions: enable macos testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,15 +33,9 @@ jobs:
       matrix:
         os: ['ubuntu-latest']
         python-version: ['3.7', '3.8', '3.9']
-        # TODO: re-enable macos testing
-        # currently (in the absence of a wrapper script) rose cannot be run
-        # from within cylc jobs in situations where the output of the following
-        # commands differ:
-        #   bash -c 'which python'
-        #   bash -l -c 'which python'
-        # include:
-        #   - os: 'macos-latest'
-        #     python-version: '3.7'
+        include:
+          - os: 'macos-latest'
+            python-version: '3.7'
 
     steps:
       - name: Checkout
@@ -93,16 +87,6 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y shellcheck sqlite3 at
-
-      - name: MacOS DNS Patch
-        if: startsWith(matrix.os, 'macos')
-        run: |
-          # apply DNS patch
-          hostuserutil="$(python3 -c '
-          import cylc.flow.hostuserutil
-          print(cylc.flow.hostuserutil.__file__)
-          ')"
-          patch "${hostuserutil}" < rose/etc/conf/macos-patch
 
       - name: Install Rose
         working-directory: rose

--- a/metomi/rose/scripts/rosa-rpmbuild
+++ b/metomi/rose/scripts/rosa-rpmbuild
@@ -47,6 +47,7 @@ RELEASE=1
 if [[ $REV_NAME != "$REV_BASE" ]]; then
     COMMIT_DATE="$(\
         date -u +%Y%m%dT%H%M "--date=$(git show -s --format=%ci "$REV")")"
+    # shellcheck disable=SC2295
     RELEASE=${COMMIT_DATE}git${REV_NAME#$REV_BASE-*-g}
 fi
 REV_BASE_DOT="$(sed 's/-/./g' <<<"$REV_BASE")"


### PR DESCRIPTION
~Built on #2494 (cli change required for MacOS due to the way Python is installed)~

Closes #2447 