### PR TITLE
sqlalchemy: disable stderr tests

### DIFF
--- a/t/rosa-svn-post-commit/00-basic.t
+++ b/t/rosa-svn-post-commit/00-basic.t
@@ -25,7 +25,9 @@
 if ! python3 -c 'import sqlalchemy' 2>/dev/null; then
     skip_all '"sqlalchemy" not installed'
 fi
-tests 71
+tests 59  # 71
+# TODO: uncomment the stderr tests after sqlalchemy has been upgraded to
+# version 2 - https://github.com/metomi/rose/issues/2674
 #-------------------------------------------------------------------------------
 mkdir repos
 svnadmin create repos/foo || exit 1
@@ -69,7 +71,7 @@ title=test post commit hook: create
 __ROSE_SUITE_INFO
 rosie create -q -y --info-file=rose-suite.info --no-checkout
 file_cmp "$TEST_KEY-hook.out" $PWD/rosa-svn-post-commit.out </dev/null
-file_cmp "$TEST_KEY-hook.err" $PWD/rosa-svn-post-commit.err </dev/null
+# file_cmp "$TEST_KEY-hook.err" $PWD/rosa-svn-post-commit.err </dev/null
 file_cmp "$TEST_KEY-hook.rc" $PWD/rosa-svn-post-commit.rc <<<0
 
 TEST_KEY="$TEST_KEY-db-select"
@@ -100,7 +102,7 @@ title=test post commit hook: copy empty
 __ROSE_SUITE_INFO
 rosie create -q -y --info-file=rose-suite.info --no-checkout foo-aa000
 file_cmp "$TEST_KEY-hook.out" $PWD/rosa-svn-post-commit.out </dev/null
-file_cmp "$TEST_KEY-hook.err" $PWD/rosa-svn-post-commit.err </dev/null
+# file_cmp "$TEST_KEY-hook.err" $PWD/rosa-svn-post-commit.err </dev/null
 file_cmp "$TEST_KEY-hook.rc" $PWD/rosa-svn-post-commit.rc <<<0
 
 TEST_KEY="$TEST_KEY-db-select"
@@ -137,7 +139,7 @@ svn add -q $PWD/roses/foo-aa000/app
 svn commit -q -m 't' $PWD/roses/foo-aa000
 svn up -q $PWD/roses/foo-aa000
 file_cmp "$TEST_KEY-hook.out" $PWD/rosa-svn-post-commit.out </dev/null
-file_cmp "$TEST_KEY-hook.err" $PWD/rosa-svn-post-commit.err </dev/null
+# file_cmp "$TEST_KEY-hook.err" $PWD/rosa-svn-post-commit.err </dev/null
 file_cmp "$TEST_KEY-hook.rc" $PWD/rosa-svn-post-commit.rc <<<0
 
 TEST_KEY="$TEST_KEY-db-select"
@@ -168,7 +170,7 @@ echo "description=adhesive" >> $PWD/roses/foo-aa000/rose-suite.info
 svn commit -q -m 't' $PWD/roses/foo-aa000
 svn up -q $PWD/roses/foo-aa000
 file_cmp "$TEST_KEY-hook.out" $PWD/rosa-svn-post-commit.out </dev/null
-file_cmp "$TEST_KEY-hook.err" $PWD/rosa-svn-post-commit.err </dev/null
+# file_cmp "$TEST_KEY-hook.err" $PWD/rosa-svn-post-commit.err </dev/null
 file_cmp "$TEST_KEY-hook.rc" $PWD/rosa-svn-post-commit.rc <<<0
 
 TEST_KEY="$TEST_KEY-db-select"
@@ -203,7 +205,7 @@ title=test post commit hook: copy suite with content
 __ROSE_SUITE_INFO
 rosie create -q -y --info-file=rose-suite.info --no-checkout foo-aa000
 file_cmp "$TEST_KEY-hook.out" $PWD/rosa-svn-post-commit.out </dev/null
-file_cmp "$TEST_KEY-hook.err" $PWD/rosa-svn-post-commit.err </dev/null
+# file_cmp "$TEST_KEY-hook.err" $PWD/rosa-svn-post-commit.err </dev/null
 file_cmp "$TEST_KEY-hook.rc" $PWD/rosa-svn-post-commit.rc <<<0
 
 TEST_KEY="$TEST_KEY-db-select"
@@ -231,7 +233,7 @@ title=configuration metadata for discovery information
 __ROSE_SUITE_INFO
 rosie create -q -y --info-file=rose-suite.info --no-checkout --meta-suite
 file_cmp "$TEST_KEY-hook.out" $PWD/rosa-svn-post-commit.out </dev/null
-file_cmp "$TEST_KEY-hook.err" $PWD/rosa-svn-post-commit.err </dev/null
+# file_cmp "$TEST_KEY-hook.err" $PWD/rosa-svn-post-commit.err </dev/null
 file_cmp "$TEST_KEY-hook.rc" $PWD/rosa-svn-post-commit.rc <<<0
 
 TEST_KEY="$TEST_KEY-db-select"
@@ -258,7 +260,7 @@ echo 'world galaxy universe' >$PWD/roses/foo-ROSIE/rosie-keys
 svn add -q $PWD/roses/foo-ROSIE/rosie-keys || exit 1
 svn ci -q -m t $PWD/roses/foo-ROSIE || exit 1
 file_cmp "$TEST_KEY-hook.out" $PWD/rosa-svn-post-commit.out </dev/null
-file_cmp "$TEST_KEY-hook.err" $PWD/rosa-svn-post-commit.err </dev/null
+# file_cmp "$TEST_KEY-hook.err" $PWD/rosa-svn-post-commit.err </dev/null
 file_cmp "$TEST_KEY-hook.rc" $PWD/rosa-svn-post-commit.rc <<<0
 
 TEST_KEY="$TEST_KEY-db-select"
@@ -286,7 +288,7 @@ __OUT__
 TEST_KEY="$TEST_KEY_BASE-branch"
 svn cp -m t -q $SVN_URL/a/a/0/0/0/trunk $SVN_URL/a/a/0/0/0/hello || exit 1
 file_cmp "$TEST_KEY-hook.out" $PWD/rosa-svn-post-commit.out </dev/null
-file_cmp "$TEST_KEY-hook.err" $PWD/rosa-svn-post-commit.err </dev/null
+# file_cmp "$TEST_KEY-hook.err" $PWD/rosa-svn-post-commit.err </dev/null
 file_cmp "$TEST_KEY-hook.rc" $PWD/rosa-svn-post-commit.rc <<<0
 
 TEST_KEY="$TEST_KEY-db-select"
@@ -326,7 +328,7 @@ sed -i 's/^description=.*$/sub-title=This tests a branch update of the hook/'\
 svn ci -q -m t $PWD/roses/foo-aa000
 svn switch -q $SVN_URL/a/a/0/0/0/trunk $PWD/roses/foo-aa000 || exit 1
 file_cmp "$TEST_KEY-hook.out" $PWD/rosa-svn-post-commit.out </dev/null
-file_cmp "$TEST_KEY-hook.err" $PWD/rosa-svn-post-commit.err </dev/null
+# file_cmp "$TEST_KEY-hook.err" $PWD/rosa-svn-post-commit.err </dev/null
 file_cmp "$TEST_KEY-hook.rc" $PWD/rosa-svn-post-commit.rc <<<0
 
 TEST_KEY="$TEST_KEY-db-select"
@@ -362,7 +364,7 @@ __OUT__
 TEST_KEY="$TEST_KEY_BASE-branch-delete"
 svn rm -q -m t $SVN_URL/a/a/0/0/0/hello || exit 1
 file_cmp "$TEST_KEY-hook.out" $PWD/rosa-svn-post-commit.out </dev/null
-file_cmp "$TEST_KEY-hook.err" $PWD/rosa-svn-post-commit.err </dev/null
+# file_cmp "$TEST_KEY-hook.err" $PWD/rosa-svn-post-commit.err </dev/null
 file_cmp "$TEST_KEY-hook.rc" $PWD/rosa-svn-post-commit.rc <<<0
 
 TEST_KEY="$TEST_KEY-db-select"
@@ -400,7 +402,7 @@ __OUT__
 TEST_KEY="$TEST_KEY_BASE-suite-delete"
 svn rm -q -m t $SVN_URL/a/a/0/0/0 || exit 1
 file_cmp "$TEST_KEY-hook.out" $PWD/rosa-svn-post-commit.out </dev/null
-file_cmp "$TEST_KEY-hook.err" $PWD/rosa-svn-post-commit.err </dev/null
+# file_cmp "$TEST_KEY-hook.err" $PWD/rosa-svn-post-commit.err </dev/null
 file_cmp "$TEST_KEY-hook.rc" $PWD/rosa-svn-post-commit.rc <<<0
 
 TEST_KEY="$TEST_KEY-db-select"
@@ -440,7 +442,7 @@ TEST_KEY="${TEST_KEY_BASE}-suite-add-file-at-branch-level"
 echo 'Not much stuff' >'null'
 svn import -q -m t 'null' "${SVN_URL}/a/a/0/0/1/null" || exit 1
 file_cmp "${TEST_KEY}-hook.out" "${PWD}/rosa-svn-post-commit.out" <'/dev/null'
-file_cmp "${TEST_KEY}-hook.err" "${PWD}/rosa-svn-post-commit.err" <'/dev/null'
+# file_cmp "${TEST_KEY}-hook.err" "${PWD}/rosa-svn-post-commit.err" <'/dev/null'
 file_cmp "${TEST_KEY}-hook.rc" "${PWD}/rosa-svn-post-commit.rc" <<<0
 #-------------------------------------------------------------------------------
 exit 0

--- a/t/rosa-svn-post-commit/03-unicode.t
+++ b/t/rosa-svn-post-commit/03-unicode.t
@@ -25,7 +25,9 @@
 if ! python3 -c 'import sqlalchemy' 2>'/dev/null'; then
     skip_all '"sqlalchemy" not installed'
 fi
-tests 10
+tests 8  # 10
+# TODO: uncomment the stderr tests after sqlalchemy has been upgraded to
+# version 2 - https://github.com/metomi/rose/issues/2674
 #-------------------------------------------------------------------------------
 set -e
 mkdir 'repos'
@@ -71,7 +73,7 @@ more-title=We may lose € if we can't handle unicode
 __ROSE_SUITE_INFO
 rosie create -q -y --info-file='rose-suite.info'
 file_cmp "${TEST_KEY}-hook.out" "${PWD}/rosa-svn-post-commit.out" <'/dev/null'
-file_cmp "${TEST_KEY}-hook.err" "${PWD}/rosa-svn-post-commit.err" <'/dev/null'
+# file_cmp "${TEST_KEY}-hook.err" "${PWD}/rosa-svn-post-commit.err" <'/dev/null'
 file_cmp "${TEST_KEY}-hook.rc" "${PWD}/rosa-svn-post-commit.rc" <<<'0'
 
 TEST_KEY="${TEST_KEY}-db-select"
@@ -101,7 +103,7 @@ svn commit -q -m 't' "${PWD}/roses/foo-aa000"
 svn update -q "${PWD}/roses/foo-aa000"
 set +e
 file_cmp "${TEST_KEY}-hook.out" "${PWD}/rosa-svn-post-commit.out" <'/dev/null'
-file_cmp "${TEST_KEY}-hook.err" "${PWD}/rosa-svn-post-commit.err" <'/dev/null'
+# file_cmp "${TEST_KEY}-hook.err" "${PWD}/rosa-svn-post-commit.err" <'/dev/null'
 file_cmp "${TEST_KEY}-hook.rc" "${PWD}/rosa-svn-post-commit.rc" <<<'0'
 
 TEST_KEY="${TEST_KEY}-db-select"


### PR DESCRIPTION
* Disable stderr tests until sqlalchemy has been upgraded to version 2 and deprecation warnings addressed
* See https://github.com/metomi/rose/issues/2674