### PR TITLE
Macro validation fix

### DIFF
--- a/.github/actions/install-libs/action.yml
+++ b/.github/actions/install-libs/action.yml
@@ -28,8 +28,8 @@ runs:
 
         # NOTE: hard-coded branches need to be manually updated as necessary.
         if [[ "$BASE_REF" == '2.0.x' ]]; then
-          : ${CYLC_FLOW_REF:='8.0.x'}
-          : ${CYLC_ROSE_REF:='1.1.x'}
+          : ${CYLC_FLOW_REF:='8.1.x'}
+          : ${CYLC_ROSE_REF:='master'}
         fi
 
         if [[ -n "$CYLC_FLOW_REF" ]]; then

--- a/.github/actions/install-libs/action.yml
+++ b/.github/actions/install-libs/action.yml
@@ -27,10 +27,10 @@ runs:
         BASE_REF="${GITHUB_BASE_REF:-$GITHUB_REF_NAME}"
 
         # NOTE: hard-coded branches need to be manually updated as necessary.
-        if [[ "$BASE_REF" == '2.0.x' ]]; then
-          : ${CYLC_FLOW_REF:='8.1.x'}
-          : ${CYLC_ROSE_REF:='master'}
-        fi
+        # if [[ "$BASE_REF" == '2.0.x' ]]; then
+        : ${CYLC_FLOW_REF:='8.1.x'}
+        : ${CYLC_ROSE_REF:='master'}
+        # fi
 
         if [[ -n "$CYLC_FLOW_REF" ]]; then
           CYLC_FLOW_GITHUB="${CYLC_FLOW_GITHUB}@${CYLC_FLOW_REF}"

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,17 @@ creating a new release entry be sure to copy & paste the span tag with the
 `actions:bind` attribute, which is used by a regex to find the text to be
 updated. Only the first match gets replaced, so it's fine to leave the old
 ones in. -->
+
+--------------------------------------------------------------------------------
+
+## 2.0.3 (<span actions:bind='release-date'>Coming Soon</span>)
+
+### Fixes
+
+[#2670](https://github.com/metomi/rose/pull/2670) - Rose Macro made to
+follow Python 2 type comparison rules.
+
+
 --------------------------------------------------------------------------------
 
 ## 2.0.2 (<span actions:bind='release-date'>Released 2022-11-08</span>)

--- a/metomi/rose/macros/rule.py
+++ b/metomi/rose/macros/rule.py
@@ -68,6 +68,8 @@ class MyInt(int):
             False
             >>> MyInt(42) < 42
             False
+            >>> MyInt(77) < ''
+            False
         """
         if isinstance(other, (int, float, MyFloat, MyInt)):
             return float(self) < float(other)
@@ -203,37 +205,29 @@ class MyStr(str):
             >>> MyStr('pink fairy armadillo') < 'syrian hamster'
             True
         """
-        if isinstance(other, (MyFloat, MyInt)):
+        if isinstance(other, (int, float, MyFloat, MyInt)):
             return False
         elif isinstance(other, MyStr):
             return str(self) < str(other)
         else:
             return str(self) < other
 
-    def __eq__(self, other):
+    def __gt__(self, other):
         """
         Examples:
-            >>> MyStr('foo') == MyFloat(444.2)
+            >>> MyStr('aardvaark') > MyStr('zebra')
             False
-            >>> MyStr('foo') == MyStr('foo')
+            >>> MyStr('alligator') > MyInt(400)
             True
-            >>> MyStr('bar') == MyStr('foo')
-            False
-            >>> MyStr('Bird of Paradise') == 'Seagull'
+            >>> MyStr('pink fairy armadillo') > 'syrian hamster'
             False
         """
-        if isinstance(other, (MyFloat, MyInt)):
-            return False
+        if isinstance(other, (int, float, MyFloat, MyInt)):
+            return True
         elif isinstance(other, MyStr):
-            return str(self) == str(other)
+            return str(self) > str(other)
         else:
-            return str(self) == other
-
-    def __gt__(self, other):
-        return (
-            not self.__lt__(other)
-            and not self.__eq__(other)
-        )
+            return str(self) > other
 
     def __le__(self, other):
         return not self.__gt__(other)

--- a/metomi/rose/macros/rule.py
+++ b/metomi/rose/macros/rule.py
@@ -50,25 +50,25 @@ REC_EXPR_IS_THIS_RULE = re.compile(
 )
 
 
-class MyInt(int):
+class Int(int):
     """Override integer to maintain Python2 style interface
     """
     def __lt__(self, other):
         """
         Examples:
-            >>> MyInt(4) < MyInt(6)
+            >>> Int(4) < Int(6)
             True
-            >>> MyInt(4) < MyFloat(6.1)
+            >>> Int(4) < Float(6.1)
             True
-            >>> MyInt(4) < MyStr('Zaphod Beeblebrox')
+            >>> Int(4) < Str('Zaphod Beeblebrox')
             True
-            >>> MyInt(99999) < MyStr('Zaphod Beeblebrox')
+            >>> Int(99999) < Str('Zaphod Beeblebrox')
             True
-            >>> MyInt(4) < MyFloat(-5.5)
+            >>> Int(4) < Float(-5.5)
             False
-            >>> MyInt(42) < 42
+            >>> Int(42) < 42
             False
-            >>> MyInt(77) < ''
+            >>> Int(77) < ''
             False
         """
         try:
@@ -79,9 +79,9 @@ class MyInt(int):
     def __gt__(self, other):
         """
         Examples:
-            >>> MyInt(2) > MyFloat(2.0)
+            >>> Int(2) > Float(2.0)
             False
-            >>> MyInt(3) > MyFloat(2.0)
+            >>> Int(3) > Float(2.0)
             True
         """
         try:
@@ -96,21 +96,21 @@ class MyInt(int):
         return not self.__lt__(other)
 
 
-class MyFloat(float):
+class Float(float):
     def __lt__(self, other):
         """
         Examples:
-            >>> MyInt(4) < MyInt(6)
+            >>> Int(4) < Int(6)
             True
-            >>> MyInt(4) < MyFloat(6.1)
+            >>> Int(4) < Float(6.1)
             True
-            >>> MyInt(4) < MyStr('Zaphod Beeblebrox')
+            >>> Int(4) < Str('Zaphod Beeblebrox')
             True
-            >>> MyInt(99999) < MyStr('Zaphod Beeblebrox')
+            >>> Int(99999) < Str('Zaphod Beeblebrox')
             True
-            >>> MyInt(4) < MyFloat(-5.5)
+            >>> Int(4) < Float(-5.5)
             False
-            >>> MyInt(1199) < 1199
+            >>> Int(1199) < 1199
             False
         """
         try:
@@ -121,9 +121,9 @@ class MyFloat(float):
     def __gt__(self, other):
         """
         Examples:
-            >>> MyInt(2) > MyFloat(2.0)
+            >>> Int(2) > Float(2.0)
             False
-            >>> MyInt(3) > MyFloat(2.0)
+            >>> Int(3) > Float(2.0)
             True
         """
         try:
@@ -138,20 +138,20 @@ class MyFloat(float):
         return not self.__lt__(other)
 
 
-class MyStr(str):
+class Str(str):
     def __lt__(self, other):
         """
         Examples:
-            >>> MyStr('aardvaark') < MyStr('zebra')
+            >>> Str('aardvaark') < Str('zebra')
             True
-            >>> MyStr('alligator') < MyInt(400)
+            >>> Str('alligator') < Int(400)
             False
-            >>> MyStr('pink fairy armadillo') < 'syrian hamster'
+            >>> Str('pink fairy armadillo') < 'syrian hamster'
             True
         """
-        if isinstance(other, (int, float, MyFloat, MyInt)):
+        if isinstance(other, (int, float, Float, Int)):
             return False
-        elif isinstance(other, MyStr):
+        elif isinstance(other, Str):
             return str(self) < str(other)
         else:
             return str(self) < other
@@ -159,16 +159,16 @@ class MyStr(str):
     def __gt__(self, other):
         """
         Examples:
-            >>> MyStr('aardvaark') > MyStr('zebra')
+            >>> Str('aardvaark') > Str('zebra')
             False
-            >>> MyStr('alligator') > MyInt(400)
+            >>> Str('alligator') > Int(400)
             True
-            >>> MyStr('pink fairy armadillo') > 'syrian hamster'
+            >>> Str('pink fairy armadillo') > 'syrian hamster'
             False
         """
-        if isinstance(other, (int, float, MyFloat, MyInt)):
+        if isinstance(other, (int, float, Float, Int)):
             return True
-        elif isinstance(other, MyStr):
+        elif isinstance(other, Str):
             return str(self) > str(other)
         else:
             return str(self) > other
@@ -180,7 +180,7 @@ class MyStr(str):
         return not self.__lt__(other)
 
 
-MYTYPES = {str: MyStr, int: MyInt, bool: MyInt, float: MyFloat}
+MYTYPES = {str: Str, int: Int, bool: Int, float: Float}
 
 
 class RuleValueError(Exception):

--- a/metomi/rose/macros/rule.py
+++ b/metomi/rose/macros/rule.py
@@ -71,35 +71,10 @@ class MyInt(int):
             >>> MyInt(77) < ''
             False
         """
-        if isinstance(other, (int, float, MyFloat, MyInt)):
-            return float(self) < float(other)
-        elif isinstance(other, MyStr):
-            return True
-        else:
-            return int(self) == other
-
-    def __eq__(self, other):
-        """
-        Examples:
-            >>> MyInt(22) == MyInt(22)
-            True
-            >>> MyInt(22) == MyInt(44)
-            False
-            >>> MyInt(22) == MyFloat(4.75734)
-            False
-            >>> MyInt(22) == MyFloat(22.0)
-            True
-            >>> MyInt(123) == MyStr('Hello World')
-            False
-            >>> MyInt(-77) == 'Viltvodle VI'
-            False
-        """
-        if isinstance(other, (int, float, MyFloat, MyInt)):
-            return float(self) == float(other)
-        elif isinstance(other, MyStr):
+        try:
+            return int(self) < other
+        except TypeError:
             return False
-        else:
-            return int(self) == other
 
     def __gt__(self, other):
         """
@@ -109,19 +84,16 @@ class MyInt(int):
             >>> MyInt(3) > MyFloat(2.0)
             True
         """
-        return (
-            not self.__lt__(other)
-            and not self.__eq__(other)
-        )
+        try:
+            return int(self) > other
+        except TypeError:
+            return True
 
     def __le__(self, other):
         return not self.__gt__(other)
 
     def __ge__(self, other):
         return not self.__lt__(other)
-
-    def __ne__(self, other):
-        return not self.__eq__(other)
 
 
 class MyFloat(float):
@@ -141,35 +113,10 @@ class MyFloat(float):
             >>> MyInt(1199) < 1199
             False
         """
-        if isinstance(other, (int, float, MyFloat, MyInt)):
+        try:
             return float(self) < float(other)
-        elif isinstance(other, MyStr):
+        except (TypeError, ValueError):
             return True
-        else:
-            return float(self) < other
-
-    def __eq__(self, other):
-        """
-        Examples:
-            >>> MyInt(22) == MyInt(22)
-            True
-            >>> MyInt(22) == MyInt(44)
-            False
-            >>> MyInt(22) == MyFloat(4.75734)
-            False
-            >>> MyInt(22) == MyFloat(22.0)
-            True
-            >>> MyInt(123) == MyStr('Hello World')
-            False
-            >>> MyInt(8000) == 8000.0
-            True
-        """
-        if isinstance(other, (int, float, MyFloat, MyInt)):
-            return float(self) == float(other)
-        elif isinstance(other, MyStr):
-            return False
-        else:
-            return float(self) == other
 
     def __gt__(self, other):
         """
@@ -179,19 +126,16 @@ class MyFloat(float):
             >>> MyInt(3) > MyFloat(2.0)
             True
         """
-        return (
-            not self.__lt__(other)
-            and not self.__eq__(other)
-        )
+        try:
+            return float(self) > float(other)
+        except (TypeError, ValueError):
+            return False
 
     def __le__(self, other):
         return not self.__gt__(other)
 
     def __ge__(self, other):
         return not self.__lt__(other)
-
-    def __ne__(self, other):
-        return not self.__eq__(other)
 
 
 class MyStr(str):
@@ -234,9 +178,6 @@ class MyStr(str):
 
     def __ge__(self, other):
         return not self.__lt__(other)
-
-    def __ne__(self, other):
-        return not self.__eq__(other)
 
 
 MYTYPES = {str: MyStr, int: MyInt, bool: MyInt, float: MyFloat}

--- a/metomi/rose/tests/macros/test_py2_compat_types.py
+++ b/metomi/rose/tests/macros/test_py2_compat_types.py
@@ -180,5 +180,6 @@ def test_python2_compat_classes(test):
         if isinstance(second, basetype):
             second = mytype(second)
 
+    assert (first <= second) != test[1]['gt']
     assert (first > second) == test[1]['gt']
     assert (first == second) == test[1]['eq']

--- a/metomi/rose/tests/macros/test_py2_compat_types.py
+++ b/metomi/rose/tests/macros/test_py2_compat_types.py
@@ -179,7 +179,5 @@ def test_python2_compat_classes(test):
             first = mytype(first)
         if isinstance(second, basetype):
             second = mytype(second)
-
-    assert (first <= second) != test[1]['gt']
     assert (first > second) == test[1]['gt']
     assert (first == second) == test[1]['eq']

--- a/metomi/rose/tests/macros/test_py2_compat_types.py
+++ b/metomi/rose/tests/macros/test_py2_compat_types.py
@@ -1,0 +1,184 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# Copyright (C) 2012-2020 British Crown (Met Office) & Contributors.
+#
+# This file is part of Rose, a framework for meteorological suites.
+#
+# Rose is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Rose is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Rose. If not, see <http://www.gnu.org/licenses/>.
+# -----------------------------------------------------------------------------
+"""
+Tests for Python 2 compatibility types
+
+These types MyInt, MyFloat and MyStr over-ride Python3 types
+to produce Python2 behaviour to provide back compatibility for Rose.
+
+The tests were generated as follows:
+
+#!/usr/bin/env python2
+# Examine what python2 does in a variety of cases
+
+import itertools
+
+floats = [-999.0, -5.1, -1., 0., 1., 5.1, 999.]
+ints = [-999, -5, -1, 0, 1, 5, 999]
+strings = ['aardvaark', 'zebra']
+
+data = {}
+for combo in itertools.permutations(floats + ints + strings, 2):
+    gt = combo[0] > combo[1]
+    eq = combo[0] == combo[1]
+    data[combo] = {}
+    data[combo]["gt"] = gt
+    data[combo]["eq"] = eq
+
+print(data)
+
+"""
+import pytest
+from metomi.rose.macros.rule import MyFloat, MyInt, MyStr
+
+TESTS = {
+    (1.0, "zebra"): {"gt": False, "eq": False},
+    ("zebra", 0.0): {"gt": True, "eq": False},
+    (-1.0, 0.0): {"gt": False, "eq": False},
+    (1.0, -5): {"gt": True, "eq": False},
+    (-999.0, 1.0): {"gt": False, "eq": False},
+    (5.1, "zebra"): {"gt": False, "eq": False},
+    ("zebra", -1.0): {"gt": True, "eq": False},
+    (-5, 1.0): {"gt": False, "eq": False},
+    (-5.1, 1.0): {"gt": False, "eq": False},
+    (999.0, -1.0): {"gt": True, "eq": False},
+    (-5.1, "aardvaark"): {"gt": False, "eq": False},
+    (-5, -5.1): {"gt": True, "eq": False},
+    (-999.0, -5): {"gt": False, "eq": False},
+    ("aardvaark", -999.0): {"gt": True, "eq": False},
+    ("zebra", 5): {"gt": True, "eq": False},
+    (-5.1, -5): {"gt": False, "eq": False},
+    (-1.0, 999.0): {"gt": False, "eq": False},
+    (1.0, 1): {"gt": False, "eq": True},
+    ("aardvaark", -5.1): {"gt": True, "eq": False},
+    (5, 999.0): {"gt": False, "eq": False},
+    (-999.0, 5.1): {"gt": False, "eq": False},
+    (0.0, "aardvaark"): {"gt": False, "eq": False},
+    (-1.0, "aardvaark"): {"gt": False, "eq": False},
+    (0.0, 1.0): {"gt": False, "eq": False},
+    (-5.1, "zebra"): {"gt": False, "eq": False},
+    (5.1, -5): {"gt": True, "eq": False},
+    (-999.0, -5.1): {"gt": False, "eq": False},
+    ("aardvaark", 0.0): {"gt": True, "eq": False},
+    (5, -1.0): {"gt": True, "eq": False},
+    (-999.0, 999.0): {"gt": False, "eq": False},
+    (-999.0, 5): {"gt": False, "eq": False},
+    (-5, 5.1): {"gt": False, "eq": False},
+    (-5, "aardvaark"): {"gt": False, "eq": False},
+    (5.1, 1.0): {"gt": True, "eq": False},
+    (-5, 5): {"gt": False, "eq": False},
+    (5.1, -1.0): {"gt": True, "eq": False},
+    (999.0, 5.1): {"gt": True, "eq": False},
+    (-1.0, 1.0): {"gt": False, "eq": False},
+    (5.1, "aardvaark"): {"gt": False, "eq": False},
+    (999.0, 1.0): {"gt": True, "eq": False},
+    ("aardvaark", 5): {"gt": True, "eq": False},
+    ("aardvaark", 1.0): {"gt": True, "eq": False},
+    (0.0, 999.0): {"gt": False, "eq": False},
+    (999.0, "aardvaark"): {"gt": False, "eq": False},
+    (1.0, 5): {"gt": False, "eq": False},
+    (-999.0, 0.0): {"gt": False, "eq": False},
+    (-1.0, -1): {"gt": False, "eq": True},
+    (-1.0, -5.1): {"gt": True, "eq": False},
+    (-5, 0.0): {"gt": False, "eq": False},
+    (-5, 999.0): {"gt": False, "eq": False},
+    (-5.1, 0.0): {"gt": False, "eq": False},
+    (0.0, 5.1): {"gt": False, "eq": False},
+    (999.0, 999): {"gt": False, "eq": True},
+    (-999.0, -999): {"gt": False, "eq": True},
+    (0.0, 5): {"gt": False, "eq": False},
+    (-999.0, "zebra"): {"gt": False, "eq": False},
+    (1.0, 0.0): {"gt": True, "eq": False},
+    (-1.0, -5): {"gt": True, "eq": False},
+    ("zebra", 5.1): {"gt": True, "eq": False},
+    (-5, "zebra"): {"gt": False, "eq": False},
+    ("aardvaark", -1.0): {"gt": True, "eq": False},
+    (-5.1, 5.1): {"gt": False, "eq": False},
+    (0.0, -1.0): {"gt": True, "eq": False},
+    (5.1, 5): {"gt": True, "eq": False},
+    (-5, -999.0): {"gt": True, "eq": False},
+    (-1.0, 5): {"gt": False, "eq": False},
+    (1.0, -5.1): {"gt": True, "eq": False},
+    (1.0, -1.0): {"gt": True, "eq": False},
+    ("zebra", "aardvaark"): {"gt": True, "eq": False},
+    (0.0, -5): {"gt": True, "eq": False},
+    (0.0, "zebra"): {"gt": False, "eq": False},
+    (1.0, -999.0): {"gt": True, "eq": False},
+    (5, 5.1): {"gt": False, "eq": False},
+    ("zebra", -5): {"gt": True, "eq": False},
+    (5.1, 0.0): {"gt": True, "eq": False},
+    (0.0, -5.1): {"gt": True, "eq": False},
+    (-5.1, -1.0): {"gt": False, "eq": False},
+    (999.0, 5): {"gt": True, "eq": False},
+    (-5, -1.0): {"gt": False, "eq": False},
+    (999.0, -5): {"gt": True, "eq": False},
+    (-1.0, 5.1): {"gt": False, "eq": False},
+    (5, -5.1): {"gt": True, "eq": False},
+    (-999.0, -1.0): {"gt": False, "eq": False},
+    (5, 0.0): {"gt": True, "eq": False},
+    (-999.0, "aardvaark"): {"gt": False, "eq": False},
+    (0.0, -999.0): {"gt": True, "eq": False},
+    (5.1, -999.0): {"gt": True, "eq": False},
+    ("aardvaark", -5): {"gt": True, "eq": False},
+    ("aardvaark", "zebra"): {"gt": False, "eq": False},
+    ("zebra", 999.0): {"gt": True, "eq": False},
+    (999.0, -5.1): {"gt": True, "eq": False},
+    ("zebra", -999.0): {"gt": True, "eq": False},
+    (5, "aardvaark"): {"gt": False, "eq": False},
+    (5.1, 999.0): {"gt": False, "eq": False},
+    (-5.1, -999.0): {"gt": True, "eq": False},
+    (5, 1.0): {"gt": True, "eq": False},
+    (5, -5): {"gt": True, "eq": False},
+    (1.0, 999.0): {"gt": False, "eq": False},
+    (999.0, 0.0): {"gt": True, "eq": False},
+    (5.1, -5.1): {"gt": True, "eq": False},
+    (1.0, 5.1): {"gt": False, "eq": False},
+    (5, -999.0): {"gt": True, "eq": False},
+    (-5.1, 5): {"gt": False, "eq": False},
+    ("aardvaark", 5.1): {"gt": True, "eq": False},
+    (-1.0, -999.0): {"gt": True, "eq": False},
+    ("aardvaark", 999.0): {"gt": True, "eq": False},
+    (0.0, 0): {"gt": False, "eq": True},
+    (-1.0, "zebra"): {"gt": False, "eq": False},
+    (-5.1, 999.0): {"gt": False, "eq": False},
+    (5, "zebra"): {"gt": False, "eq": False},
+    ("zebra", -5.1): {"gt": True, "eq": False},
+    (999.0, "zebra"): {"gt": False, "eq": False},
+    (1.0, "aardvaark"): {"gt": False, "eq": False},
+    (999.0, -999.0): {"gt": True, "eq": False},
+    ("zebra", 1.0): {"gt": True, "eq": False},
+}
+MYTYPES = {int: MyInt, float: MyFloat, str: MyStr}
+
+
+@pytest.mark.parametrize('test', TESTS.items())
+def test_python2_compat_classes(test):
+    """Subclassed types (MYTYPES.values) behave like Python2 types.
+    """
+    first, second = test[0]
+    # Convert test values from base to subclassed types:
+    for basetype, mytype in MYTYPES.items():
+        if isinstance(first, basetype):
+            first = mytype(first)
+        if isinstance(second, basetype):
+            second = mytype(second)
+
+    assert (first > second) == test[1]['gt']
+    assert (first == second) == test[1]['eq']

--- a/metomi/rose/tests/macros/test_py2_compat_types.py
+++ b/metomi/rose/tests/macros/test_py2_compat_types.py
@@ -20,7 +20,7 @@
 """
 Tests for Python 2 compatibility types
 
-These types MyInt, MyFloat and MyStr over-ride Python3 types
+These types Int, Float and Str over-ride Python3 types
 to produce Python2 behaviour to provide back compatibility for Rose.
 
 The tests were generated as follows:
@@ -46,7 +46,7 @@ print(data)
 
 """
 import pytest
-from metomi.rose.macros.rule import MyFloat, MyInt, MyStr
+from metomi.rose.macros.rule import Float, Int, Str
 
 TESTS = {
     (1.0, "zebra"): {"gt": False, "eq": False},
@@ -165,7 +165,7 @@ TESTS = {
     (999.0, -999.0): {"gt": True, "eq": False},
     ("zebra", 1.0): {"gt": True, "eq": False},
 }
-MYTYPES = {int: MyInt, float: MyFloat, str: MyStr}
+MYTYPES = {int: Int, float: Float, str: Str}
 
 
 @pytest.mark.parametrize('test', TESTS.items())


### PR DESCRIPTION
Closes #2662 .

Following the instructions in the issue the following error is seen:

```
Invalid trigger expression: this < 1
```
The underlying cause is at `metomi/rose/macros/rule.py:214` is that type comparisons are not the same at Python 3 for base types as they are at Python 2.

```
(Pdb) template.render(rule_id_values)
*** TypeError: '<' not supported between instances of 'str' and 'int'
```

@oliver-sanders  suggested the following workarounds (in order of preference):

> Order of preference:
> 1a. Try to overwrite the str. float, bool & int, __lt__, __gt__, __ge__, __le__ methods used by Jinja2. 
> 1b. You may be able to do this by subclassing str, float, int etc as I started.
>       You may be able to do this by redefining them in the Python environment before calling Jinja2.
>
> 2. try/except cascade 
> try/except(TypeError)If this == '', then this=-999999999999999999999999999999try/except(TypeError)this = Falsetry/except(TypeError)raise
>
> 3. Cry

This PR uses approach 1a. 😃 