### PR TITLE
Rose env cat fix

### DIFF
--- a/metomi/rose/env_cat.py
+++ b/metomi/rose/env_cat.py
@@ -30,12 +30,18 @@ def rose_env_cat(args, opts):
     if not opts.output_file or opts.output_file == "-":
         out_handle = sys.stdout
     else:
-        out_handle = open(opts.output_file, "wb")
+        out_handle = open(opts.output_file, "w")
     for arg in args:
         if arg == "-":
             in_handle = sys.stdin
         else:
-            in_handle = open(arg)
+            try:
+                in_handle = open(arg)
+            except FileNotFoundError as exc:
+                Reporter().report(exc)
+                if opts.debug_mode:
+                    raise exc
+                return
         line_num = 0
         while True:
             line_num += 1

--- a/metomi/rose/env_cat.py
+++ b/metomi/rose/env_cat.py
@@ -19,8 +19,42 @@
 
 import sys
 
+from metomi.rose.reporter import Reporter
 from metomi.rose.env import UnboundEnvironmentVariableError, env_var_process
 from metomi.rose.opt_parse import RoseOptionParser
+
+
+def rose_env_cat(args, opts):
+    if not args:
+        args = ["-"]
+    if not opts.output_file or opts.output_file == "-":
+        out_handle = sys.stdout
+    else:
+        out_handle = open(opts.output_file, "wb")
+    for arg in args:
+        if arg == "-":
+            in_handle = sys.stdin
+        else:
+            in_handle = open(arg)
+        line_num = 0
+        while True:
+            line_num += 1
+            line = in_handle.readline()
+            if not line:
+                break
+            try:
+                out_handle.write(
+                    env_var_process(
+                        line, opts.unbound, opts.match_mode
+                    )
+                )
+            except UnboundEnvironmentVariableError as exc:
+                name = arg
+                if arg == "-":
+                    name = "<STDIN>"
+                sys.exit("%s:%s: %s" % (name, line_num, str(exc)))
+        in_handle.close()
+    out_handle.close()
 
 
 def main():
@@ -54,34 +88,7 @@ EXAMPLES
         ),
     )
     opts, args = opt_parser.parse_args()
-    if not args:
-        args = ["-"]
-    if not opts.output_file or opts.output_file == "-":
-        out_handle = sys.stdout
-    else:
-        out_handle = open(opts.output_file, "wb")
-    for arg in args:
-        if arg == "-":
-            in_handle = sys.stdin
-        else:
-            in_handle = open(arg)
-        line_num = 0
-        while True:
-            line_num += 1
-            line = in_handle.readline()
-            if not line:
-                break
-            try:
-                out_handle.write(
-                    env_var_process(line, opts.unbound, opts.match_mode)
-                )
-            except UnboundEnvironmentVariableError as exc:
-                name = arg
-                if arg == "-":
-                    name = "<STDIN>"
-                sys.exit("%s:%s: %s" % (name, line_num, str(exc)))
-        in_handle.close()
-    out_handle.close()
+    rose_env_cat(args, opts)
 
 
 if __name__ == "__main__":

--- a/metomi/rose/tests/test_env_cat.py
+++ b/metomi/rose/tests/test_env_cat.py
@@ -1,0 +1,67 @@
+# Copyright (C) British Crown (Met Office) & Contributors.
+# This file is part of Rose, a framework for meteorological suites.
+#
+# Rose is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Rose is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Rose. If not, see <http://www.gnu.org/licenses/>.
+# -----------------------------------------------------------------------------
+"""Tests for metomi.rose.env_cat
+
+Incomplete coverage - scenarios covered:
+- If input file not found log sensible error.
+- Output file is written.
+"""
+
+import pytest
+
+from types import SimpleNamespace
+
+from metomi.rose.env_cat import rose_env_cat
+
+
+def test_output_to_file(tmp_path, monkeypatch):
+    """It writes output to file.
+    """
+    inputfile = tmp_path / 'inputfile'
+    outputfile = tmp_path / 'outputfile'
+    inputfile.write_text(r'Hello ${WORLD}')
+    monkeypatch.setenv('WORLD', 'Jupiter')
+
+    opts = SimpleNamespace(
+        match_mode=None,
+        output_file=str(outputfile),
+        unbound=None
+    )
+    args = [str(inputfile)]
+
+    assert rose_env_cat(args, opts) is None
+    assert outputfile.read_text() == 'Hello Jupiter'
+
+
+@pytest.mark.parametrize('debug_mode', (True, False))
+def test_no_input_file_handled(tmp_path, debug_mode, capsys):
+    """It raises a nice error when there is no input file.
+    """
+    inputfile = tmp_path / 'inputfile'
+    opts = SimpleNamespace(
+        match_mode=None,
+        output_file=None,
+        unbound=None,
+        debug_mode=debug_mode
+    )
+    args = [str(inputfile)]
+    if debug_mode:
+        with pytest.raises(FileNotFoundError):
+            rose_env_cat(args, opts)
+    else:
+        rose_env_cat(args, opts)
+        assert 'No such file or directory' in capsys.readouterr().err


### PR DESCRIPTION
Fixes two bugs found by tester.

#### Missing input file produces traceback
Handle this more elegantly.

#### Write to output file doesn't work
Trying to write a string to a file handle opened in bytes mode.

#### Testing/Refactor
The first commit is a refactor without functional changes to allow for testing, and tests for the issues described. Checking f8126199 out should cause two of the three tests (`pytest metomi/rose/tests/test_env_cat.py   -vv`) to fail.

The second commit 1abaca8fe3ae7ef655baf1cffab30a60a532704b fixes both problems.

#### Additional check
By inserting print statements into the code I was able to ascertain that there coverage is now ~100%, though this is only a measure of quantity, not quality.

Tagged @oliver-sanders as a single Python test :. this is a smallish change with @dpmatthews as a functional tester.
