### PR TITLE
date: send warning to stderr not stdout

### DIFF
--- a/metomi/rose/date.py
+++ b/metomi/rose/date.py
@@ -441,13 +441,10 @@ def upgrade_offset(offset: str) -> str:
 
     Examples:
         >>> upgrade_offset('1w')
-        [WARN] This offset syntax 1w is deprecated: Using P7DT0H0M0S
         'P7DT0H0M0S'
         >>> upgrade_offset('1w1d1h')
-        [WARN] This offset syntax 1w1d1h is deprecated: Using P8DT1H0M0S
         'P8DT1H0M0S'
         >>> upgrade_offset('1h1d')
-        [WARN] This offset syntax 1h1d is deprecated: Using P1DT1H0M0S
         'P1DT1H0M0S'
     """
 

--- a/metomi/rose/date.py
+++ b/metomi/rose/date.py
@@ -474,9 +474,9 @@ def upgrade_offset(offset: str) -> str:
 
     result = f'{sign}P{days}DT{hours}H{minutes}M{seconds}S'
 
-    Reporter().report(
-        f'This offset syntax {offset} is deprecated: Using {result}',
-        prefix=Reporter.PREFIX_WARN, level=Reporter.WARN
+    print(
+        f'[WARN] This offset syntax {offset} is deprecated: Using {result}',
+        file=sys.stderr,
     )
 
     return result

--- a/metomi/rose/date_cli.py
+++ b/metomi/rose/date_cli.py
@@ -188,10 +188,8 @@ def _handle_old_offsets(args: list) -> list:
 
     Examples:
     >>> _handle_old_offsets(['rose-date', '--offset=1d1s'])
-    [WARN] This offset syntax 1d1s is deprecated: Using P1DT0H0M1S
     ['rose-date', '--offset=P1DT0H0M1S']
     >>> _handle_old_offsets(['rose-date', '-s', '1d1s'])
-    [WARN] This offset syntax 1d1s is deprecated: Using P1DT0H0M1S
     ['rose-date', '-s', 'P1DT0H0M1S']
     """
     for index, arg in enumerate(args):

--- a/metomi/rose/tests/test_date_cli.py
+++ b/metomi/rose/tests/test_date_cli.py
@@ -95,4 +95,4 @@ def test__handle_old_offsets(args, expect, warn, capsys):
     """
     assert _handle_old_offsets(args.split(' ')) == expect.split(' ')
     if warn:
-        assert capsys.readouterr().out == warn
+        assert capsys.readouterr().err == warn


### PR DESCRIPTION
Looks like the `Reporter()` instance didn't check out the way we would have expected it to, easier just to `print()` for the time being.