### PR TITLE
Remove release candidate warning from docs

### DIFF
--- a/sphinx/index.rst
+++ b/sphinx/index.rst
@@ -11,11 +11,6 @@
 Rose Documentation
 ==================
 
-.. warning::
-
-   This is a release candidate, for production work select a Rose 2019
-   version.
-
 Rose is a toolkit for writing, editing and running application configurations.
 :ref:`What Is Rose <Rose Tutorial>`?
 


### PR DESCRIPTION
Do we still want this?

Perhaps it's worth me reading this cover to cover at some point and jotting down anything else we might want rid of.

I've just noted a reference to file installation in the slides, for example. Will create a new issue later, but I think that this is required now.