### PR TITLE
bump version; make setuptools dep formal

### DIFF
--- a/metomi/rose/__init__.py
+++ b/metomi/rose/__init__.py
@@ -144,4 +144,4 @@ FILE_VAR_SOURCE = "source"
 # Paths in the Rose distribution.
 FILEPATH_README = "README.md"
 
-__version__ = "2.0rc1"
+__version__ = "2.0rc2.dev"

--- a/setup.cfg
+++ b/setup.cfg
@@ -69,6 +69,7 @@ include = metomi*
 docs =
     cylc-sphinx-extensions[all]>=1.2.0
     hieroglyph>=2.1.0
+    setuptools>=49
     sphinx
     sphinx_rtd_theme
     sphinxcontrib-httpdomain


### PR DESCRIPTION
* Move over to the `.dev` convention.
  * I think this is safe now after the CLI changes, will find out when the tests fail...
* Make the setupools dep formal
  * The setuptools dependency was missing (provides `pkg_resources`).
  * This dependency is often omitted as it is vendored (i.e. used by pip), adding it for correctness.
  * Pinning the setuptools version fairly arbitrary to the version used by cylc-flow.