### PR TITLE
Remove prune remote logs at from rose prune settings

### DIFF
--- a/metomi/rose/apps/rose_prune.py
+++ b/metomi/rose/apps/rose_prune.py
@@ -143,7 +143,6 @@ class RosePruneApp(BuiltinApp):
         are delimited by colons ":".
         E.g.:
 
-        prune-remote-logs-at=-PT6H -PT12H
         prune-server-logs-at=-P7D
         prune-datac-at=-PT6H:foo/* -PT12H:'bar/* baz/*' -P1D
         prune-work-at=-PT6H:t1*:*.tar -PT12H:t1*: -PT12H:*.gz -P1D

--- a/metomi/rose/apps/rose_prune.py
+++ b/metomi/rose/apps/rose_prune.py
@@ -47,10 +47,7 @@ class RosePruneApp(BuiltinApp):
             return
 
         # Tar-gzip job logs on suite host
-        # Prune job logs on remote hosts and suite host
-        prune_remote_logs_cycles = self._get_conf(
-            app_runner, conf_tree, "prune-remote-logs-at"
-        )
+        # Prune job logs on suite host
         prune_server_logs_cycles = self._get_conf(
             app_runner, conf_tree, "prune-server-logs-at"
         )
@@ -58,28 +55,14 @@ class RosePruneApp(BuiltinApp):
             app_runner, conf_tree, "archive-logs-at"
         )
         if (
-            prune_remote_logs_cycles
-            or prune_server_logs_cycles
+            prune_server_logs_cycles
             or archive_logs_cycles
         ):
-            tmp_prune_remote_logs_cycles = []
-            for cycle in prune_remote_logs_cycles:
-                if cycle not in archive_logs_cycles:
-                    tmp_prune_remote_logs_cycles.append(cycle)
-            prune_remote_logs_cycles = tmp_prune_remote_logs_cycles
-
             tmp_prune_server_logs_cycles = []
             for cycle in prune_server_logs_cycles:
                 if cycle not in archive_logs_cycles:
                     tmp_prune_server_logs_cycles.append(cycle)
             prune_server_logs_cycles = tmp_prune_server_logs_cycles
-
-            if prune_remote_logs_cycles:
-                app_runner.suite_engine_proc.job_logs_pull_remote(
-                    suite_name,
-                    prune_remote_logs_cycles,
-                    prune_remote_mode=True,
-                )
 
             if prune_server_logs_cycles:
                 app_runner.suite_engine_proc.job_logs_remove_on_server(

--- a/metomi/rose/etc/rose-meta/rose_prune/HEAD/rose-meta.conf
+++ b/metomi/rose/etc/rose-meta/rose_prune/HEAD/rose-meta.conf
@@ -37,16 +37,6 @@ help=Remove the ROSE_DATACs of the specified cycles, or items in them.
     =prune-datac-at=-6h:foo* -12h:'bar* baz*' -1d
 sort-key=04
 
-[prune=prune-remote-logs-at]
-description=Remove remote job logs at these cycles (after a re-sync)
-help=Re-sync remote job logs at these cycles and remove them from remote hosts.
-    =
-    =A space delimited list of cycles, normally expressed as date/time
-    =offsets relative to the current cycle, in a format recognised by the
-    ="--offset=OFFSET" option of "rose date". E.g. "-6h" is 6 hours before the
-    =current cycle time.
-sort-key=01
-
 [prune=prune-server-logs-at]
 description=Remove logs on the suite server at these cycles.
 help=Removes both log directories and archived logs on the suite server.

--- a/metomi/rose/etc/rose_prune/HEAD/rose-meta.conf
+++ b/metomi/rose/etc/rose_prune/HEAD/rose-meta.conf
@@ -37,16 +37,6 @@ help=Remove the ROSE_DATACs of the specified cycles, or items in them.
     =prune-datac-at=-6h:foo* -12h:'bar* baz*' -1d
 sort-key=04
 
-[prune=prune-remote-logs-at]
-description=Remove remote job logs at these cycles (after a re-sync)
-help=Re-sync remote job logs at these cycles and remove them from remote hosts.
-    =
-    =A space delimited list of cycles, normally expressed as date/time
-    =offsets relative to the current cycle, in a format recognised by the
-    ="--offset=OFFSET" option of "rose date". E.g. "-6h" is 6 hours before the
-    =current cycle time.
-sort-key=01
-
 [prune=prune-server-logs-at]
 description=Remove logs on the suite server at these cycles.
 help=Removes both log directories and archived logs on the suite server.

--- a/sphinx/api/built-in/rose_prune.rst
+++ b/sphinx/api/built-in/rose_prune.rst
@@ -53,7 +53,6 @@ Example
 
    [prune]
    cycle-format{cycle_year_month}=CCYYMM
-   prune-remote-logs-at=-PT6H
    archive-logs-at=-P1D
    prune-server-logs-at=-P7D
    prune{work}=-PT6H:task_x* -PT12H:*/other*.dat -PT18H:task_y* -PT24H
@@ -80,11 +79,6 @@ Configuration
          The ``key`` can be any string that can be used in a ``%(key)s``
          substitution, and format should be a a valid :ref:`command-rose-date`
          print format.
-
-      .. rose:conf:: prune-remote-logs-at=cycle ...
-
-         Re-sync remote job logs at these cycles and remove them from
-         remote hosts.
 
       .. rose:conf:: prune-server-logs-at=cycle ...
 

--- a/t/rose-task-run/06-app-prune-iso/app/rose_prune/rose-app.conf
+++ b/t/rose-task-run/06-app-prune-iso/app/rose_prune/rose-app.conf
@@ -2,7 +2,6 @@ meta=rose_prune/HEAD
 mode=rose_prune
 
 [prune]
-prune-remote-logs-at=-PT12H
 archive-logs-at=-P1D
 prune{share/cycle}=-PT12H:a* -P1D:'b* c*' -P1DT12H
 prune{work}=-PT12H

--- a/t/rose-task-run/12-app-prune-integer/app/prune/rose-app.conf
+++ b/t/rose-task-run/12-app-prune-integer/app/prune/rose-app.conf
@@ -2,7 +2,6 @@ meta=rose_prune
 mode=rose_prune
 
 [prune]
-prune-remote-logs-at=-P1
 archive-logs-at=-P1
 prune{work}=-P1
 prune{share/cycle}=-P1

--- a/t/rose-task-run/35-app-prune-log-on-hosts-sharing-fs/app/pruner/rose-app.conf
+++ b/t/rose-task-run/35-app-prune-log-on-hosts-sharing-fs/app/pruner/rose-app.conf
@@ -1,5 +1,2 @@
 meta=rose_prune/HEAD
 mode=rose_prune
-
-[prune]
-prune-remote-logs-at=-P20Y


### PR DESCRIPTION
Closes https://github.com/metomi/rose/issues/2469: Remove `prune-remote-logs-at=cycle` from Rose Prune options. 