### PR TITLE
Changed Links to point to Cylc 8 "stable"

### DIFF
--- a/sphinx/api/configuration/suite.rst
+++ b/sphinx/api/configuration/suite.rst
@@ -29,7 +29,7 @@ A suite directory may contain the following:
 * A ``meta/`` directory containing the suite's configuration metadata.
 * ``opt/`` directory. For detail, see :ref:`Optional Configuration`.
 * Other items, as long as they do not clash with the scheduler's working
-  directories. E.g. for a Cylc suite, ``log*/``, ``share/``, ``state/`` and
+  directories. E.g. for a Cylc workflow, ``log*/``, ``share/``, ``state/`` and
   ``work/`` should be avoided.
 
 .. rose:file:: rose-suite.conf
@@ -68,8 +68,8 @@ A suite directory may contain the following:
 
       .. rose:conf:: CYLC_VERSION=CYLC_VERSION_NUMBER
 
-         If specified for a Cylc suite, the Rose suite runner
-         will attempt to use this version of cylc.
+         If specified for a Cylc workflow, the Rose suite runner
+         will attempt to use this version of Cylc.
 
    .. rose:conf:: template variables
 

--- a/sphinx/conf.py
+++ b/sphinx/conf.py
@@ -77,7 +77,7 @@ else:
 
 # mapping to other Sphinx projects
 # (allows us to reference objects from other projects)
-cylc_version = 'latest'
+cylc_version = 'stable'
 intersphinx_mapping = {
     'cylc': (f'https://cylc.github.io/cylc-doc/{cylc_version}/html/', None),
     'python': ('https://docs.python.org/', None),

--- a/sphinx/glossary.rst
+++ b/sphinx/glossary.rst
@@ -11,7 +11,7 @@ Glossary
       Rose configurations are directories containing a Rose configuration
       file along with other optional files and directories.
 
-      The two types of Rose configuration relevant to Cylc suites are:
+      The two types of Rose configuration relevant to Cylc workflows are:
 
       * :term:`Rose application configuration`
       * :term:`Rose suite configuration`

--- a/sphinx/hyperlinks.rst
+++ b/sphinx/hyperlinks.rst
@@ -12,8 +12,8 @@
 .. _Cylc: https://cylc.github.io/
 .. _Cylc Flow: https://github.com/cylc/cylc-flow
 .. _Cylc Rose: https://github.com/cylc/cylc-rose
-.. _Cylc User Guide: https://cylc.github.io/cylc-doc/latest/html/user-guide/index.html
-.. _Cylc Suite Design Guide: https://cylc.github.io/cylc-doc/stable/html/suite-design-guide/suite-design-guide-master.html
+.. _Cylc User Guide: https://cylc.github.io/cylc-doc/stable/html/user-guide/index.html
+.. _Cylc Workflow Design Guide: https://cylc.github.io/cylc-doc/stable/html/workflow-design-guide/index.html
 
 .. _EmPy: http://www.alcyone.com/software/empy/
 .. _extglob pattern matching: https://www.gnu.org/software/bash/manual/html_node/Pattern-Matching.html#Pattern-Matching

--- a/sphinx/tutorial/rose/configurations.rst
+++ b/sphinx/tutorial/rose/configurations.rst
@@ -47,7 +47,7 @@ Rose Configuration Format
    along with other optional files and directories.
 
    All Rose configuration files use the same format which is based on the
-   `INI`_ file format. *Like* the file format for :ref:`Cylc suites
+   `INI`_ file format. *Like* the file format for :ref:`Cylc workflows
    <Cylc file format>`:
 
 .. ifslides::
@@ -63,7 +63,7 @@ Rose Configuration Format
 .. ifnotslides::
 
    However, there are also key differences, and *unlike* the file format for
-   :ref:`Cylc suites <Cylc file format>`:
+   :ref:`Cylc workflows <Cylc file format>`:
 
 .. ifslides::
 

--- a/sphinx/tutorial/rose/summary.rst
+++ b/sphinx/tutorial/rose/summary.rst
@@ -13,7 +13,7 @@ Suite Structure
 
 So far we have covered:
 
-* Cylc suites.
+* Cylc workflows.
 * Rose suite configurations.
 * Rosie suites.
 
@@ -124,7 +124,7 @@ Suite Commands
    :ref:`command-rose-app-run`
       Runs a Rose application.
    :ref:`command-rose-task-run`
-      Runs a Rose application from within a Cylc suite.
+      Runs a Rose application from within a Cylc workflow.
 
 .. ifslides::
 
@@ -209,7 +209,7 @@ Next Steps
    :ref:`Rose Configuration <rose-configuration>`
       The possible settings which can be used in the different Rose
       configuration files.
-   `Cylc Suite Design Guide`_
+   `Cylc workflow Design Guide`_
       Contains recommended best practice for the style and structure of Cylc
       suites.
 
@@ -218,7 +218,7 @@ Next Steps
    * :ref:`Rose Further Topics`
    * :ref:`Command Reference`
    * :ref:`Rose Configuration <rose-configuration>`
-   * `Cylc Suite Design Guide`_
+   * `Cylc workflow Design Guide`_
 
 .. TODO - write some JS or python extension for representing definition
           lists as bullet lists for the slides builder.


### PR DESCRIPTION
Updated instersphinx mapping
Fixed egregious instances of "Cylc Suite"

Closes #2457 

Marked as blocked until after Cylc 8.0.0 docs are changed to "stable"