### PR TITLE
renamed function job_logs_pull_remote → job_logs_housekeep_remote

### DIFF
--- a/metomi/rose/apps/rose_prune.py
+++ b/metomi/rose/apps/rose_prune.py
@@ -76,7 +76,7 @@ class RosePruneApp(BuiltinApp):
             prune_server_logs_cycles = tmp_prune_server_logs_cycles
 
             if prune_remote_logs_cycles:
-                app_runner.suite_engine_proc.job_logs_pull_remote(
+                app_runner.suite_engine_proc.job_logs_housekeep_remote(
                     suite_name,
                     prune_remote_logs_cycles,
                     prune_remote_mode=True,

--- a/metomi/rose/suite_engine_proc.py
+++ b/metomi/rose/suite_engine_proc.py
@@ -467,7 +467,7 @@ class SuiteEngineProcessor:
         """
         raise NotImplementedError()
 
-    def job_logs_pull_remote(
+    def job_logs_housekeep_remote(
         self, suite_name, items, prune_remote_mode=False, force_mode=False
     ):
         """Pull and housekeep the job logs on remote task hosts.

--- a/metomi/rose/suite_engine_procs/cylc.py
+++ b/metomi/rose/suite_engine_procs/cylc.py
@@ -172,7 +172,8 @@ class CylcProcessor(SuiteEngineProcessor):
                 cycle = self._parse_task_cycle_id(item)[0]
                 if cycle:
                     cycles.append(cycle)
-        self.job_logs_housekeep_remote(suite_name, cycles, prune_remote_mode=True)
+        self.job_logs_housekeep_remote(
+            suite_name, cycles, prune_remote_mode=True)
         cwd = os.getcwd()
         self.fs_util.chdir(self.get_suite_dir(suite_name))
         try:

--- a/metomi/rose/suite_engine_procs/cylc.py
+++ b/metomi/rose/suite_engine_procs/cylc.py
@@ -172,7 +172,7 @@ class CylcProcessor(SuiteEngineProcessor):
                 cycle = self._parse_task_cycle_id(item)[0]
                 if cycle:
                     cycles.append(cycle)
-        self.job_logs_pull_remote(suite_name, cycles, prune_remote_mode=True)
+        self.job_logs_housekeep_remote(suite_name, cycles, prune_remote_mode=True)
         cwd = os.getcwd()
         self.fs_util.chdir(self.get_suite_dir(suite_name))
         try:
@@ -207,16 +207,15 @@ class CylcProcessor(SuiteEngineProcessor):
             except OSError:
                 pass
 
-    def job_logs_pull_remote(
+    def job_logs_housekeep_remote(
         self, suite_name, items, prune_remote_mode=False, force_mode=False,
     ):
-        """Pull and housekeep the job logs on remote task hosts.
+        """Housekeep the job logs on remote task hosts.
 
         suite_name -- The name of a suite.
         items -- A list of relevant items.
         prune_remote_mode -- Remove remote job logs after pulling them.
         force_mode -- Pull even if "job.out" already exists.
-
         """
         # Pull from remote.
         # Create a file with a uuid name, so system knows to do nothing on

--- a/sphinx/api/built-in/rose_prune.rst
+++ b/sphinx/api/built-in/rose_prune.rst
@@ -83,8 +83,7 @@ Configuration
 
       .. rose:conf:: prune-remote-logs-at=cycle ...
 
-         Re-sync remote job logs at these cycles and remove them from
-         remote hosts.
+         Remove remote job logs at these cycles.
 
       .. rose:conf:: prune-server-logs-at=cycle ...
 


### PR DESCRIPTION
Follow up #2522 

Reflects a telephone conversation from earlier today:
- [x] Document the fact that `job_logs_pull_remote` doesn't actually pull anymore.
- [x] Update the documentation. 