### PR TITLE
Allow get_task_auth (used by fcm make) to return None if

### DIFF
--- a/metomi/rose/suite_engine_procs/cylc.py
+++ b/metomi/rose/suite_engine_procs/cylc.py
@@ -107,7 +107,12 @@ class CylcProcessor(SuiteEngineProcessor):
         from cylc.flow.exceptions import WorkflowFilesError
         from cylc.flow.hostuserutil import is_remote_platform
         from cylc.flow.platforms import get_host_from_platform
-        from cylc.rose.platform_utils import get_platform_from_task_def
+
+        try:
+            from cylc.rose.platform_utils import get_platform_from_task_def
+        except ModuleNotFoundError:
+            return None
+
         try:
             platform = get_platform_from_task_def(suite_name, task_name)
         except KeyError:

--- a/metomi/rose/suite_engine_procs/cylc.py
+++ b/metomi/rose/suite_engine_procs/cylc.py
@@ -109,10 +109,10 @@ class CylcProcessor(SuiteEngineProcessor):
         from cylc.flow.platforms import get_host_from_platform
         try:
             from cylc.rose.platform_utils import get_platform_from_task_def
-        except ModuleImportError:
+        except ModuleNotFoundError:
             # Allow single stage fcm_make app to work without requiring
             # cylc.rose
-            return None 
+            return None
 
         try:
             platform = get_platform_from_task_def(suite_name, task_name)

--- a/metomi/rose/suite_engine_procs/cylc.py
+++ b/metomi/rose/suite_engine_procs/cylc.py
@@ -107,8 +107,11 @@ class CylcProcessor(SuiteEngineProcessor):
         from cylc.flow.exceptions import WorkflowFilesError
         from cylc.flow.hostuserutil import is_remote_platform
         from cylc.flow.platforms import get_host_from_platform
-
-            # Allow single stage fcm_make app to work without requiring cylc.rose
+        try:
+            from cylc.rose.platform_utils import get_platform_from_task_def
+        except:
+            # Allow single stage fcm_make app to work without requiring
+            # cylc.rose
             return None 
 
         try:

--- a/metomi/rose/suite_engine_procs/cylc.py
+++ b/metomi/rose/suite_engine_procs/cylc.py
@@ -109,7 +109,7 @@ class CylcProcessor(SuiteEngineProcessor):
         from cylc.flow.platforms import get_host_from_platform
         try:
             from cylc.rose.platform_utils import get_platform_from_task_def
-        except:
+        except ModuleImportError:
             # Allow single stage fcm_make app to work without requiring
             # cylc.rose
             return None 

--- a/metomi/rose/suite_engine_procs/cylc.py
+++ b/metomi/rose/suite_engine_procs/cylc.py
@@ -108,10 +108,8 @@ class CylcProcessor(SuiteEngineProcessor):
         from cylc.flow.hostuserutil import is_remote_platform
         from cylc.flow.platforms import get_host_from_platform
 
-        try:
-            from cylc.rose.platform_utils import get_platform_from_task_def
-        except ModuleNotFoundError:
-            return None
+            # Allow single stage fcm_make app to work without requiring cylc.rose
+            return None 
 
         try:
             platform = get_platform_from_task_def(suite_name, task_name)

--- a/metomi/rose/suite_engine_procs/cylc.py
+++ b/metomi/rose/suite_engine_procs/cylc.py
@@ -98,9 +98,16 @@ class CylcProcessor(SuiteEngineProcessor):
     ) -> Union[str, None]:
         """Get host for a remote task from a Cylc workflow definition.
 
-        Returns: Hostname or None if:
+        Returns: Hostname, or None if:
           - task does not run remotely.
           - task has not been defined.
+          - cylc-rose is not installed(*)
+
+        (*) This function is only used by the fcm_make built-in app. Returning
+        None is equivalent to there being no fcm_make2 task found or no
+        workflow file found which is fine - 2 stage fcm_make is only supported
+        on the localhost install target (the workflow files aren't mirrored).
+
         """
         # n.b. Imports inside function to avoid dependency on Cylc and
         # Cylc-Rose is Rose is being used with a different workflow engine.


### PR DESCRIPTION
cylc.rose is not installed.

Proved horrendous to test - @dpmatthews  - can you test manually, whilst @oliver-sanders checks for Python goodness?