### PR TITLE
Allow Rose Apps to set PYTHONPATH=_PYTHONPATH before running

### DIFF
--- a/metomi/rose/app_run.py
+++ b/metomi/rose/app_run.py
@@ -429,6 +429,7 @@ class AppRunner(Runner):
 
         # Environment variables: PATH
         self._prep_path(conf_tree)
+        self._prep_shadow_pythonpath(conf_tree)
 
         # Free format files not defined in the configuration file
         file_section_prefix = self.config_pm.get_handler("file").PREFIX
@@ -483,6 +484,13 @@ class AppRunner(Runner):
             conf_tree.node.set(["env", "PATH"], value)
         else:
             conf_tree.node.set(["env", "PATH"], os.getenv("PATH"))
+
+    @staticmethod
+    def _prep_shadow_pythonpath(conf_tree):
+        """Restore users PYTHONPATH from _PYTHONPATH"""
+        shadow_pythonpath = os.environ.get('_PYTHONPATH', None)
+        if shadow_pythonpath:
+            conf_tree.node.set(["env", "PYTHONPATH"], shadow_pythonpath)
 
     def _poll(self, conf_tree):
         """Run any configured file polling."""

--- a/t/integration/test_rose_app_run.py
+++ b/t/integration/test_rose_app_run.py
@@ -1,0 +1,59 @@
+# Copyright (C) British Crown (Met Office) & Contributors.
+# This file is part of Rose, a framework for meteorological suites.
+#
+# Rose is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Rose is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Rose. If not, see <http://www.gnu.org/licenses/>.
+# -----------------------------------------------------------------------------
+"""Integration tests for Rose app-run"""
+
+import pytest
+
+from metomi.rose.app_run import AppRunner as rose_app_run
+from metomi.rose.popen import RosePopenError
+from metomi.rose.opt_parse import RoseOptionParser
+from metomi.rose.reporter import Reporter
+
+
+def test_adds_shadow_pythonpath(monkeypatch, tmp_path, capsys):
+    """If _PYTHONPATH is set rose app uses this as PYTHONPATH.
+
+    This allows Cylc and Rose to operate in some other environment
+    but this app to go to the users preferred env.
+    """
+    # Sets up a rose-app:
+    (tmp_path / 'rose-app.conf').write_text(
+        '[command]\n'
+        'default = echo "${PYTHONPATH}" && exit 0'
+    )
+
+    monkeypatch.setenv('_PYTHONPATH', '/foo:/bar')
+
+    # Fake the rose options:
+    opt_parser = RoseOptionParser()
+    option_keys = rose_app_run.OPTIONS
+    opt_parser.add_my_options(*option_keys)
+    opts, args = opt_parser.parse_args()
+    opts.conf_dir = str(tmp_path)
+    event_handler = Reporter(opts.verbosity - opts.quietness)
+    runner = rose_app_run(event_handler)
+
+    # Run our app.
+    # Rose Popen doesn't like Pytests fake stdin and fails
+    # we want to ensure that it's _that_ failure:
+    with pytest.raises(RosePopenError) as exc:
+        runner(opts, [str(tmp_path)])
+    assert exc.value.stderr.split(' ')[-1] == f"'{str(tmp_path)}'"
+
+    # Finally we test what we came here for:
+    readouterr = capsys.readouterr()
+    assert 'export PYTHONPATH=/foo:/bar' in readouterr.out

--- a/t/test_rose_app_run.py
+++ b/t/test_rose_app_run.py
@@ -1,0 +1,55 @@
+# Copyright (C) British Crown (Met Office) & Contributors.
+# This file is part of Rose, a framework for meteorological suites.
+#
+# Rose is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Rose is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Rose. If not, see <http://www.gnu.org/licenses/>.
+# -----------------------------------------------------------------------------
+"""Unit tests for Rose app-run"""
+
+from io import StringIO
+import pytest
+from types import SimpleNamespace
+
+from metomi.rose.app_run import AppRunner
+from metomi.rose.config import ConfigLoader
+
+
+@pytest.fixture
+def get_conf_tree():
+    """Give me a config tree"""
+    def _inner():
+        raw_config = (
+            '[command]\n'
+            'default = foo\n'
+        )
+        return SimpleNamespace(node=ConfigLoader().load(StringIO(raw_config)))
+    return _inner
+
+
+def test___prep_shadow_pythonpath(monkeypatch, get_conf_tree):
+    """Copies _PYTHONPATH to PYTHONPATH: If not _PYTHONPATH does nothing.
+
+    Checks that setting _PYTHONPATH sets PYTHONPATH for this rose-app conf.
+    """
+    # Both variables are set; _PYTHONPATH overwrites PYTHONPATH
+    conf_tree = get_conf_tree()
+    monkeypatch.setenv('_PYTHONPATH', 'bar')
+    monkeypatch.setenv('PYTHONPATH', 'foo')
+    AppRunner._prep_shadow_pythonpath(conf_tree)
+    assert conf_tree.node.value['env'].value['PYTHONPATH'].value == 'bar'
+
+    # _PYTHONPATH unset; Nothing happens
+    conf_tree = get_conf_tree()
+    monkeypatch.delenv('_PYTHONPATH')
+    AppRunner._prep_shadow_pythonpath(conf_tree)
+    assert 'env' not in conf_tree.node.value


### PR DESCRIPTION
Allows Cylc Wrapper to cached the users PYTHONPATH before switching to a Cylc 8 environment.

Partner of https://github.com/cylc/cylc-flow/pull/5727

The Rose end of https://github.com/cylc/cylc-flow/issues/5124

Tagging @dpmatthews  who may want to be involved in functionally testing this, although I'll propose a user test when I put up a companion PR for Cylc. Probably won't want to be a main reviewer.

This PR is self-sufficient. It won't break anything if it goes in without the companion Cylc PR.