### PR TITLE
fixed broken link.

### DIFF
--- a/sphinx/hyperlinks.rst
+++ b/sphinx/hyperlinks.rst
@@ -12,7 +12,7 @@
 .. _Cylc: https://cylc.github.io/
 .. _Cylc Flow: https://github.com/cylc/cylc-flow
 .. _Cylc Rose: https://github.com/cylc/cylc-rose
-.. _Cylc User Guide: https://cylc.github.io/documentation/#the-cylc-user-guide
+.. _Cylc User Guide: https://cylc.github.io/documentation/
 .. _Cylc Suite Design Guide: https://cylc.github.io/cylc-doc/stable/html/suite-design-guide/suite-design-guide-master.html
 
 .. _EmPy: http://www.alcyone.com/software/empy/

--- a/sphinx/hyperlinks.rst
+++ b/sphinx/hyperlinks.rst
@@ -12,7 +12,7 @@
 .. _Cylc: https://cylc.github.io/
 .. _Cylc Flow: https://github.com/cylc/cylc-flow
 .. _Cylc Rose: https://github.com/cylc/cylc-rose
-.. _Cylc User Guide: https://cylc.github.io/documentation/
+.. _Cylc User Guide: https://cylc.github.io/cylc-doc/latest/html/user-guide/index.html
 .. _Cylc Suite Design Guide: https://cylc.github.io/cylc-doc/stable/html/suite-design-guide/suite-design-guide-master.html
 
 .. _EmPy: http://www.alcyone.com/software/empy/


### PR DESCRIPTION
https://cylc.github.io/cylc-doc/latest/html/user-guide/index.html might also be a valid destination, especially since this is rose2.

What do you (reviewer) think?