### PR TITLE
Bunch: Incremental mode tweaks

### DIFF
--- a/metomi/rose/apps/rose_bunch.py
+++ b/metomi/rose/apps/rose_bunch.py
@@ -291,6 +291,10 @@ class RoseBunchApp(BuiltinApp):
         # Set max number of processes to run at once
         max_procs = conf_tree.node.get_value([self.BUNCH_SECTION, "pool-size"])
 
+        # Add CYLC_TASK_FLOW_NUMBERS to configuration:
+        cylc_task_flow_numbers = os.environ.get('CYLC_TASK_FLOW_NUMBERS', "0")
+        conf_tree.node.set(['CYLC_TASK_FLOW_NUMBERS'], cylc_task_flow_numbers)
+
         if max_procs:
             max_procs = int(metomi.rose.env.env_var_process(max_procs))
         else:
@@ -475,7 +479,7 @@ class RoseBunchDAO:
     def create_tables(self):
         """Create tables as appropriate"""
         existing = []
-        first_run = os.environ.get("CYLC_TASK_TRY_NUMBER") == "1"
+        first_run = os.environ.get("CYLC_TASK_SUBMIT_NUMBER") == "1"
 
         for row in self.conn.execute(
             "SELECT name FROM sqlite_master " + "WHERE type=='table'"
@@ -566,7 +570,6 @@ class RoseBunchDAO:
 
     def record_config(self, config, clear_db=False):
         """Take in a conf_tree object and record the entries"""
-
         if clear_db:
             d_stmt = "DELETE FROM " + self.TABLE_CONFIG
             self.conn.execute(d_stmt)

--- a/sphinx/api/built-in/rose_bunch.rst
+++ b/sphinx/api/built-in/rose_bunch.rst
@@ -12,12 +12,12 @@ its output directed to separate ``.out`` and ``.err`` files of the form:
 .. code-block:: sub
 
    bunch.<name>.out
-   
+
 Should you need separate working directories you should configure your
 command to create the appropriate subdirectory for working in.
 
 .. note::
-   
+
    Under load balancing systems such as PBS or Slurm, you will need to
    set resource requests to reflect the resources required by running
    multiple commands at once e.g. if one command would require 1GB
@@ -91,7 +91,7 @@ sections of the :rose:file:`rose-app.conf` file, but
       .. rose:conf:: fail-mode=continue|abort
 
          :default: continue
-         
+
          Specify what action you want the job to take on the failure of a
          command that it is trying to run. If set to continue all command
          variants will be run by the job and the job will return a non-zero
@@ -111,7 +111,7 @@ sections of the :rose:file:`rose-app.conf` file, but
       .. rose:conf:: incremental=true|false
 
          :default: true
-         
+
          If set to ``true`` then only failed commands will be re-run on
          retrying running of the job. If any changes are made to the
          configuration being run then all variants will be re-run. Similarly,
@@ -120,6 +120,10 @@ sections of the :rose:file:`rose-app.conf` file, but
          will result in all commands being run. In verbose mode the app
          will report commands that won't be run due to previous successes
          in the job output with a ``[PASS]`` prefix.
+
+         .. seealso::
+
+            :ref:`rosebunch.CylcTasks`
 
       .. rose:conf:: names=name1 name2 ...
 
@@ -167,3 +171,14 @@ sections of the :rose:file:`rose-app.conf` file, but
          ``command-instances`` and ``COMMAND_INSTANCES``, which are reserved
          for the auto-generated list of instances when the
          :rose:conf:`[bunch]command-instances=N` option is used.
+
+.. _roseBunch.CylcTasks:
+
+Incremental Mode In Cylc Tasks
+------------------------------
+
+When incremental mode is turned on, only failed commands will be re-run
+if the task is run again (e.g. by manual triggering, or automatic retries).
+
+If the task is run again as part of a new flow (e.g. ``--flow=new``),
+then all commands will be re-run.

--- a/t/rose-task-run/31-app-bunch/flow.cylc
+++ b/t/rose-task-run/31-app-bunch/flow.cylc
@@ -10,8 +10,11 @@
     final cycle point = 20100101
     [[dependencies]]
         [[[T00]]]
-            graph="""BUNCH_TASKS:finish-all => dummy
-                     dummy => !BUNCH_TASKS"""
+            graph = """
+                BUNCH_TASKS:finish-all => dummy
+                bunch_incremental => dummy
+                dummy => !BUNCH_TASKS
+            """
 
 [runtime]
     [[root]]
@@ -24,9 +27,6 @@
     [[bunch_fail]]
         inherit = BUNCH_TASKS
     [[bunch_incremental]]
-        inherit = BUNCH_TASKS
-        [[[job]]]
-            execution retry delays = PT1S
     [[bunch_bigpop]]
         inherit = BUNCH_TASKS
     [[bunch_names]]

--- a/t/rose-task-run/43-bunch-check-flows.t
+++ b/t/rose-task-run/43-bunch-check-flows.t
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+#-------------------------------------------------------------------------------
+# Copyright (C) British Crown (Met Office) & Contributors.
+#
+# This file is part of Rose, a framework for meteorological suites.
+#
+# Rose is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Rose is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Rose. If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test "rose_bunch" built-in application:
+# Test that CYLC_FLOW_TASK_NUMBERS is stored in the rose_bunch database
+# and incremental mode turned off if changes made to its value in a later run.
+#-------------------------------------------------------------------------------
+. $(dirname $0)/test_header
+
+tests 24
+
+grep_incrementals() {
+    # Check that a rose app-run runs, skips, and fails the desired number of
+    # Tasks;
+    local TEST_SET="$1"
+    local OK="$2"
+    local FAIL="$3"
+    local SKIP="$4"
+    run_fail "${TEST_SET}" rose app-run
+    file_grep "${TEST_SET}-ok" "OK: ${OK}" "${TEST_SET}.out"
+    file_grep "${TEST_SET}-fail" "FAIL: ${FAIL}" "${TEST_SET}.out"
+    file_grep "${TEST_SET}-skip" "SKIP: ${SKIP}" "${TEST_SET}.out"
+}
+
+# App with one bunch member which will fail and one which will pass:
+cat > "rose-app.conf" <<__HERE__
+mode=rose_bunch
+meta=rose_bunch
+
+[bunch-args]
+arg1=true false
+
+[bunch]
+command-format=%(arg1)s
+incremental=true
+fail-mode=continue
+__HERE__
+
+
+# App outside Cylc task
+unset CYLC_FLOW_TASK_NUMBERS
+# It doesn't skip running anything the first time through:
+grep_incrementals "no-flow" 1 1 0
+# It doesn't run the OK task again:
+grep_incrementals "no-flow-again" 0 1 1
+
+
+# App inside Cylc Task:
+export CYLC_TASK_FLOW_NUMBERS="1"
+# It runs when we are now have CYLC_FLOW_TASK_NUMBERS set
+grep_incrementals "flow1" 1 1 0
+# It doesn't run the OK task again
+grep_incrementals "flow1-again" 0 1 1
+
+# It runs all jobs when CYLC_TASK_FLOW_NUMBERS changed:
+export CYLC_TASK_FLOW_NUMBERS="2"
+grep_incrementals "flow2" 1 1 0
+
+# It runs all jobs if the task has multiple flow numbers:
+export CYLC_TASK_FLOW_NUMBERS="1,2"
+grep_incrementals "flow2" 1 1 0

--- a/t/rose-task-run/44-bunch-incremental.t
+++ b/t/rose-task-run/44-bunch-incremental.t
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+#-------------------------------------------------------------------------------
+# Copyright (C) British Crown (Met Office) & Contributors.
+#
+# This file is part of Rose, a framework for meteorological suites.
+#
+# Rose is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Rose is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Rose. If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test "rose_bunch" built-in application's interaction with Cylc tasks:
+# Run a task
+# * Once: Should run all subtasks.
+# * A second time in the same flow: Should skip the OK task from the first
+#   run/
+# * Run task with --flow=new: Should run all subtasks.
+#-------------------------------------------------------------------------------
+. $(dirname $0)/test_header
+
+tests 9
+
+get_reg
+
+APP_LOG_PATH="${HOME}/cylc-run/${FLOW}/log/job/2000/bunchapp"
+SCHD_LOG_PATH="${HOME}/cylc-run/${FLOW}/log/scheduler/log"
+
+grep_incrementals() {
+    # Check that a rose app-run runs, skips, and fails the desired number of
+    # Tasks;
+    local TEST_SET="$1"
+    local OK="$2"
+    local SKIP="$3"
+    file_grep "${TEST_SET}-ok" "OK: ${OK}" "${TEST_SET}/job.out"
+    file_grep "${TEST_SET}-skip" "SKIP: ${SKIP}" "${TEST_SET}/job.out"
+}
+
+mkdir -p app/bunchapp
+touch "rose-suite.conf"
+
+# Create a Cylc Workflow
+cat > "flow.cylc" <<__HERE__
+[scheduler]
+    cycle point format = %Y
+
+[scheduling]
+    initial cycle point = 2000
+
+    [[graph]]
+        R1 = bunchapp & long
+
+[runtime]
+    [[bunchapp]]
+        script = rose task-run
+    [[long]]
+        script = sleep 300
+
+__HERE__
+
+# App with one bunch member which will fail and one which will pass:
+cat > "app/bunchapp/rose-app.conf" <<__HERE__
+mode=rose_bunch
+meta=rose_bunch
+
+[bunch-args]
+arg1=true
+
+[bunch]
+command-format=%(arg1)s
+incremental=true
+fail-mode=continue
+__HERE__
+
+# install and play the workflow
+TEST_SET="play-once"
+run_pass "${TEST_SET}" \
+    cylc vip . --host=localhost --workflow-name "${FLOW}" --no-run-name
+
+# Wait for first run of the task to finish - bunch should have one
+# success and one failure:
+poll ! grep CYLC_JOB_EXIT "${APP_LOG_PATH}/01/job.status" 2>&1 /dev/null
+grep_incrementals "${APP_LOG_PATH}/01" 1 0
+
+# Re trigger task in same flow - bunch should skip previously succeeded tasks:
+cylc trigger "${FLOW}//2000/bunchapp/"
+poll ! grep CYLC_JOB_EXIT "${APP_LOG_PATH}/02/job.status" 2>&1 /dev/null
+grep_incrementals "${APP_LOG_PATH}/02" 0 1
+
+# Re trigger task in new flow - bunch should treat as a new task:
+cylc trigger "${FLOW}//2000/bunchapp/" --flow=new
+poll ! grep CYLC_JOB_EXIT "${APP_LOG_PATH}/03/job.status" 2>&1 /dev/null
+grep_incrementals "${APP_LOG_PATH}/03" 1 0
+
+run_pass "stop workflow" cylc stop "${FLOW}" --kill
+poll ! grep DONE "${SCHD_LOG_PATH}"
+run_pass "cleanup" cylc clean -y "${FLOW}"


### PR DESCRIPTION
Closes #2698 

Two related issues:
- [x] Previously rose bunch is was using CYLC_TASK_TRY_NUMBER, causing it to treat each submit as the first run of the job and turning off incremental running - this needed changing to CYLC_TASK_SUBMIT_NUMBER.
- [x] rose bunch needs awareness of flow numbers. A new submit should not run in incremental mode if the task belongs to a different flow to the previous run -- full details of investigation in #2698 .
- [x] Add documentation about how incremental mode works.