### PR TITLE
Popen always decodes

### DIFF
--- a/metomi/rose/apps/ana_builtin/grepper.py
+++ b/metomi/rose/apps/ana_builtin/grepper.py
@@ -196,8 +196,6 @@ class SingleCommandStatus(AnalysisTask):
     def run_command(self, command):
         """Simple command runner; returns output error and return code."""
         retcode, stdout, stderr = self.popen.run(command, shell=True)
-        if isinstance(stdout, bytes):
-            stdout, stderr = stdout.decode(), stderr.decode()
         return retcode, stdout, stderr
 
     def read_file(self, filename):

--- a/metomi/rose/apps/rose_arch.py
+++ b/metomi/rose/apps/rose_arch.py
@@ -412,8 +412,6 @@ class RoseArchApp(BuiltinApp):
                 "target": app_runner.popen.list_to_shell_str([target.name]),
             }
             ret_code, out, err = app_runner.popen.run(command, shell=True)
-            if isinstance(out, bytes):
-                out, err = out.decode(), err.decode()
             times[2] = time()  # archived time
             if ret_code:
                 app_runner.handle_event(

--- a/metomi/rose/apps/rose_prune.py
+++ b/metomi/rose/apps/rose_prune.py
@@ -131,7 +131,6 @@ class RosePruneApp(BuiltinApp):
             except RosePopenError as exc:
                 app_runner.handle_event(exc)
             else:
-                out = out.decode()
                 if sdir is None:
                     event = FileSystemEvent(
                         FileSystemEvent.CHDIR, host + ":" + suite_dir_rel

--- a/metomi/rose/check_software.py
+++ b/metomi/rose/check_software.py
@@ -104,7 +104,7 @@ def cmd_version(command, command_template='--version',
     if not isinstance(command_template, list):
         command_template = [command_template]
     output = Popen([command] + command_template, stdout=PIPE,
-                   stderr=PIPE).communicate()[outfile - 1].decode().strip()
+                   stderr=PIPE, text=True).communicate()[outfile - 1].strip()
     try:
         return re.search(version_template, output).groups()[0]
     except AttributeError:
@@ -112,7 +112,7 @@ def cmd_version(command, command_template='--version',
 
 
 def shell_command(_, shell=None, version_template=r'(.*)', outfile=1):
-    output = Popen(shell, stdout=PIPE).communicate()[outfile - 1].decode()
+    output = Popen(shell, stdout=PIPE, text=True).communicate()[outfile - 1]
     try:
         return re.search(version_template, output).groups()[0]
     except AttributeError:

--- a/metomi/rose/config_diff.py
+++ b/metomi/rose/config_diff.py
@@ -305,8 +305,8 @@ CONFIGURATION
     return_code = 1
     try:
         return_code, stdout, stderr = popener.run(*diff_cmd)
-        sys.stdout.buffer.write(stdout)
-        sys.stderr.buffer.write(stderr)
+        sys.stdout.buffer.write(stdout.encode())
+        sys.stderr.buffer.write(stderr.encode())
     finally:
         fs_util = metomi.rose.fs_util.FileSystemUtil()
         for path in output_filenames:

--- a/metomi/rose/host_select.py
+++ b/metomi/rose/host_select.py
@@ -424,7 +424,7 @@ class HostSelector:
             proc = self.popen.run_bg(
                 *command, stdin=stdin, preexec_fn=os.setpgrp
             )
-            proc.stdin.write(stdin.encode('UTF-8'))
+            proc.stdin.write(stdin)
             proc.stdin.flush()
             host_proc_dict[host_name] = (proc, metrics)
 

--- a/metomi/rose/host_select.py
+++ b/metomi/rose/host_select.py
@@ -437,7 +437,7 @@ class HostSelector:
                 if proc.poll() is None:
                     score = None
                 elif proc.wait():
-                    stdout, stderr = (f.decode() for f in proc.communicate())
+                    stdout, stderr = proc.communicate()
                     self.handle_event(
                         HostSelectCommandFailedEvent(
                             proc.returncode, host_name
@@ -445,7 +445,7 @@ class HostSelector:
                     )
                     host_proc_dict.pop(host_name)
                 else:
-                    out = proc.communicate()[0].decode()
+                    out = proc.communicate()[0]
                     out = _deserialise(metrics, json.loads(out.strip()))
 
                     host_proc_dict.pop(host_name)

--- a/metomi/rose/loc_handlers/rsync.py
+++ b/metomi/rose/loc_handlers/rsync.py
@@ -63,8 +63,8 @@ class RsyncLocHandler:
         cmd = self.manager.popen.get_cmd(
             "ssh", host, "python3", "-", path, loc.TYPE_BLOB, loc.TYPE_TREE
         )
-        with open(rsync_remote_check_file, 'rb') as stdin:
-            out = self.manager.popen(*cmd, stdin=stdin)[0].decode()
+        with open(rsync_remote_check_file, 'r') as stdin:
+            out = self.manager.popen(*cmd, stdin=stdin)[0]
         lines = out.splitlines()
         if not lines or lines[0] not in [loc.TYPE_BLOB, loc.TYPE_TREE]:
             raise ValueError(loc.name)

--- a/metomi/rose/popen.py
+++ b/metomi/rose/popen.py
@@ -257,10 +257,6 @@ class RosePopener:
         """
         ret_code, stdout, stderr = self.run(*args, **kwargs)
         if ret_code:
-            if stderr:
-                stderr = stderr
-            else:
-                stderr = ''
             raise RosePopenError(
                 args, ret_code, stdout, stderr, kwargs.get("stdin")
             )

--- a/metomi/rose/popen.py
+++ b/metomi/rose/popen.py
@@ -189,16 +189,7 @@ class RosePopener:
         stdout, stderr = proc.communicate(stdin)
         retcode = proc.wait()
 
-        def _decode_if_bytes(obj):
-            if isinstance(obj, bytes):
-                return obj.decode()
-            return obj
-
-        return (
-            _decode_if_bytes(retcode),
-            _decode_if_bytes(stdout),
-            _decode_if_bytes(stderr)
-        )
+        return retcode, stdout, stderr
 
     def run_bg(self, *args, **kwargs):
         """Provide a Rose-friendly interface to subprocess.Popen.
@@ -222,9 +213,9 @@ class RosePopener:
         sys.stdout.flush()
         try:
             if kwargs.get("shell"):
-                proc = Popen(args[0], **kwargs)
+                proc = Popen(args[0], text=True, **kwargs)
             else:
-                proc = Popen(args, **kwargs)
+                proc = Popen(args, text=True, **kwargs)
         except OSError as exc:
             if exc.filename is None and args:
                 exc.filename = args[0]

--- a/metomi/rose/suite_engine_procs/cylc.py
+++ b/metomi/rose/suite_engine_procs/cylc.py
@@ -327,7 +327,6 @@ class CylcProcessor(SuiteEngineProcessor):
                         self.handle_event(exc, level=Reporter.WARN)
                     else:
                         for line in sorted(ssh_ls_out.splitlines()):
-                            line = line.decode()
                             event = FileSystemEvent(
                                 FileSystemEvent.DELETE,
                                 "%s:log/job/%s/" % (auth, line),
@@ -432,7 +431,7 @@ class CylcProcessor(SuiteEngineProcessor):
             user = None
         if host and ("`" in host or "$" in host):
             command = ["bash", "-ec", "H=" + host + "; echo $H"]
-            host = self.popen(*command)[0].strip().decode()
+            host = self.popen(*command)[0].strip()
         if host in ["None", self.host] or self.host_selector.is_local_host(
             host
         ):

--- a/metomi/rosie/suite_id.py
+++ b/metomi/rosie/suite_id.py
@@ -144,7 +144,7 @@ class SuiteId:
                 raise SuiteIdLatestError(prefix)
             dirs = [
                 line
-                for line in out.decode().splitlines()
+                for line in out.splitlines()
                 if line.endswith("/")
             ]
             # Note - 'R/O/S/I/E' sorts to top for lowercase initial idx letter

--- a/metomi/rosie/svn_hook.py
+++ b/metomi/rosie/svn_hook.py
@@ -114,7 +114,7 @@ class RosieSvnHook(object):
     def _svnlook(self, *args):
         """Return the standard output from "svnlook"."""
         command = ["svnlook", *args]
-        return self.popen(*command)[0].decode()
+        return self.popen(*command)[0]
 
     def _load_info(
         self,

--- a/metomi/rosie/vc.py
+++ b/metomi/rosie/vc.py
@@ -101,7 +101,7 @@ class LocalCopyStatusError(Exception):
         super(LocalCopyStatusError, self).__init__(id_, status)
 
     def __str__(self):
-        data = (str(self.id_), self.id_.to_local_copy(), self.status.decode())
+        data = (str(self.id_), self.id_.to_local_copy(), self.status)
         return "%s: %s: local copy has uncommitted changes:\n%s" % data
 
 
@@ -385,7 +385,7 @@ class RosieVCClient:
                 from_id.revision,
             )
             out_data = self.popen("svn", "cat", from_info_url)[0]
-            from_config = metomi.rose.config.load(StringIO(out_data.decode()))
+            from_config = metomi.rose.config.load(StringIO(out_data))
 
         res_loc = ResourceLocator.default()
         older_config = None

--- a/sphinx/api/command-reference.rst
+++ b/sphinx/api/command-reference.rst
@@ -41,7 +41,6 @@ This command has been replaced by ``cylc play``.
 
 .. TODO: This is here to allow the documentation tests to pass
 
-
 ----
 
 .. _command-rose-test-battery:


### PR DESCRIPTION
Closes #2320 

Make the rose Popener run object always return stdout, stderr and retcode as str and not bytes. This allows removed of a number of checks elsewhere.

This is an oversight from my original conversion of Rose to Python 3.