### PR TITLE
2019.01.6-pre-release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,7 +3,7 @@
 Go to https://github.com/metomi/rose/milestones?state=closed
 for a full listing of issues for each release.
 
-## 2019.01.5 (2022-03-29)
+## 2019.01.6 (2022-03-29)
 
 ### Fixes
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,13 @@
 Go to https://github.com/metomi/rose/milestones?state=closed
 for a full listing of issues for each release.
 
+## 2019.01.5 (2022-03-29)
+
+### Fixes
+
+[#2485](https://github.com/metomi/rose/pull/2486) - Prevent Rose 2019
+modifying Cylc 8 workflows.
+
 ## 2019.01.5 (2021-03-19)
 
 Rose release 62. This maintenance release is expected to be used with:

--- a/rose-version
+++ b/rose-version
@@ -16,4 +16,4 @@
 # You should have received a copy of the GNU General Public License
 # along with Rose. If not, see <http://www.gnu.org/licenses/>.
 # -----------------------------------------------------------------------------
-ROSE_VERSION="2019.01.5"
+ROSE_VERSION="2019.01.6"


### PR DESCRIPTION
## Rose 2019.01.6 Release PR

Refer to https://www-nwp/~fcm/metomi-docs/team/how_to_create_a_git_release.html#before-you-start-first-time

- [x] Updated `rose-version` file.
- [x] Updated `CHANGES.md`.
- [x] Bumped or closed issues on https://github.com/metomi/rose/milestone/72
- [x] Checked Shortlog and mailmap. A number of people are missing from the contributors list, but I've made sure @MetRonnie  and @datamel are sorted.
- [x] Rebase on master after Merge of https://github.com/metomi/rose/pull/2572
