### PR TITLE
make cylc8 check compatible with python 2.6

### DIFF
--- a/lib/python/rose/suite_run.py
+++ b/lib/python/rose/suite_run.py
@@ -499,7 +499,7 @@ class SuiteRunner(Runner):
         # Checking through the children of the destination path to a maximum
         # depth of max_depth.
         patterns = [
-            destpath + '{}/'.format("/*"*i) + banned_file
+            destpath + '{_}/'.format(_="/*"*i) + banned_file
             for i in range(scan_depth)
             for banned_file in ['_cylc-install', 'flow.cylc']
         ]


### PR DESCRIPTION
Some deployments of Rose 2019 use Python 2 where the following snippet doesn't work:

```python
# Python 2.6
>>> "{}".format('foo')  
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ValueError: zero length field name in format
>>> "{_}".format('foo')
```

This led to a problem with the Cylc 8 checking method.

### To test
```bash
> ssh machine-with-python3.6-rose
# make a workflow
# before
> rose suite-run
[FAIL] zero length field name in format
> cd your/rose
> git co <this-branch>
> export ROSE_HOME=your/rose
> rose suite-run
```

Also checked that I haven't used format in changing 2019.01.5 → .6 anywhere else.
