### PR TITLE
Return a sensible warning popup if user presses play when Cylc Versio…

### DIFF
--- a/lib/python/rose/gtk/run.py
+++ b/lib/python/rose/gtk/run.py
@@ -20,8 +20,9 @@
 """Miscellaneous gtk mini-applications."""
 
 import multiprocessing
+from subprocess import check_output
 
-from rose.gtk.dialog import DialogProcess
+from rose.gtk.dialog import DialogProcess, run_dialog, DIALOG_TYPE_WARNING
 from rose.opt_parse import RoseOptionParser
 from rose.suite_run import SuiteRunner
 from rose.reporter import Reporter, ReporterContextQueue
@@ -29,6 +30,17 @@ from rose.reporter import Reporter, ReporterContextQueue
 
 def run_suite(*args):
     """Run "rose suite-run [args]" with a GTK dialog."""
+
+    # Check that we are not using Cylc 8: Else return a helpful message:
+    cylc_version = check_output(['cylc', 'version'])
+    if cylc_version[0] == '8':
+        run_dialog(
+            DIALOG_TYPE_WARNING,
+            '`rose suite-run` does not work with Cylc 8 workflows: '
+            'Use `cylc install`.',
+            'Cylc Version == 8'
+        )
+        return None
 
     # Set up reporter
     queue = multiprocessing.Manager().Queue()


### PR DESCRIPTION
…n == 8.x

Closes #2597 

## Summary

If the user presses the `rose suite-run` button in `rose edit` or `rosie go` return a sensible warning.

## How to test:

With the branch checked out:

```
PYTHONPATH=$PWD/lib/python:$PYTHONPATH ./bin/rosie go
PYTHONPATH=$PWD/lib/python:$PYTHONPATH ./bin/rose edit
```

Try pressing play.

n.b. if you haven't got any rosie workflows you may need to use the create button in Rosie to create one.