### PR TITLE
Fcm make fix for remote and subshell platforms

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,20 @@ updated. Only the first match gets replaced, so it's fine to leave the old
 ones in. -->
 --------------------------------------------------------------------------------
 
+## 2.0rc2 (<span actions:bind='release-date'>Upcoming</span>)
+
+### Enhancements
+
+[#2555](https://github.com/metomi/rose/pull/2555) - `rose host-select` now
+passes through `$CYLC_ENV_NAME` and the user's login env vars.
+
+### Fixes
+
+[#2548](https://github.com/metomi/rose/pull/2548) - Added back the
+`rose-conf.vim` syntax highlighting file for ViM that was accidentally removed.
+
+--------------------------------------------------------------------------------
+
 ## 2.0rc1 (<span actions:bind='release-date'>Released 2022-02-17</span>)
 
 [#2510](https://github.com/metomi/rose/pull/2510) -

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,10 @@ passes through `$CYLC_ENV_NAME` and the user's login env vars.
 
 ### Fixes
 
+[#2557](https://github.com/metomi/rose/pull/2557) - Fcm make now works
+correctly with remote tasks and tasks which have their platform or host defined
+as a subshell.
+
 [#2548](https://github.com/metomi/rose/pull/2548) - Added back the
 `rose-conf.vim` syntax highlighting file for ViM that was accidentally removed.
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,7 +19,8 @@ passes through `$CYLC_ENV_NAME` and the user's login env vars.
 
 ### Fixes
 
-[#2557](https://github.com/metomi/rose/pull/2557) - Fcm make now works
+[#2557](https://github.com/metomi/rose/pull/2557) -
+[FCM Make](https://github.com/metomi/fcm) now works
 correctly with remote tasks and tasks which have their platform or host defined
 as a subshell.
 

--- a/metomi/rose/apps/fcm_make.py
+++ b/metomi/rose/apps/fcm_make.py
@@ -16,6 +16,7 @@
 # ----------------------------------------------------------------------------
 """Builtin application: run "fcm make"."""
 
+from contextlib import suppress
 import os
 from pipes import quote
 import shlex
@@ -29,7 +30,10 @@ from metomi.rose.env import (
     env_var_process,
 )
 from metomi.rose.fs_util import FileSystemEvent
-from metomi.rose.popen import RosePopenError
+from metomi.rose.popen import (
+    RosePopenError,
+    WorkflowFileNotFoundError
+)
 
 ORIG = 0
 CONT = 1
@@ -209,9 +213,11 @@ class FCMMakeApp(BuiltinApp):
         task_name_cont = task.task_name.replace(
             orig_cont_map[ORIG], orig_cont_map[CONT]
         )
-        auth = app_runner.suite_engine_proc.get_task_auth(
-            task.suite_name, task_name_cont
-        )
+        auth = None
+        with suppress(WorkflowFileNotFoundError):
+            auth = app_runner.suite_engine_proc.get_task_auth(
+                task.suite_name, task_name_cont
+            )
         if auth is not None:
             dest_cont = _conf_value(conf_tree, ["dest-cont"])
             if dest_cont is None:

--- a/metomi/rose/popen.py
+++ b/metomi/rose/popen.py
@@ -29,6 +29,18 @@ from metomi.rose.reporter import Event
 from metomi.rose.resource import ResourceLocator
 
 
+class WorkflowFileNotFoundError(Exception):
+
+    """Error: Workflow file not found.
+
+    Expected error for fcm_make remote where the flow.cylc is
+    not included in the file installation.
+    """
+
+    def __str__(self):
+        return "No workflow file found."
+
+
 class RosePopenError(Exception):
 
     """An error raised when a shell command call fails."""

--- a/metomi/rose/suite_engine_procs/cylc.py
+++ b/metomi/rose/suite_engine_procs/cylc.py
@@ -107,15 +107,10 @@ class CylcProcessor(SuiteEngineProcessor):
         # Cylc-Rose is Rose is being used with a different workflow engine.
         from cylc.flow.exceptions import WorkflowFilesError
         from cylc.flow.hostuserutil import is_remote_platform
-        from cylc.flow.platforms import (
-            get_host_from_platform,
-            platform_from_name
-        )
+        from cylc.flow.platforms import get_host_from_platform
         from cylc.rose.platform_utils import get_platform_from_task_def
         try:
-            platform = get_platform_from_task_def(
-                suite_name, task_name, quiet=True
-            )
+            platform = get_platform_from_task_def(suite_name, task_name)
         except KeyError:
             return None
         except (WorkflowFilesError):
@@ -123,24 +118,11 @@ class CylcProcessor(SuiteEngineProcessor):
         else:
             if platform is None:
                 return 'localhost'
-            elif isinstance(platform, str):
-                platform_evaluated = self.eval_subshell(platform)
-                platform = platform_from_name(platform_evaluated)
             # If task has been defined return host:
             if is_remote_platform(platform):
                 return get_host_from_platform(platform)
             else:
                 return None
-
-    @staticmethod
-    def eval_subshell(platform):
-        """Evaluates platforms/hosts"""
-        from cylc.flow.platforms import HOST_REC_COMMAND
-        match = HOST_REC_COMMAND.match(platform)
-        output = subprocess.run(
-            ['bash', '-c', f" {match[2]}"], capture_output=True
-        )
-        return output.stdout.strip().decode()
 
     def get_task_props_from_env(self):
         """Get attributes of a suite task from environment variables.

--- a/metomi/rose/suite_engine_procs/cylc.py
+++ b/metomi/rose/suite_engine_procs/cylc.py
@@ -23,7 +23,6 @@ from random import shuffle
 import re
 import socket
 import sqlite3
-import subprocess
 import tarfile
 from time import sleep
 from typing import Any, List, Tuple, Union

--- a/metomi/rose/tests/suite_engine_procs/test_cylc.py
+++ b/metomi/rose/tests/suite_engine_procs/test_cylc.py
@@ -40,7 +40,7 @@ from metomi.rose.suite_engine_procs.cylc import CylcProcessor
     ],
 )
 def test_get_task_auth(monkeypatch, platform, expect):
-    def fake_get_platform(*_):
+    def fake_get_platform(*_, quiet=False):
         if platform is None:
             raise KeyError
         else:

--- a/metomi/rose/tests/suite_engine_procs/test_cylc.py
+++ b/metomi/rose/tests/suite_engine_procs/test_cylc.py
@@ -40,7 +40,7 @@ from metomi.rose.suite_engine_procs.cylc import CylcProcessor
     ],
 )
 def test_get_task_auth(monkeypatch, platform, expect):
-    def fake_get_platform(*_, quiet=False):
+    def fake_get_platform(*_):
         if platform is None:
             raise KeyError
         else:

--- a/t/rose-task-run/08-app-fcm-make.t
+++ b/t/rose-task-run/08-app-fcm-make.t
@@ -112,7 +112,6 @@ else
 
     TEST_KEY="$TEST_KEY_BASE-t5-part-2"
     # TODO: this test relies on "retrieve job logs = True".
-    #rose suite-log -q --name=$FLOW --update fcm_make2_t5
     file_grep "$TEST_KEY.out" \
         "\\[INFO\\] [0-9]*-[0-9]*-[0-9]*T[0-9]*:[0-9]*:[0-9]*+[0:9]* fcm make -C .*/cylc-run/${FLOW}/share/fcm_make_t5 -n 2 -j 4" \
         $FLOW_RUN_DIR/log/job/1/fcm_make2_t5/01/job.out

--- a/t/rose-task-run/08-app-fcm-make.t
+++ b/t/rose-task-run/08-app-fcm-make.t
@@ -65,6 +65,7 @@ if [[ -n $JOB_HOST ]]; then
     file_cmp "$TEST_KEY" "$TEST_KEY" <<'__DB__'
 fcm_make2_t5|succeeded
 fcm_make_t1|succeeded
+fcm_make_t1_remote|succeeded
 fcm_make_t2|succeeded
 fcm_make_t3|succeeded
 fcm_make_t4|succeeded

--- a/t/rose-task-run/08-app-fcm-make/flow.cylc
+++ b/t/rose-task-run/08-app-fcm-make/flow.cylc
@@ -13,6 +13,7 @@ fcm_make_t3 # opt.jobs
 fcm_make_t4 # args
 {% if HOST is defined %}
 fcm_make_t5 => fcm_make2_t5 # mirror
+fcm_make_t1_remote # basic remote
 {% endif %}
 """
 [runtime]
@@ -23,6 +24,11 @@ fcm_make_t5 => fcm_make2_t5 # mirror
     [[fcm_make_t5]]
     [[fcm_make2_t5]]
         [[[remote]]]
-            host={{HOST}}
+            host=$(echo {{HOST}})
             retrieve job logs = true
+    [[fcm_make_t1_remote]]
+        [[[environment]]]
+            ROSE_TASK_APP = fcm_make_t1
+        [[[remote]]]
+            host=$(echo {{HOST}})
 {% endif %}


### PR DESCRIPTION
closes: https://github.com/metomi/rose/issues/2553

Requires sibling cylc-rose to be checked out (https://github.com/cylc/cylc-rose/pull/120).

Credit to @wxtim for pairing this.