### PR TITLE
GH Actions: fix order of pip installation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -94,18 +94,18 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y shellcheck sqlite3 at graphviz graphviz-dev
 
+      - name: Install Rose
+        working-directory: rose
+        run: |
+          pip install ."[all]"
+          yarn install
+
       - name: Install Cylc libs
         uses: ./rose/.github/actions/install-libs
         with:
           cylc-flow-repo: ${{ inputs.cylc_flow_repo }}
           cylc-flow-ref: ${{ inputs.cylc_flow_ref }}
           cylc-rose-ref: ${{ inputs.cylc_rose_ref }}
-
-      - name: Install Rose
-        working-directory: rose
-        run: |
-          pip install ."[all]"
-          yarn install
 
       - name: Checkout FCM
         if: startsWith(matrix.os, 'ubuntu')
@@ -207,16 +207,16 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y graphviz pkg-config libgraphviz-dev
 
+      - name: Install Rose
+        run: |
+          pip install -e .[docs,graph]
+
       - name: Install Cylc libs
         uses: ./.github/actions/install-libs
         with:
           cylc-flow-repo: ${{ inputs.cylc_flow_repo }}
           cylc-flow-ref: ${{ inputs.cylc_flow_ref }}
           cylc-rose-ref: ${{ inputs.cylc_rose_ref }}
-
-      - name: Install Rose
-        run: |
-          pip install -e .[docs,graph]
 
       - name: build (html)
         run: |

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,15 @@ updated. Only the first match gets replaced, so it's fine to leave the old
 ones in. -->
 --------------------------------------------------------------------------------
 
+## 2.0.2 (<span actions:bind='release-date'>Upcoming</span>)
+
+### Fixes
+
+[#2608](https://github.com/metomi/rose/pull/2608) - Fix problems with the
+tutorials.
+
+--------------------------------------------------------------------------------
+
 ## 2.0.1 (<span actions:bind='release-date'>Released 2022-09-14</span>)
 
 ### Fixes


### PR DESCRIPTION
This was failing for master because when installing cylc-rose before rose, it was complaining it couldn't find rose 2.1

I've also added a missing changelog entry