### PR TITLE
Mpi launch fix

### DIFF
--- a/metomi/rose/scripts/rose-mpi-launch
+++ b/metomi/rose/scripts/rose-mpi-launch
@@ -252,7 +252,6 @@ fi
 #-------------------------------------------------------------------------------
 # 3. Launch the program.
 #-------------------------------------------------------------------------------
-
 if [[ -n $ROSE_COMMAND_FILE ]]; then
     if [[ -z $ROSE_LAUNCHER_BASE ]]; then
         err "ROSE_LAUNCHER not defined, command file not supported."

--- a/metomi/rose/scripts/rose-mpi-launch
+++ b/metomi/rose/scripts/rose-mpi-launch
@@ -239,7 +239,7 @@ if [[ -n $ROSE_LAUNCHER ]]; then
     # Path
     ROSE_LAUNCHER_PATH=""
     for command in ${ROSE_LAUNCHER}; do
-        if  command="$(type -P "$command")"; then
+        if  command="$(type -P $command)"; then
             ROSE_LAUNCHER_PATH="${ROSE_LAUNCHER_PATH} ${command}"
         else
             err "ROSE_LAUNCHER: $ROSE_LAUNCHER: command not found"

--- a/metomi/rose/scripts/rose-mpi-launch
+++ b/metomi/rose/scripts/rose-mpi-launch
@@ -237,9 +237,14 @@ fi
 ROSE_LAUNCHER_BASE=
 if [[ -n $ROSE_LAUNCHER ]]; then
     # Path
-    if ! ROSE_LAUNCHER_PATH="$(type -P "$ROSE_LAUNCHER")"; then
-        err "ROSE_LAUNCHER: $ROSE_LAUNCHER: command not found"
-    fi
+    ROSE_LAUNCHER_PATH=""
+    for command in ${ROSE_LAUNCHER}; do
+        if  command="$(type -P "$command")"; then
+            ROSE_LAUNCHER_PATH="${ROSE_LAUNCHER_PATH} ${command}"
+        else
+            err "ROSE_LAUNCHER: $ROSE_LAUNCHER: command not found"
+        fi
+    done
     ROSE_LAUNCHER=$ROSE_LAUNCHER_PATH
     ROSE_LAUNCHER_BASE="$(basename "$ROSE_LAUNCHER")"
 fi
@@ -247,6 +252,7 @@ fi
 #-------------------------------------------------------------------------------
 # 3. Launch the program.
 #-------------------------------------------------------------------------------
+
 if [[ -n $ROSE_COMMAND_FILE ]]; then
     if [[ -z $ROSE_LAUNCHER_BASE ]]; then
         err "ROSE_LAUNCHER not defined, command file not supported."

--- a/metomi/rose/scripts/rose-mpi-launch
+++ b/metomi/rose/scripts/rose-mpi-launch
@@ -236,7 +236,9 @@ fi
 #-------------------------------------------------------------------------------
 ROSE_LAUNCHER_BASE=
 if [[ -n $ROSE_LAUNCHER ]]; then
-    # Path
+    # ROSE_LAUNCHER should be able to contain multiple commands.
+    # Each command should be handled separately by `type -P` so we must
+    # allow word splitting.
     # shellcheck disable=SC2086
     if ! ROSE_LAUNCHER_PATH="$(type -P $ROSE_LAUNCHER)"; then
         err "ROSE_LAUNCHER: $ROSE_LAUNCHER: command not found"

--- a/metomi/rose/scripts/rose-mpi-launch
+++ b/metomi/rose/scripts/rose-mpi-launch
@@ -237,14 +237,9 @@ fi
 ROSE_LAUNCHER_BASE=
 if [[ -n $ROSE_LAUNCHER ]]; then
     # Path
-    ROSE_LAUNCHER_PATH=""
-    for command in ${ROSE_LAUNCHER}; do
-        if  command="$(type -P $command)"; then
-            ROSE_LAUNCHER_PATH="${ROSE_LAUNCHER_PATH} ${command}"
-        else
-            err "ROSE_LAUNCHER: $ROSE_LAUNCHER: command not found"
-        fi
-    done
+    if ! ROSE_LAUNCHER_PATH="$(type -P $ROSE_LAUNCHER)"; then
+        err "ROSE_LAUNCHER: $ROSE_LAUNCHER: command not found"
+    fi
     ROSE_LAUNCHER=$ROSE_LAUNCHER_PATH
     ROSE_LAUNCHER_BASE="$(basename "$ROSE_LAUNCHER")"
 fi

--- a/metomi/rose/scripts/rose-mpi-launch
+++ b/metomi/rose/scripts/rose-mpi-launch
@@ -237,6 +237,7 @@ fi
 ROSE_LAUNCHER_BASE=
 if [[ -n $ROSE_LAUNCHER ]]; then
     # Path
+    # shellcheck disable=SC2086
     if ! ROSE_LAUNCHER_PATH="$(type -P $ROSE_LAUNCHER)"; then
         err "ROSE_LAUNCHER: $ROSE_LAUNCHER: command not found"
     fi

--- a/t/rose-mpi-launch/03-commands.t
+++ b/t/rose-mpi-launch/03-commands.t
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+#-------------------------------------------------------------------------------
+# Copyright (C) British Crown (Met Office) & Contributors.
+#
+# This file is part of Rose, a framework for meteorological suites.
+#
+# Rose is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Rose is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Rose. If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test "rose mpi-launch" with multiple commands; e.g.
+#   $ export ROSE_LAUNCHER="time mpiexec"
+#   $ rose mpi-launch -v true
+#
+# Should work through each command.
+#
+# Response to bug @https://github.com/metomi/rose/issues/2573
+#-------------------------------------------------------------------------------
+. $(dirname $0)/test_header
+tests 4
+#-------------------------------------------------------------------------------
+true_path=$(which true)
+ls_path=$(which ls)
+time_path=$(which time)
+
+# Control - test that having one command in "ROSE_LAUNCHER" still works.
+TEST_NAME="${TEST_KEY_BASE}-check-single-path"
+export ROSE_LAUNCHER="ls"
+run_pass ${TEST_NAME} rose mpi-launch -v true
+file_grep \
+    "${TEST_NAME}-output" \
+    "exec ${ls_path} ${true_path}"\
+    "${TEST_NAME}.out"
+
+# Test - test having multiple commands in "ROSE_LAUNCHER".
+TEST_NAME="${TEST_KEY_BASE}-check-multiple-paths"
+export ROSE_LAUNCHER="time ls"
+run_pass ${TEST_NAME} rose mpi-launch -v true
+
+file_grep \
+    "${TEST_NAME}-output" \
+    "exec ${time_path} ${ls_path} ${true_path}"\
+    "${TEST_NAME}.out"

--- a/t/rose-mpi-launch/03-commands.t
+++ b/t/rose-mpi-launch/03-commands.t
@@ -35,7 +35,7 @@ time_path=$(which time)
 # Control - test that having one command in "ROSE_LAUNCHER" still works.
 TEST_NAME="${TEST_KEY_BASE}-check-single-path"
 export ROSE_LAUNCHER="ls"
-run_pass ${TEST_NAME} rose mpi-launch -v true
+run_pass "${TEST_NAME}" rose mpi-launch -v true
 file_grep \
     "${TEST_NAME}-output" \
     "exec ${ls_path} ${true_path}"\
@@ -44,7 +44,7 @@ file_grep \
 # Test - test having multiple commands in "ROSE_LAUNCHER".
 TEST_NAME="${TEST_KEY_BASE}-check-multiple-paths"
 export ROSE_LAUNCHER="time ls"
-run_pass ${TEST_NAME} rose mpi-launch -v true
+run_pass "${TEST_NAME}" rose mpi-launch -v true
 
 file_grep \
     "${TEST_NAME}-output" \


### PR DESCRIPTION
closes #2573 

## Summary of problem
Rose MPI launch fails if `ROSE_LAUNCHER` contains spaces.