### PR TITLE
Fix problems with rose stem

### DIFF
--- a/sphinx/api/command-reference.rst
+++ b/sphinx/api/command-reference.rst
@@ -41,8 +41,6 @@ This command has been replaced by ``cylc play``.
 
 .. TODO: This is here to allow the documentation tests to pass
 
-.. _command-rose-stem:
-
 rose stem
 ^^^^^^^^^
 

--- a/sphinx/ext/auto_cli_doc.py
+++ b/sphinx/ext/auto_cli_doc.py
@@ -30,7 +30,7 @@ from sphinx.util.nodes import nested_parse_with_titles
 # RE_CMD = re.compile(r'^={5,}$\n^(.*)$\n^={5,}$')
 RE_CMD = re.compile(r'={5,}\n')
 RE_USAGE = re.compile(r'Usage: (.*)')
-RE_SECTION = re.compile(r'^([A-Z][A-Z: ]+)$')
+RE_SECTION = re.compile(r'^(([A-Z][A-Z: ]+)|Options:)$')
 
 RST_HEADINGS = ['=', '-', '^', '"']
 
@@ -204,6 +204,7 @@ def write(ns, cmds, _write):
             rst_body(content['DESCRIPTION'])
         )
         for key, text in content.items():
+            key = key.upper()
             if key in {'USAGE', 'DESCRIPTION'}:
                 continue
             _write(


### PR DESCRIPTION
- Remove duplicate `.. _command-rose-stem`.
- Allow Rose Stem's CLI Help parsing to use Options from Cylc Option parser.