### PR TITLE
Rose Date only warns if run in an interactive shell

### DIFF
--- a/metomi/rose/date_cli.py
+++ b/metomi/rose/date_cli.py
@@ -180,10 +180,11 @@ from metomi.isodatetime.main import main as iso_main
 
 def main():
     """Implement rose date."""
-    print(
-        'WARNING: "rose date" is depreacted, use the "isodatetime" command.',
-        file=sys.stderr
-    )
+    if sys.stdin.isatty():
+        print(
+            'WARNING: "rose date" is depreacted, use the "isodatetime" command.',
+            file=sys.stderr
+        )
 
     if '--help' in sys.argv:
         print('\n' + __doc__)

--- a/metomi/rose/date_cli.py
+++ b/metomi/rose/date_cli.py
@@ -182,7 +182,8 @@ def main():
     """Implement rose date."""
     if sys.stdin.isatty():
         print(
-            'WARNING: "rose date" is depreacted, use the "isodatetime" command.',
+            'WARNING: "rose date" is depreacted, use the "isodatetime" '
+            'command.',
             file=sys.stderr
         )
 

--- a/metomi/rose/date_cli.py
+++ b/metomi/rose/date_cli.py
@@ -182,7 +182,7 @@ def main():
     """Implement rose date."""
     if sys.stdin.isatty():
         print(
-            'WARNING: "rose date" is depreacted, use the "isodatetime" '
+            'WARNING: "rose date" is deprecated, use the "isodatetime" '
             'command.',
             file=sys.stderr
         )


### PR DESCRIPTION
Closes #2524 

Easy test of whether this is working 
```
# Control - should have the warning
rose date
# Changed from master
cd ~/rose/sphinx
make clean html
```

The second case should produce the warning on master, but not on this branch.