### PR TITLE
docs: add reference labels for builtin apps

### DIFF
--- a/sphinx/api/built-in/fcm_make.rst
+++ b/sphinx/api/built-in/fcm_make.rst
@@ -1,3 +1,5 @@
+.. _builtin.fcm_make:
+
 ``fcm_make``
 ============
 

--- a/sphinx/api/built-in/rose_ana.rst
+++ b/sphinx/api/built-in/rose_ana.rst
@@ -1,3 +1,5 @@
+.. _builtin.rose_ana:
+
 ``rose_ana``
 ============
 

--- a/sphinx/api/built-in/rose_bunch.rst
+++ b/sphinx/api/built-in/rose_bunch.rst
@@ -1,3 +1,5 @@
+.. _builtin.rose_bunch:
+
 ``rose_bunch``
 ==============
 

--- a/sphinx/api/built-in/rose_prune.rst
+++ b/sphinx/api/built-in/rose_prune.rst
@@ -1,6 +1,8 @@
 .. include:: ../../hyperlinks.rst
    :start-line: 1
 
+.. _builtin.rose_prune:
+
 ``rose_prune``
 ==============
 


### PR DESCRIPTION
Sneaking some reference labels into the docs for intersphinx links.