### PR TITLE
Invoke host-select via bash login shell

### DIFF
--- a/metomi/rose/app_run.py
+++ b/metomi/rose/app_run.py
@@ -297,12 +297,12 @@ class Poller:
         # Return any remaining test-failing files.
         return poll_test, poll_any_files, poll_all_files
 
-    def _poll_file(self, file_, poll_file_test):
+    def _poll_file(self, file_: str, poll_file_test: str) -> bool:
         """Poll for existence of a file."""
         is_done = False
         if poll_file_test:
             test = poll_file_test.replace(
-                "{}", self.popen.list_to_shell_str([file_])
+                r'{}', self.popen.list_to_shell_str([file_])
             )
             is_done = (
                 self.popen.run(

--- a/metomi/rose/etc/rose-meta/rose-app-conf/rose-meta.conf
+++ b/metomi/rose/etc/rose-meta/rose-app-conf/rose-meta.conf
@@ -58,7 +58,7 @@ description=Specify prerequisites to poll for before running the actual applicat
            = with delays between them.
 
 [poll=all-files]
-help=A space delimited list of file paths.
+help=A space delimited list of file paths. Accepts globs.
     =
     = This test passes only if all file paths in the list exist.
     =
@@ -67,7 +67,7 @@ help=A space delimited list of file paths.
     = for all file paths.
 
 [poll=any-files]
-help=A space delimited list of file paths.
+help=A space delimited list of file paths. Accepts globs.
     =
     = This test passes if any file path in the list exists.
     =

--- a/metomi/rose/host_select.py
+++ b/metomi/rose/host_select.py
@@ -31,6 +31,7 @@ from socket import (
     gethostname,
 )
 import sys
+import textwrap
 from time import sleep, time
 import traceback
 from typing import List, Optional
@@ -63,17 +64,22 @@ class HostSelectCommandFailedEvent(Event):
 
     KIND = Event.KIND_ERR
 
-    def __init__(self, return_code: int, host: str):
-        self.return_code = return_code
+    def __init__(
+        self, host: str, return_code: int, stderr: Optional[str] = None
+    ):
         self.host = host
+        self.return_code = return_code
+        self.stderr = stderr
         Event.__init__(self)
 
-    def __str__(self):
+    def __str__(self) -> str:
         if self.return_code == 255:
             msg = 'ssh failed'
         else:
-            msg = f'failed {self.return_code}'
-        return f'{self.host}: ({msg})'
+            msg = f"failed ({self.return_code})"
+            if self.stderr is not None:
+                msg += f"\n{textwrap.indent(self.stderr, '    ')}"
+        return f"{self.host}: {msg}"
 
 
 class HostThresholdNotMetEvent(Event):
@@ -391,7 +397,7 @@ class HostSelector:
                 elif proc.wait():
                     self.handle_event(
                         HostSelectCommandFailedEvent(
-                            proc.returncode, host_name
+                            host_name, proc.returncode
                         )
                     )
                 else:
@@ -452,19 +458,18 @@ class HostSelector:
         while host_proc_dict:
             sleep(self.SSH_CMD_POLL_DELAY)
             for host_name, (proc, metrics) in list(host_proc_dict.items()):
-                if proc.poll() is None:
-                    score = None
-                elif proc.wait():
-                    stdout, stderr = proc.communicate()
+                if proc.poll() is None:  # still running
+                    continue
+                stdout, stderr = proc.communicate()
+                if proc.returncode:
                     self.handle_event(
                         HostSelectCommandFailedEvent(
-                            proc.returncode, host_name
+                            host_name, proc.returncode, stderr
                         )
                     )
                     host_proc_dict.pop(host_name)
                 else:
-                    out = proc.communicate()[0]
-                    out = _deserialise(metrics, json.loads(out.strip()))
+                    out = _deserialise(metrics, json.loads(stdout.strip()))
 
                     host_proc_dict.pop(host_name)
                     for threshold_conf in threshold_confs:

--- a/metomi/rose/run_source_vc.py
+++ b/metomi/rose/run_source_vc.py
@@ -62,12 +62,12 @@ def write_source_vc_info(run_source_dir, output=None, popen=None):
         os.chdir(run_source_dir)
         try:
             for args in args_list:
-                cmd = [vcs] + args
+                cmd = [vcs, *args]
                 ret_code, out, _ = popen.run(*cmd, env=environ)
                 if out:
                     write_safely(("#" * 80 + "\n"), handle)
                     write_safely(
-                        ("# %s\n" % popen.list_to_shell_str(cmd)), handle
+                        ("# %s\n" % popen.shlex_join(cmd)), handle
                     )
                     write_safely(("#" * 80 + "\n"), handle)
                     write_safely(out, handle)

--- a/metomi/rose/suite_engine_procs/cylc.py
+++ b/metomi/rose/suite_engine_procs/cylc.py
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with Rose. If not, see <http://www.gnu.org/licenses/>.
 # -----------------------------------------------------------------------------
-"""Logic specific to the Cylc suite engine."""
+"""Logic specific to the Cylc workflow engine."""
 
 from glob import glob
 import os
@@ -39,7 +39,7 @@ from metomi.rose.suite_engine_proc import (
 
 class CylcProcessor(SuiteEngineProcessor):
 
-    """Logic specific to the cylc suite engine."""
+    """Logic specific to the Cylc workflow engine."""
 
     REC_CYCLE_TIME = re.compile(
         r"\A[\+\-]?\d+(?:W\d+)?(?:T\d+(?:Z|[+-]\d+)?)?\Z"

--- a/metomi/rose/tests/suite_engine_procs/test_cylc.py
+++ b/metomi/rose/tests/suite_engine_procs/test_cylc.py
@@ -17,9 +17,13 @@
 """Tests for functions in the cylc suite engine proc.
 """
 
-import cylc.rose.platform_utils
 import pytest
 from pytest import param
+
+try:
+    import cylc.rose.platform_utils
+except ImportError:
+    pytestmark = pytest.mark.skip(reason="cylc-rose not found")
 
 from metomi.rose.suite_engine_procs.cylc import CylcProcessor
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -82,6 +82,9 @@ tests =
     mypy>=0.800
     pytest
     types-aiofiles
+    # Note: some tests also depend on cylc-rose which has to be the
+    # development version installed manually (because the latest production
+    # version is pinned to the previous rose release)
 all =
     %(docs)s
     %(graph)s

--- a/sphinx/api/configuration/application.rst
+++ b/sphinx/api/configuration/application.rst
@@ -34,7 +34,7 @@ contain the following:
      ``[!file:hello.txt]``, then the file will not be installed at all.
 
 * ``bin/`` directory for e.g. scripts and executables used by the application
-  at run time. If a ``bin/`` exists in the application configuration, it will 
+  at run time. If a ``bin/`` exists in the application configuration, it will
   prepended to the ``PATH`` environment variable at run time.
 * ``meta/`` directory for the metadata of the application.
 * ``opt/`` directory (see :ref:`Optional Configuration`).
@@ -98,7 +98,7 @@ E.g. The application configuration directory may look like:
          which can be selected at runtime.
 
          See the :ref:`rose-tutorial-command-keys` tutorial.
-  
+
    .. rose:conf:: env
 
       Specify environment variables to be provided to the
@@ -120,12 +120,12 @@ E.g. The application configuration directory may look like:
          Define an environment variable ``KEY`` with the value ``VALUE``.
 
       .. rose:conf:: UNDEF
-      
+
          A special variable that is always undefined at run time.
 
          Reference to it will cause a failure at run time. It can be used to
          indicate that a value must be overridden at run time.
-  
+
    .. rose:conf:: [etc]
 
       Specify misc. settings.
@@ -186,23 +186,29 @@ E.g. The application configuration directory may look like:
       .. rose:conf:: all-files
 
          A list of space delimited list of file paths. This test
-         passes only if all file paths in the list exist.
+         passes only if all file paths in the list exist. Accepts globs.
 
       .. rose:conf:: any-files
 
          A list of space delimited list of file paths. This test
-         passes if any file path in the list exists.
+         passes if any file path in the list exists. Accepts globs.
 
       .. rose:conf:: test
 
          A shell command. This test passes if the command returns a 0
          (zero) return code.
 
-         Normally, the :rose:conf:`all-files` and :rose:conf:`any-files`
-         tests both test for the existence of file paths.
+         This test is run in addition to
+         the :rose:conf:`all-files` and :rose:conf:`any-files`
+         tests for the existence of file paths.
 
       .. rose:conf:: file-test
-     
+
+         A shell command run for each file path, where ``{}`` is substituted
+         for the file path at runtime. This test passes if the command returns
+         a 0 (zero) return code for all paths in ``all-files``
+         and any path in ``any-files``.
+
          If :rose:conf:`test` is not enough, e.g. you want to test for the
          existence of a string in each file, you can specify a
          :rose:conf:`file-test` to do a ``grep``. E.g.:
@@ -212,10 +218,17 @@ E.g. The application configuration directory may look like:
             all-files=file1 file2
             file-test=test -e {} && grep -q 'hello' {}
 
-         At runtime, any ``{}`` pattern in the above would be replaced
-         with the name of the file. The above make sure that both
+         At runtime, any ``{}`` in the command is replaced
+         with the name of the file (or glob pattern).
+         The example above tests that both
          ``file1`` and ``file2`` exist and that they both contain the
-         string ``hello``.
+         string ``hello``. It is run for each path/pattern, so the
+         example above would be equivalent to:
+
+         .. code-block:: bash
+
+            test -e file1 && grep -q 'hello' file1
+            test -e file2 && grep -q 'hello' file2
 
       .. rose:conf:: delays
 

--- a/t/rose-app-run/08-poll.t
+++ b/t/rose-app-run/08-poll.t
@@ -61,9 +61,9 @@ run_fail "$TEST_KEY" rose app-run --config=../config -q
 file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
 file_grep "$TEST_KEY.err.0" \
     '\[FAIL\] ....-..-..T..:..:....* poll timeout after PT..*S' "$TEST_KEY.err"
-file_grep "$TEST_KEY.err.1" '* test' "$TEST_KEY.err"
-file_grep "$TEST_KEY.err.2" '* any-files' "$TEST_KEY.err"
-file_grep "$TEST_KEY.err.3" '* all-files:file0\* file1 file2' "$TEST_KEY.err"
+file_grep "$TEST_KEY.err.1" '\* test' "$TEST_KEY.err"
+file_grep "$TEST_KEY.err.2" '\* any-files' "$TEST_KEY.err"
+file_grep "$TEST_KEY.err.3" "\* all-files:file0\* file1 file2" "$TEST_KEY.err"
 test_teardown
 #-------------------------------------------------------------------------------
 # Timeout test 2. Missing a file in all-files.

--- a/t/rose-host-select/00-basic.t
+++ b/t/rose-host-select/00-basic.t
@@ -36,7 +36,7 @@ TEST_KEY="${TEST_KEY_BASE}-ssh-fail"
 run_fail "${TEST_KEY}" rose 'host-select' 'electric-monkey-eggs'
 file_cmp "${TEST_KEY}.out" "${TEST_KEY}.out" </dev/null
 file_cmp "${TEST_KEY}.err" "${TEST_KEY}.err" <<__HERE__
-[WARN] electric-monkey-eggs: (ssh failed)
+[WARN] electric-monkey-eggs: ssh failed
 [FAIL] No hosts selected.
 __HERE__
 #-------------------------------------------------------------------------------

--- a/t/rose-host-select/01-timeout.t
+++ b/t/rose-host-select/01-timeout.t
@@ -36,11 +36,11 @@ file_cmp "$TEST_KEY.sorted.err" "$TEST_KEY.sorted.err" <<'__ERR__'
 [WARN] sleepy2: (timed out)
 __ERR__
 cut -f2- mock-ssh.out | LANG=C sort >mock-ssh.out.sorted
-sed -i 's/env CYLC_VERSION=[^ ]* //' mock-ssh.out.sorted
+sed -i -E 's/env CYLC_VERSION=[^ ]*( CYLC_ENV_NAME=[^ ]*)? //' mock-ssh.out.sorted
 # N.B. Tab between 1 and sleepy?
 file_cmp "$TEST_KEY.mock-ssh.out" mock-ssh.out.sorted <<'__OUT__'
-sleepy1 rose host-select-client
-sleepy2 rose host-select-client
+sleepy1 bash -l -c 'rose host-select-client'
+sleepy2 bash -l -c 'rose host-select-client'
 __OUT__
 # Make sure there is no lingering processes
 run_fail "$TEST_KEY.ps" ps $(cut -f1 mock-ssh.out)

--- a/t/rose-host-select/02-localhost.t
+++ b/t/rose-host-select/02-localhost.t
@@ -45,9 +45,8 @@ tests "$(($(wc -w <<<"${HOSTS}") + 2))"
 run_pass "${TEST_KEY_BASE}" rose 'host-select' -v -v ${HOSTS}
 
 # 1 bash command
-file_grep \
-    "${TEST_KEY_BASE}.out" \
-    "rose host-select-client <<'__STDIN__'" \
+file_grep "${TEST_KEY_BASE}.out-grep" \
+    "bash -l -c 'rose host-select-client' <<'__STDIN__'" \
     "${TEST_KEY_BASE}.out"
 
 # 0 ssh LOCAL_HOST command


### PR DESCRIPTION
This closes #2552

Changes the command that gets run in the background, as follows:
```diff
 ssh -oBatchMode=yes -oStrictHostKeyChecking=no -oConnectTimeout=8 <hostname> \
-    env CYLC_VERSION=<version> rose host-select-client
+    env CYLC_VERSION=<version> CYLC_ENV_NAME=<$CYLC_ENV_NAME> bash -l -c 'rose host-select-client'
```