### PR TITLE
Add a scheduled check that the tests work

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,8 @@ on:
       cylc_repo:
         description: The Cylc repo to test against
         required: false
+  schedule:
+  - cron: '37 04 * * 1-5' # 03:37, Monday-Friday
 
 defaults:
   run:

--- a/t/rose-task-run/14-app-prune-remove.t
+++ b/t/rose-task-run/14-app-prune-remove.t
@@ -32,7 +32,7 @@ get_reg
 TEST_KEY="${TEST_KEY_BASE}-install"
 run_pass "$TEST_KEY" \
     cylc install \
-        -C "$TEST_SOURCE_DIR/$TEST_KEY_BASE" \
+        "$TEST_SOURCE_DIR/$TEST_KEY_BASE" \
         --flow-name="$FLOW" \
         --no-run-name
 TEST_KEY="${TEST_KEY_BASE}-play"


### PR DESCRIPTION
Having just discovered that the tests have been failing on master for 19 days since https://github.com/cylc/cylc-flow/pull/4823 was merged I propose the addition of a daily run of the test battery on weekdays so that repository subscribers get to see a problem early.