### PR TITLE
setup: add pygraphviz opt dep

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,7 +60,14 @@ jobs:
         if: startsWith(matrix.os, 'macos')
         run: |
           # install system deps
-          brew install bash coreutils gnu-sed shellcheck sqlite3 subversion
+          brew install \
+            bash \
+            coreutils \
+            gnu-sed \
+            shellcheck \
+            sqlite3 \
+            subversion \
+            graphviz
 
           # add GNU coreutils and sed to the user PATH (for actions steps)
           # (see instructions in brew install output)
@@ -86,7 +93,7 @@ jobs:
         if: startsWith(matrix.os, 'ubuntu')
         run: |
           sudo apt-get update
-          sudo apt-get install -y shellcheck sqlite3 at
+          sudo apt-get install -y shellcheck sqlite3 at graphviz graphviz-dev
 
       - name: Install Rose
         working-directory: rose

--- a/metomi/rose/rose.py
+++ b/metomi/rose/rose.py
@@ -20,7 +20,10 @@ import os
 from pathlib import Path
 import sys
 
-from pkg_resources import iter_entry_points
+from pkg_resources import (
+    DistributionNotFound,
+    iter_entry_points,
+)
 
 from metomi.rose import (
     __file__ as rose_init_file,
@@ -163,7 +166,7 @@ def _exec_bash(ns, sub_cmd, args):
 
 def _exec_python(ns, sub_cmd, entry_point, args):
     # load the entry point
-    fcn = entry_point.load()
+    fcn = load_entry_point(entry_point)
 
     # set the argv for the sub command
     sys.argv = [f'{ns}-{sub_cmd}', *args]
@@ -174,6 +177,22 @@ def _exec_python(ns, sub_cmd, entry_point, args):
     else:
         fcn()
     sys.exit(0)
+
+
+def load_entry_point(entry_point):
+    try:
+        return entry_point.load()
+    except DistributionNotFound:
+        print(
+            (
+                'This functionality requires optional dependencies:'
+                f' {", ".join(entry_point.extras)}'
+                '\n(e.g. pip install metomi-rose'
+                f' [{",".join(entry_point.extras)}])'
+            ),
+            file=sys.stderr
+        )
+        sys.exit(1)
 
 
 def _get_sub_cmds(ns):

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,9 +17,12 @@
 
 [metadata]
 name = metomi-rose
+version = attr: metomi.rose.__version__
 description = Rose, a framework for meteorological suites.
 author = British Crown (Met Office) & Contributors
 author_email = metomi@metoffice.gov.uk
+long_description=file: README.md
+long_description_content_type=text/markdown
 url=https://metomi.github.io/rose/doc/html/index.html
 license = GPL
 license_file=COPYING
@@ -42,6 +45,48 @@ classifiers =
     Topic :: Scientific/Engineering :: Atmospheric Science
 python_requires = >=3.7
 
+[options]
+packages = find_namespace:
+include_package_data = True
+python_requires = >=3.7
+install_requires =
+    aiofiles
+    jinja2>=2.10.1
+    ldap3
+    metomi-isodatetime
+    psutil>=5.6.0
+    requests
+    sqlalchemy
+
+[options.packages.find]
+include = metomi*
+
+[options.extras_require]
+# disco =
+#     TODO: rosie disco has been disabled due to the removal of WSGI support at
+#     Tornado 6.
+#     tornado
+docs =
+    cylc-sphinx-extensions[all]>=1.2.0
+    hieroglyph>=2.1.0
+    sphinx
+    sphinx_rtd_theme
+    sphinxcontrib-httpdomain
+    sphinxcontrib-svg2pdfconverter
+graph =
+    pygraphviz
+rosa =
+tests =
+    flake8>=3.0.0
+    mypy>=0.800
+    pytest
+    types-aiofiles
+all =
+    %(docs)s
+    %(graph)s
+    %(rosa)s
+    %(tests)s
+
 [options.entry_points]
 # top level shell commands
 console_scripts =
@@ -62,7 +107,7 @@ rose.commands =
     macro = metomi.rose.macro:main
     metadata-check = metomi.rose.metadata_check:main
     metadata-gen = metomi.rose.metadata_gen:main
-    metadata-graph = metomi.rose.metadata_graph:main
+    metadata-graph = metomi.rose.metadata_graph:main [graph]
     namelist-dump = metomi.rose.namelist_dump:main
     resource = metomi.rose.resource:main
     task-env = metomi.rose.task_env:main
@@ -71,9 +116,9 @@ rosie.commands =
     checkout = metomi.rosie.vc:checkout
     create = metomi.rosie.vc:create
     delete = metomi.rosie.vc:delete
-    disco = metomi.rosie.ws:main
+    disco = metomi.rosie.ws:main [disco]
     go = metomi.rosie.browser:main
-    graph = metomi.rosie.graph:main
+    graph = metomi.rosie.graph:main [graph]
     hello = metomi.rosie.ws_client_cli:hello
     id = metomi.rosie.suite_id:main
     lookup = metomi.rosie.ws_client_cli:lookup

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,4 @@
 #!/usr/ bin/env python3
-# coding=utf-8
-
 # Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This file is part of Rose, a framework for meteorological suites.
@@ -18,76 +16,6 @@
 # You should have received a copy of the GNU General Public License
 # along with Rose. If not, see <http://www.gnu.org/licenses/>.
 
-import codecs
-from os.path import abspath, dirname, join
-import re
+from setuptools import setup
 
-from setuptools import find_namespace_packages, setup
-
-here = abspath(dirname(__file__))
-
-
-def read(*parts):
-    with codecs.open(join(here, *parts), "r") as fp:
-        return fp.read()
-
-
-def find_version(*file_paths):
-    version_file = read(*file_paths)
-    version_match = re.search(
-        r"^__version__ = ['\"]([^'\"]*)['\"]", version_file, re.M
-    )
-    if version_match:
-        return version_match.group(1)
-    raise RuntimeError("Unable to find version string.")
-
-
-with open("README.md", "r") as fh:
-    long_description = fh.read()
-
-
-INSTALL_REQUIRES = [
-    "aiofiles",
-    "jinja2>=2.10.1",
-    "ldap3",
-    "metomi-isodatetime",
-    "requests",
-    "sqlalchemy",
-    # TODO: rosie disco has been disabled due to the removal of WSGI support at
-    # Tornado 6.
-    # "tornado",
-    'psutil>=5.6.0',
-]
-EXTRAS_REQUIRE = {
-    'docs': [
-        'sphinx',
-        'sphinx_rtd_theme',
-        'sphinxcontrib-httpdomain',
-        'hieroglyph>=2.1.0',
-        'sphinxcontrib-svg2pdfconverter',
-        'cylc-sphinx-extensions[all]>=1.2.0',
-    ]
-}
-TESTS_REQUIRE = [
-    'pytest',
-    'flake8>=3.0.0',
-    'mypy>=0.800',
-    'types-aiofiles',
-]
-EXTRAS_REQUIRE['all'] = list(
-    set([y for x in EXTRAS_REQUIRE.values() for y in x] + TESTS_REQUIRE)
-)
-
-
-setup(
-    # Metadata
-    long_description=long_description,
-    long_description_content_type="text/markdown",
-    version=find_version("metomi", "rose", "__init__.py"),
-    # Options
-    install_requires=INSTALL_REQUIRES,
-    extras_require=EXTRAS_REQUIRE,
-    tests_require=TESTS_REQUIRE,
-    include_package_data=True,
-    packages=find_namespace_packages(include=["metomi.*"]),
-)
+setup()


### PR DESCRIPTION
Closes #2523

* Convert setup file format to setup.cfg.
* Add pygraphviz opt dep.
* Add logic to metomi.rose.rose to provide more helpful error messages
  when optional dependencies are not present.
* Add graphviz to CI deps.