### PR TITLE
Re-enable Rosie ID.

### DIFF
--- a/metomi/rosie/suite_id.py
+++ b/metomi/rosie/suite_id.py
@@ -421,17 +421,17 @@ class SuiteId:
         loc = Path(location).expanduser().resolve()
         if suite_dir_rel_root:
             sdrr = Path('~', suite_dir_rel_root).expanduser().resolve()
-        try:
-            loc.relative_to(sdrr)
-        except ValueError:
-            # Not an installed Cylc8 workflow run directory
-            pass
-        else:
-            # Slightly odd construction = loc + parents
-            for loc in (loc.relative_to(sdrr) / '_').parents:
-                vcfilepath = sdrr / loc / SuiteId.VC_FILENAME
-                if os.access(vcfilepath, os.F_OK | os.R_OK):
-                    return vcfilepath
+            try:
+                loc.relative_to(sdrr)
+            except ValueError:
+                # Not an installed Cylc8 workflow run directory
+                pass
+            else:
+                # Slightly odd construction = loc + parents
+                for loc in (loc.relative_to(sdrr) / '_').parents:
+                    vcfilepath = sdrr / loc / SuiteId.VC_FILENAME
+                    if os.access(vcfilepath, os.F_OK | os.R_OK):
+                        return vcfilepath
         return None
 
     @staticmethod

--- a/metomi/rosie/suite_id.py
+++ b/metomi/rosie/suite_id.py
@@ -419,7 +419,8 @@ class SuiteId:
             suite_engine_proc, "SUITE_DIR_REL_ROOT", None
         )
         loc = Path(location).expanduser().resolve()
-        sdrr = Path('~', suite_dir_rel_root).expanduser().resolve()
+        if suite_dir_rel_root:
+            sdrr = Path('~', suite_dir_rel_root).expanduser().resolve()
         try:
             loc.relative_to(sdrr)
         except ValueError:
@@ -431,7 +432,7 @@ class SuiteId:
                 vcfilepath = sdrr / loc / SuiteId.VC_FILENAME
                 if os.access(vcfilepath, os.F_OK | os.R_OK):
                     return vcfilepath
-            return None
+        return None
 
     @staticmethod
     def _parse_cylc_vc_file(fpath):

--- a/sphinx/api/command-reference.rst
+++ b/sphinx/api/command-reference.rst
@@ -41,7 +41,6 @@ This command has been replaced by ``cylc play``.
 
 .. TODO: This is here to allow the documentation tests to pass
 
-
 ----
 
 .. _command-rose-test-battery:

--- a/t/rosie-id/00-basic.t
+++ b/t/rosie-id/00-basic.t
@@ -114,9 +114,6 @@ foo-aa000
 __OUT__
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
 
-# TODO: Cylc8 support for rosie id
-# https://github.com/metomi/rose/issues/2432
-
 TEST_KEY="${TEST_KEY_BASE}-run"
 get_reg
 svn co -q "${URL}/a/a/0/0/0/trunk" 'foo-aa000'

--- a/t/rosie-id/00-basic.t
+++ b/t/rosie-id/00-basic.t
@@ -21,7 +21,7 @@
 #-------------------------------------------------------------------------------
 . $(dirname $0)/test_header
 #-------------------------------------------------------------------------------
-tests 36
+tests 39
 #-------------------------------------------------------------------------------
 svnadmin create foo
 URL=file://$PWD/foo
@@ -117,28 +117,26 @@ file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
 # TODO: Cylc8 support for rosie id
 # https://github.com/metomi/rose/issues/2432
 
-#TEST_KEY="${TEST_KEY_BASE}-run"
-#get_reg
-#svn co -q "${URL}/a/a/0/0/0/trunk" 'foo-aa000'
-#touch 'foo-aa000/rose-suite.conf'
-#cat >'foo-aa000/flow.cylc' <<'__SUITE_RC__'
-#[scheduling]
-#    [[dependencies]]
-#        graph='t1'
-#[runtime]
-#    [[t1]]
-#__SUITE_RC__
-#cylc install \
-#    -C "${PWD}/foo-aa000" \
-#    --flow-name="${FLOW}" \
-#    --no-run-name
-#run_pass "$TEST_KEY" rosie id "${HOME}/cylc-run/${FLOW}"
-#file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<__OUT__
-#foo-aa000
-#__OUT__
-#file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
-#purge
-#rm -fr 'foo-aa000'
+TEST_KEY="${TEST_KEY_BASE}-run"
+get_reg
+svn co -q "${URL}/a/a/0/0/0/trunk" 'foo-aa000'
+touch 'foo-aa000/rose-suite.conf'
+cat >'foo-aa000/flow.cylc' <<'__SUITE_RC__'
+[scheduling]
+   [[dependencies]]
+       graph='t1'
+[runtime]
+   [[t1]]
+__SUITE_RC__
+cylc install \
+   -C "${PWD}/foo-aa000" \
+   --flow-name="${FLOW}" \
+   --no-run-name
+run_pass "$TEST_KEY" rosie id "${HOME}/cylc-run/${FLOW}"
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<__OUT__
+foo-aa000
+__OUT__
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
 #-------------------------------------------------------------------------------
 # Latest and next should still be correct if latest suite removed from HEAD
 TEST_KEY=$TEST_KEY_BASE-latest-not-at-head
@@ -155,4 +153,6 @@ foo-aa001
 __OUT__
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
 #-------------------------------------------------------------------------------
+purge
+rm -fr 'foo-aa000'
 exit 0


### PR DESCRIPTION
Closes #2432 

> Extract version control information from installed Cylc8 workflows for the rosie id command.
>
> Depends on: cylc/cylc-flow#3849

Requires #2509  merger to pass

- [x] Re-written basic functionality.
- [x] Re-enables t/rosie-id/00-basic.t tests 31-33 which tests functionality.