### PR TITLE
get_suite_job_auths should use install targets not host from platform.

### DIFF
--- a/metomi/rose/suite_engine_procs/cylc.py
+++ b/metomi/rose/suite_engine_procs/cylc.py
@@ -67,34 +67,45 @@ class CylcProcessor(SuiteEngineProcessor):
         """
         return os.path.join(cls.SUITE_DIR_REL_ROOT, suite_name, *paths)
 
+    @staticmethod
     def get_suite_jobs_auths(
-        self, suite_name: str, cycle_name_tuples: Tuple[Any] = None
+        suite_name: str, cycle_name_tuples: Tuple[Any] = None
     ) -> List[str]:
         """Get hosts of jobs from a Cylc workflow database.
 
-        returns: list of hostname strings.
+        returns: list of hostname strings used by tasks for given cycles.
+
+        Example:
+            (Can't work as a doc-test because this function requires a
+            workflow databse)
+            this('remote-eg/run3', [('10660101T0000Z', None)])
+            returns
+            ['host1', 'host2']
         """
         # n.b. Imports inside function to avoid dependency on Cylc and
         # Cylc-Rose is Rose is being used with a different workflow engine.
         from cylc.flow.platforms import get_host_from_platform
         from cylc.rose.platform_utils import get_platforms_from_task_jobs
 
+        # Get a list of task platforms for the tasks at this cycle point.
         task_platforms = {}
         if cycle_name_tuples is not None:
             for cycle, name in cycle_name_tuples:
                 new_platforms = get_platforms_from_task_jobs(suite_name, cycle)
                 task_platforms[cycle] = new_platforms
 
-        # For each platform get a list of hosts.
+        # For each platform get a list of install targets.
         hosts = []
         for cycle, tasks in task_platforms.items():
             for platform in tasks.values():
-                hosts.append(get_host_from_platform(platform))
+                if platform['install target'] is not None:
+                    hosts.append(platform['install target'])
         hosts = list(set(hosts))
         return hosts
 
+    @staticmethod
     def get_task_auth(
-        self, suite_name: str, task_name: str
+        suite_name: str, task_name: str
     ) -> Union[str, None]:
         """Get host for a remote task from a Cylc workflow definition.
 

--- a/t/rose-task-run/34-app-prune-hosts-sharing-fs.t
+++ b/t/rose-task-run/34-app-prune-hosts-sharing-fs.t
@@ -54,11 +54,15 @@ run_pass "${TEST_KEY}" \
         --no-detach
 
 TEST_KEY="${TEST_KEY_BASE}-prune.log"
+
+# Pull out lines referring to ssh-ing to JOB_HOST_1 and 2 from prun log
 grep \
     "ssh .* \\(${JOB_HOST_1}\\|${JOB_HOST_2}\\) .* share/cycle/19700101T0000Z;" \
     "${FLOW_RUN_DIR}/prune.log" >'prune-ssh.log'
-run_pass "${TEST_KEY}-prune-ssh-wc-l" test "$(wc -l <'prune-ssh.log')" -eq 2
+run_pass "${TEST_KEY}-prune-ssh-wc-l" test "$(wc -l <'prune-ssh.log')" -eq 1
 
+# Check that Rose has only cleaned on one of the job hosts
+# with a shared file system.
 if head -n 1 'prune-ssh.log' | grep ".* ${JOB_HOST_1} .*"; then
     run_pass "${TEST_KEY}-delete-1" \
         grep -q "delete: ${JOB_HOST_1}:share/cycle/19700101T0000Z" \

--- a/t/rose-task-run/35-app-prune-log-on-hosts-sharing-fs.t
+++ b/t/rose-task-run/35-app-prune-log-on-hosts-sharing-fs.t
@@ -54,11 +54,15 @@ run_pass "${TEST_KEY}" \
         --no-detach
 
 TEST_KEY="${TEST_KEY_BASE}-prune.log"
+
+# Pull out lines referring to ssh-ing to JOB_HOST_1 and 2 from prun log
 grep \
     "ssh .* \\(${JOB_HOST_1}\\|${JOB_HOST_2}\\).* ls. -d..* 19700101T0000Z" \
     "${FLOW_RUN_DIR}/prune.log" >'prune-ssh.log'
-run_pass "${TEST_KEY}-prune-ssh-wc-l" test "$(wc -l <'prune-ssh.log')" -eq 2
+run_pass "${TEST_KEY}-prune-ssh-wc-l" test "$(wc -l <'prune-ssh.log')" -eq 1
 
+# Check that Rose has only cleaned on one of the job hosts
+# with a shared file system.
 if head -n 1 'prune-ssh.log' | grep ".* ${JOB_HOST_1} .*"; then
     run_pass "${TEST_KEY}-delete-1" \
         grep -q "delete: ${JOB_HOST_1}:log/job/19700101T0000Z" \


### PR DESCRIPTION
Closes #2549 

### Summary
Tests `t/rose-task-run/{34,35}` are failing.
It looks like an additional delete operation is being performed where it isn't required.

`get_suite_jobs_auths` in `metomi/rose/suite_engine_procs/cylc` should be returning install targets rather than hosts.

### How to test

These tests need to be run from a host with no shared file system.

### Checklist

- [x] Fixed issue in #2549 
- [x] Already tested.
- [ ] Change log updated. 