### PR TITLE
Rose Stem tutorial without svn version control

### DIFF
--- a/sphinx/tutorial/rose/furthertopics/rose-stem-tutorial.rst
+++ b/sphinx/tutorial/rose/furthertopics/rose-stem-tutorial.rst
@@ -20,9 +20,28 @@ This tutorial will walk you through creating a simple example of the
 Rose Stem testing system which will involve piloting a spaceship
 through space.
 
+.. admonition:: Without Version Control
+   :class: hint
+
+   You can run this tutorial without reference to version control using FCM.
+   Look for boxes like this one.
+   You will still need FCM installed to build the Fortran app.
 
 Getting Started
 ---------------
+
+.. admonition:: Without Version Control
+   :class: hint
+
+   This section can be replaced with
+
+   .. code-block:: console
+
+      mkdir -p ~/rose-tutorial/spaceship_working_copy
+      rose tutorial rose-stem .
+
+   Then skip to :ref:`spaceship_command`
+
 
 We will start the Rose Stem tutorial by setting up an `FCM`_ repository
 called ``SPACESHIP`` to store the code and test suite in.
@@ -61,6 +80,7 @@ Finally populate your working copy by running (answering ``y`` to the prompt)::
 
    rose tutorial rose-stem .
 
+.. _spaceship_command:
 
 ``spaceship_command.f90``
 -------------------------
@@ -231,6 +251,11 @@ app with the path to this file.
 Adding the suite to version control
 -----------------------------------
 
+.. admonition:: Without Version Control
+   :class: hint
+
+   Skip to :ref:`without_vc`
+
 Before running the suite we need to make sure that all the files and
 directories we have created are known to the version control system.
 
@@ -240,6 +265,9 @@ to the prompts)*.
 
 Running the test suite
 ----------------------
+
+Installing the workflow
+^^^^^^^^^^^^^^^^^^^^^^^
 
 We should now be able to install the test suite. Simply type::
 
@@ -252,6 +280,22 @@ We use ``--group`` in preference to ``--task`` in this suite (both are
 synonymous) as we specify a group of tasks set up in the Jinja2 variable
 ``name_graphs``.
 
+.. _without_vc:
+
+Without FCM version control
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Without the FCM source control you need to explictly state the workflow
+source and project name:
+
+.. code-block:: console
+
+   rose stem --group=command_spaceship --source=spaceship=$PWD
+
+
+Playing the Workflow
+^^^^^^^^^^^^^^^^^^^^
+
 .. admonition:: Change from Rose 2019
 
    Previously, the ``rose stem`` command ran the suite. At Cylc 8, it simply
@@ -260,8 +304,6 @@ synonymous) as we specify a group of tasks set up in the Jinja2 variable
 We must now use ``cylc play`` to start the workflow::
 
    cylc play spaceship_working_copy
-
-
 
 This can be inspected as running successfully by opening Cylc Review in a
 browser and checking the jobs. Alternatively, use the Cylc GUI or Cylc TUI to

--- a/sphinx/tutorial/rose/furthertopics/rose-stem.rst
+++ b/sphinx/tutorial/rose/furthertopics/rose-stem.rst
@@ -12,7 +12,7 @@ Rose Stem
 
 .. seealso::
 
-   :ref:`rose-stem` documentation.
+   :ref:`rose-stem` overview.
 
 Rose Stem is a testing system for use with Rose. It provides a user-friendly
 way of defining source trees and tasks on the command line which are then
@@ -20,8 +20,8 @@ passed by Rose Stem to the suite as Jinja2 variables.
 
 .. warning::
 
-   Rose Stem requires the use of `FCM`_ as it requires some of the version
-   control information.
+   Rose Stem was designed to get version control information from `FCM`_.
+   Some features will not work if ``--sources`` are not FCM projects.
 
 
 Motivation
@@ -95,36 +95,40 @@ of a program.
 The ``--source`` Argument
 -------------------------
 
-The source argument provides a set of Jinja2 variables which can then be
-included in any compilation tasks in a suite. You can specify multiple
-``--source`` arguments on the command line. For example::
+Source arguments provide a set of Jinja2 variables to Cylc.
+These arguments convey information about a directory or URL.
+
+You can specify more than one ``--source`` argument on the command line.
+For example::
 
    rose stem --source=/path/to/workingcopy --source=fcm:other_project_tr@head
 
-Each source tree is associated with a project (via an ``fcm`` command) when
-:ref:`command-rose-stem` is run on the command line. This project name
-is then used in the construction of the Jinja2 variable names.
+* If the source points to an FCM repository rose stem uses
+  FCM to get project information.
+* If the source is not an FCM repository you will need to
+  add a project name: ``--source=<name>=<path/URL>``. Some Jinja2
+  variables provided by rose-stem will be empty.
 
-Each project has a Jinja2 variable ``SOURCE_FOO`` where ``FOO`` is the
+Each project has a Jinja2 variable ``SOURCE_<project>``
 project name. This contains a space-separated list of all sourcetrees
 belonging to that project, which can then be given to an appropriate
 build task in the suite so it builds those source trees.
 
-Similarly, a ``HOST_SOURCE_FOO`` variable is also provided. This is
-identical to ``SOURCE_FOO`` except any working copies have the local
+Similarly, a ``HOST_SOURCE_<project>`` variable is also provided. This is
+identical to ``SOURCE_<project>`` except any working copies have the local
 hostname prepended. This is to assist building on remote machines.
 
 The first source specified must be a working copy which contains the
-Rose Stem suite. The suite is expected to be in a
+Rose Stem suite's Cylc workflow definitions. The suite is expected to be in a
 subdirectory named ``rose-stem`` off the top of the working copy. This
 source is used to generate three additional variables:
 
-``SOURCE_FOO_BASE``
+``SOURCE_<project>_BASE``
    The base directory of the project
-``HOST_SOURCE_FOO_BASE``
+``HOST_SOURCE_<project>_BASE``
    The base directory of the project with the hostname prepended if it is a
    working copy
-``SOURCE_FOO_REV``
+``SOURCE_<project>_REV``
    The revision of the project (if any)
 
 These settings override the variables in the :rose:file:`rose-suite.conf` file.
@@ -148,11 +152,15 @@ you can specify this using the ``--source`` argument::
    rose stem --source=foo=/path/to/source
 
 assigns the URL ``/path/to/source`` to the foo project, so the variables
-``SOURCE_FOO`` and ``SOURCE_FOO_BASE`` will be set to ``/path/to/source``.
+``SOURCE_FOO`` and ``SOURCE_<project>_BASE`` will be set to ``/path/to/source``.
 
 
-The ``--group`` Argument
-------------------------
+The ``--group`` and ``--task`` Arguments
+----------------------------------------
+
+.. note::
+
+   ``--group`` and ``--task`` are the same argument.
 
 The group argument is used to provide a Pythonic list of groups in the
 variable ``RUN_NAMES`` which can then be looped over in a suite to switch
@@ -160,19 +168,11 @@ sets of tasks on and off.
 
 Each ``--group`` argument adds another group to the list. For example::
 
-   rose stem --group=mygroup --group=myothergroup
+   rose stem --group=mygroup --task=myothergroup
 
 runs two groups named ``mygroup`` and ``myothergroup`` with the current
 working copy. The suite will then interpret these into a set of tasks which
 build with the given source tree(s), run the program, and compare the output.
-
-
-The ``--task`` Argument
------------------------
-
-The task argument is provided as a synonym for ``--group``. Depending on how
-exactly the Rose Stem suite works users may find one of these arguments more
-intuitive to use than the other.
 
 
 Comparing Output With :rose:app:`rose_ana`


### PR DESCRIPTION
Updates to make it clearer that is possible (and reasonably straightforward) to run rose stem suites where sources are not version controlled with FCM. 

### Rose stem tutorial

I chose not to create an entirely separate tutorial (even if it were mostly a copy) to avoid duplication. IMO we should also disentangle this from the reliance on FCM for Fortran building (but I haven't done that here).

### Rose stem docs

Rose stem is currently most thoroughly documented in `sphinx/tutorial/rose/furthertopics/rose-stem.rst`. This seems like a slightly odd place for it, because the script is stored in `cylc-rose`, and this document is not a tutorial.

### Review

I've tagged @oliver-sanders for a first review, since he reported this documentation bug.

IMO @dpmatthews would make a good reviewer in terms of general overview, but might be busy. 

If @markgrahamdawson can follow the instructions (avoid doing the FCM version control stuff) in the tutorial that might indicate that they are well written.