### PR TITLE
Support alternate usernames in pre-commit

### DIFF
--- a/lib/python/rosie/svn_pre_commit.py
+++ b/lib/python/rosie/svn_pre_commit.py
@@ -307,7 +307,7 @@ class RosieSvnPreCommitHook(RosieSvnHook):
 
             if (owner == author_aliases.get(txn_owner)
                     and set(access_list)
-                        == set([author_aliases.get(_) for _ in txn_access_list])):
+                        == set(author_aliases.get(_) for _ in txn_access_list)):
                 # The change has purely been an aliased one, fine.
                 continue
 

--- a/lib/python/rosie/svn_pre_commit.py
+++ b/lib/python/rosie/svn_pre_commit.py
@@ -65,14 +65,11 @@ class RosieSvnPreCommitHook(RosieSvnHook):
         access_list.sort()
         return owner, access_list
 
-    def _get_author_aliases(self, repos, txn=None):
+    def _get_author_aliases(self, repos):
         """Return the current author alternative name map."""
-        txn_args = ()
-        if txn is not None:
-            txn_args = ("-t", txn)
         try:
             text = self._svnlook(
-                "cat", repos, "/R/O/S/I/E/trunk/author_aliases", *txn_args)
+                "cat", repos, "/R/O/S/I/E/trunk/author_aliases")
         except Exception:
             return {}
         return dict([element.split(":") for element in text.split()])

--- a/lib/python/rosie/svn_pre_commit.py
+++ b/lib/python/rosie/svn_pre_commit.py
@@ -77,11 +77,9 @@ class RosieSvnPreCommitHook(RosieSvnHook):
             return {}
         return dict([element.split(":") for element in text.split()])
 
-    def _get_authors(self, txn, repos):
-        """Retrieve the author of the transaction and any alias."""
-        txn_author = self._svnlook("author", "-t", txn, repos).strip()
-        author_dict = self._get_author_aliases(repos)
-        return txn_author, author_dict.get(txn_author)
+    def _get_author(self, txn, repos):
+        """Retrieve the author of the transaction."""
+        return self._svnlook("author", "-t", txn, repos).strip()
 
     def _verify_users(self, status, path, txn_owner, txn_access_list,
                       bad_changes):
@@ -126,18 +124,11 @@ class RosieSvnPreCommitHook(RosieSvnHook):
         bad_changes = []
         rev_info_map = {}
         txn_info_map = {}
+        found_author_info = False
 
         conf = ResourceLocator.default().get_conf()
         ignores_str = conf.get_value(["rosa-svn", "ignores"], self.IGNORES)
         ignores = shlex.split(ignores_str)
-
-        author, author_alias = self._get_authors(txn, repos)
-        super_users = []
-        for s_key in ["rosa-svn", "rosa-svn-pre-commit"]:
-            value = conf.get_value([s_key, "super-users"])
-            if value is not None:
-                super_users = shlex.split(value)
-                break
 
         for status, path in sorted(changes):
             if any(fnmatch(path, ignore) for ignore in ignores):
@@ -270,6 +261,17 @@ class RosieSvnPreCommitHook(RosieSvnHook):
             if (self.ST_ADDED, path_head + "trunk/") in changes:
                 continue
 
+            if not found_author_info:
+                author = self._get_author(txn, repos)
+                author_aliases = self._get_author_aliases(repos)
+                super_users = []
+                for s_key in ["rosa-svn", "rosa-svn-pre-commit"]:
+                    value = conf.get_value([s_key, "super-users"])
+                    if value is not None:
+                        super_users = shlex.split(value)
+                        break
+                found_author_info = True
+
             # See whether author has permission to make changes
             if sid not in rev_info_map:
                 rev_info_map[sid] = self._load_info(
@@ -277,9 +279,9 @@ class RosieSvnPreCommitHook(RosieSvnHook):
             owner, access_list = self._get_access_info(rev_info_map[sid])
             admin_users = super_users + [owner]
 
-            # If an author alias username is the owner, allow the new username
-            # owner privileges.
-            if author_alias == owner:
+            if author in author_aliases and author_aliases[author] == owner:
+                # If an author alias username is the owner, allow the new username
+                # owner privileges.
                 admin_users += [author]
 
             # Only admin users can remove the suite
@@ -290,7 +292,8 @@ class RosieSvnPreCommitHook(RosieSvnHook):
 
             # Admin users and those in access list can modify everything in
             # trunk apart from specific entries in the trunk info file
-            if "*" in access_list or author in admin_users + access_list:
+            if ("*" in access_list or author in admin_users + access_list
+                    or author_aliases.get(author) in access_list):
                 if path_tail != self.TRUNK_INFO_FILE:
                     continue
             else:
@@ -298,9 +301,19 @@ class RosieSvnPreCommitHook(RosieSvnHook):
                 bad_changes.append(BadChange(status, path, content=msg))
                 continue
 
-            # Only the admin users can change owner and access list
+            # Only the admin users can change owner and access list except
+            # that access list users can change them to aliases.
+
             if owner == txn_owner and access_list == txn_access_list:
+                # No substantive change made, fine.
                 continue
+
+            if (owner == author_aliases.get(txn_owner)
+                    and set(access_list)
+                        == set([author_aliases.get(_) for _ in txn_access_list])):
+                # The change has purely been an aliased one, fine.
+                continue
+
             if author not in admin_users:
                 if owner != txn_owner:
                     bad_changes.append(BadChange(status, path, BadChange.PERM,

--- a/lib/python/rosie/svn_pre_commit.py
+++ b/lib/python/rosie/svn_pre_commit.py
@@ -72,7 +72,7 @@ class RosieSvnPreCommitHook(RosieSvnHook):
             txn_args = ("-t", txn)
         try:
             text = self._svnlook(
-                "propget", repos, "rosie:authoraliases", ".", *txn_args)
+                "cat", repos, "/R/O/S/I/E/trunk/author_aliases", *txn_args)
         except Exception:
             return {}
         return dict([element.split(":") for element in text.split()])
@@ -147,22 +147,6 @@ class RosieSvnPreCommitHook(RosieSvnHook):
             tail = None
             if not names[-1]:
                 tail = names.pop()
-
-            # Allow root property modification by super users.
-            if (len(names) == 1 and not names[0]
-                    and status == "_U"):
-                if author not in super_users:
-                    msg = "Must be a super user to change root properties"
-                    bad_changes.append(BadChange(status, path, content=msg))
-                    continue
-                try:
-                    self._get_author_aliases(repos, txn=txn)
-                except ValueError:
-                    msg = "Malformed rosie:authoraliases property"
-                    bad_changes.append(BadChange(status, path, content=msg))
-                    continue
-                # OK if author is in super users and property OK.
-                continue
 
             # Directories above the suites must match the ID patterns
             is_bad = False

--- a/sphinx/installation.rst
+++ b/sphinx/installation.rst
@@ -411,6 +411,18 @@ ID will end with ``ROSIE`` - e.g. ``foo-ROSIE``.
 
 This can be created by running ``rosie create --meta-suite``.
 
+User aliases
+^^^^^^^^^^^^
+
+If you need to map usernames from old to new, for example after
+migrating a Rosie repository from one platform to another with
+different authentication, you can set a ``rosie:authoraliases``
+property on the root of the repository with whitespace separated
+key:value pairs e.g. ``newalice:oldalice newbob:oldbob``. This
+will allow users to authenticate as owners of the suites and
+transition their owner and access-list entries over to the new
+usernames.
+
 Creating a Known Keys File
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/sphinx/installation.rst
+++ b/sphinx/installation.rst
@@ -416,10 +416,14 @@ User aliases
 
 If you need to map usernames from old to new, for example after
 migrating a Rosie repository from one platform to another with
-different authentication, you can set a ``rosie:authoraliases``
-property on the root of the repository with whitespace separated
-key:value pairs e.g. ``newalice:oldalice newbob:oldbob``. This
-will allow users to authenticate as owners of the suites and
+different authentication, you can create an ``author_aliases``
+file within the ``ROSIE`` special suite's trunk with whitespace
+separated key-value pairs e.g.::
+
+   newalice:oldalice
+   newbob:oldbob
+
+This will allow users to authenticate as owners of the suites and
 transition their owner and access-list entries over to the new
 usernames.
 

--- a/sphinx/installation.rst
+++ b/sphinx/installation.rst
@@ -425,7 +425,9 @@ separated key-value pairs e.g.::
 
 This will allow users to authenticate as owners of the suites and
 transition their owner and access-list entries over to the new
-usernames.
+usernames. Users on the access-list may also map old owner and
+access-list usernames over to the new ones using these aliases,
+but any incomplete or imprecise mapping will be disallowed.
 
 Creating a Known Keys File
 ^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/t/rosa-svn-pre-commit/04-aliases.t
+++ b/t/rosa-svn-pre-commit/04-aliases.t
@@ -230,7 +230,7 @@ file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" <<'__ERR__'
 svn: E165001: Commit failed (details follow):
 svn: E165001: Commit blocked by pre-commit hook (exit code 1) with output:
-[FAIL] PERMISSION DENIED: U   a/a/0/0/0/trunk/rose-suite.info: owner=daisynew
+[FAIL] PERMISSION DENIED: U   a/a/0/0/0/trunk/rose-suite.info: access-list=davenew franknew heywood
 
 __ERR__
 svn revert -q -R aa000

--- a/t/rosa-svn-pre-commit/04-aliases.t
+++ b/t/rosa-svn-pre-commit/04-aliases.t
@@ -130,6 +130,7 @@ __CHANGED__
 rm -rf foo_wc
 #-------------------------------------------------------------------------------
 TEST_KEY=$TEST_KEY_BASE-modify-with-alias-good-1
+svn update -q aa000
 echo "vehicle=carriage" >>aa000/rose-suite.info
 REV1=$(svn info --show-item revision aa000/)
 run_pass "$TEST_KEY" svn commit -q -m 't' --username=daisynew aa000

--- a/t/rosa-svn-pre-commit/04-aliases.t
+++ b/t/rosa-svn-pre-commit/04-aliases.t
@@ -27,7 +27,7 @@ cat >conf/rose.conf <<'__ROSE_CONF__'
 super-users=rosie
 __ROSE_CONF__
 #-------------------------------------------------------------------------------
-tests 73
+tests 70
 #-------------------------------------------------------------------------------
 mkdir repos
 svnadmin create repos/foo
@@ -40,7 +40,7 @@ __PRE_COMMIT__
 chmod +x repos/foo/hooks/pre-commit
 export LANG=C
 #-------------------------------------------------------------------------------
-TEST_KEY=$TEST_KEY_BASE-create-good-1
+TEST_KEY=$TEST_KEY_BASE-create-good
 cat >rose-suite.info <<__ROSE_SUITE_INFO__
 access-list=frank dave
 owner=daisy
@@ -63,7 +63,7 @@ A   a/a/0/0/0/trunk/
 A   a/a/0/0/0/trunk/rose-suite.info
 __CHANGED__
 #-------------------------------------------------------------------------------
-TEST_KEY=$TEST_KEY_BASE-modify-good-1
+TEST_KEY=$TEST_KEY_BASE-modify-good
 svn checkout -q $SVN_URL/a/a/0/0/0/trunk/ aa000/
 echo "vehicle=bicycle" >>aa000/rose-suite.info
 REV1=$(svn info --show-item revision aa000/)
@@ -78,7 +78,7 @@ file_cmp "$TEST_KEY.changed" "$TEST_KEY.changed" <<'__CHANGED__'
 U   a/a/0/0/0/trunk/rose-suite.info
 __CHANGED__
 #-------------------------------------------------------------------------------
-TEST_KEY=$TEST_KEY_BASE-modify-bad-1
+TEST_KEY=$TEST_KEY_BASE-modify-bad
 svn update -q aa000
 echo "subtitle=answer" >>aa000/rose-suite.info
 run_fail "$TEST_KEY" svn commit -q -m 't' --username=hal aa000
@@ -90,18 +90,7 @@ svn: E165001: Commit blocked by pre-commit hook (exit code 1) with output:
 
 __ERR__
 #-------------------------------------------------------------------------------
-TEST_KEY=$TEST_KEY_BASE-modify-bad-2
-svn update -q aa000
-run_fail "$TEST_KEY" svn commit -q -m 't' --username=daisynew aa000
-file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
-file_cmp "$TEST_KEY.err" "$TEST_KEY.err" <<'__ERR__'
-svn: E165001: Commit failed (details follow):
-svn: E165001: Commit blocked by pre-commit hook (exit code 1) with output:
-[FAIL] PERMISSION DENIED: U   a/a/0/0/0/trunk/rose-suite.info: User not in access list
-
-__ERR__
-#-------------------------------------------------------------------------------
-TEST_KEY=$TEST_KEY_BASE-create-alias-ok-1
+TEST_KEY=$TEST_KEY_BASE-create-alias-ok
 cat >rose-suite.info <<__ROSE_SUITE_INFO__
 owner=rosie_member0
 project=Rosie admin
@@ -161,7 +150,7 @@ A   a/a/0/0/0/trunk/extra-stuff
 U   a/a/0/0/0/trunk/rose-suite.info
 __CHANGED__
 #-------------------------------------------------------------------------------
-TEST_KEY=$TEST_KEY_BASE-modify-with-alias-bad-1
+TEST_KEY=$TEST_KEY_BASE-modify-with-alias-bad
 echo "references=stretched" >>aa000/rose-suite.info
 run_fail "$TEST_KEY" svn commit -q -m 't' --username=hal aa000
 file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
@@ -172,7 +161,7 @@ svn: E165001: Commit blocked by pre-commit hook (exit code 1) with output:
 
 __ERR__
 #-------------------------------------------------------------------------------
-TEST_KEY=$TEST_KEY_BASE-modify-with-alias-access-list-good-1
+TEST_KEY=$TEST_KEY_BASE-modify-with-alias-access-list-good
 # Restore the state without aliases.
 svn update -q aa000
 sed -i "s/new//g" aa000/rose-suite.info
@@ -276,7 +265,7 @@ file_cmp "$TEST_KEY.changed" "$TEST_KEY.changed" <<'__CHANGED__'
 U   a/a/0/0/0/trunk/rose-suite.info
 __CHANGED__
 #-------------------------------------------------------------------------------
-TEST_KEY=$TEST_KEY_BASE-create-single-alias-ok-1
+TEST_KEY=$TEST_KEY_BASE-create-single-alias-ok
 svn checkout -q $SVN_URL/R/O/S/I/E/trunk ROSIE/
 cat >ROSIE/author_aliases <<'__TEXT__'
 daisynew2:daisy
@@ -291,7 +280,7 @@ A   R/O/S/I/E/trunk/author_aliases
 __CHANGED__
 rm -rf ROSIE
 #-------------------------------------------------------------------------------
-TEST_KEY=$TEST_KEY_BASE-modify-with-single-alias-good-1
+TEST_KEY=$TEST_KEY_BASE-modify-with-single-alias-good
 svn update -q aa000
 echo "bicycle_for=two" >>aa000/rose-suite.info
 REV1=$(svn info --show-item revision aa000/)

--- a/t/rosa-svn-pre-commit/04-aliases.t
+++ b/t/rosa-svn-pre-commit/04-aliases.t
@@ -1,0 +1,229 @@
+#!/bin/bash
+#-------------------------------------------------------------------------------
+# Copyright (C) 2012-2020 British Crown (Met Office) & Contributors.
+#
+# This file is part of Rose, a framework for meteorological suites.
+#
+# Rose is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Rose is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Rose. If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Tests for "rosa svn-pre-commit" with username aliasing behaviour.
+#-------------------------------------------------------------------------------
+. $(dirname $0)/test_header
+export ROSE_CONF_PATH=
+mkdir conf
+cat >conf/rose.conf <<'__ROSE_CONF__'
+[rosa-svn-pre-commit]
+super-users=rosie
+__ROSE_CONF__
+#-------------------------------------------------------------------------------
+tests 53
+#-------------------------------------------------------------------------------
+mkdir repos
+svnadmin create repos/foo
+SVN_URL=file://$PWD/repos/foo
+cat >repos/foo/hooks/pre-commit <<__PRE_COMMIT__
+#!/bin/bash
+export ROSE_CONF_PATH=$PWD/conf
+exec $ROSE_HOME/sbin/rosa svn-pre-commit "\$@"
+__PRE_COMMIT__
+chmod +x repos/foo/hooks/pre-commit
+export LANG=C
+#-------------------------------------------------------------------------------
+TEST_KEY=$TEST_KEY_BASE-create-good-1
+cat >rose-suite.info <<__ROSE_SUITE_INFO__
+owner=daisy
+project=rose
+title=${TEST_KEY}
+__ROSE_SUITE_INFO__
+run_pass "$TEST_KEY" \
+    svn import rose-suite.info -q -m 't' --non-interactive \
+    $SVN_URL/a/a/0/0/0/trunk/rose-suite.info
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+svnlook changed repos/foo >"$TEST_KEY.changed"
+file_cmp "$TEST_KEY.changed" "$TEST_KEY.changed" <<'__CHANGED__'
+A   a/
+A   a/a/
+A   a/a/0/
+A   a/a/0/0/
+A   a/a/0/0/0/
+A   a/a/0/0/0/trunk/
+A   a/a/0/0/0/trunk/rose-suite.info
+__CHANGED__
+#-------------------------------------------------------------------------------
+TEST_KEY=$TEST_KEY_BASE-modify-good-1
+svn checkout -q $SVN_URL/a/a/0/0/0/trunk/ aa000/
+echo "vehicle=bicycle" >>aa000/rose-suite.info
+REV1=$(svn info --show-item revision aa000/)
+run_pass "$TEST_KEY" svn commit -q -m 't' --username=daisy aa000
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+svn update -q aa000
+REV2=$(svn info --show-item revision aa000/)
+run_pass "$TEST_KEY.rev" bash -c "(( $REV2 > $REV1 ))"
+svnlook changed repos/foo >"$TEST_KEY.changed"
+file_cmp "$TEST_KEY.changed" "$TEST_KEY.changed" <<'__CHANGED__'
+U   a/a/0/0/0/trunk/rose-suite.info
+__CHANGED__
+#-------------------------------------------------------------------------------
+TEST_KEY=$TEST_KEY_BASE-modify-bad-1
+svn update -q aa000
+echo "subtitle=answer" >>aa000/rose-suite.info
+run_fail "$TEST_KEY" svn commit -q -m 't' --username=hal aa000
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" <<'__ERR__'
+svn: E165001: Commit failed (details follow):
+svn: E165001: Commit blocked by pre-commit hook (exit code 1) with output:
+[FAIL] PERMISSION DENIED: U   a/a/0/0/0/trunk/rose-suite.info: User not in access list
+
+__ERR__
+#-------------------------------------------------------------------------------
+TEST_KEY=$TEST_KEY_BASE-create-alias-bad-1
+svn checkout -q $SVN_URL/ foo_wc/
+svn propset rosie:authoraliases "daisynew:daisy
+bar:baz" foo_wc/
+run_fail "$TEST_KEY" svn commit -q -m 't' foo_wc
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" <<'__ERR__'
+svn: E165001: Commit failed (details follow):
+svn: E165001: Commit blocked by pre-commit hook (exit code 1) with output:
+[FAIL] PERMISSION DENIED: _U  /: Must be a super user to change root properties
+
+__ERR__
+rm -rf foo_wc
+#-------------------------------------------------------------------------------
+TEST_KEY=$TEST_KEY_BASE-create-alias-bad-2
+svn checkout -q $SVN_URL/ foo_wc/
+svn propset rosie:authoraliases "daisynew:daisy bar" foo_wc/
+run_fail "$TEST_KEY" svn commit -q -m 't' --username=rosie foo_wc
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" <<'__ERR__'
+svn: E165001: Commit failed (details follow):
+svn: E165001: Commit blocked by pre-commit hook (exit code 1) with output:
+[FAIL] PERMISSION DENIED: _U  /: Malformed rosie:authoraliases property
+
+__ERR__
+rm -rf foo_wc
+#-------------------------------------------------------------------------------
+TEST_KEY=$TEST_KEY_BASE-create-alias-ok-1
+svn checkout -q $SVN_URL/ foo_wc/
+svn propset rosie:authoraliases "daisynew:daisy
+bar:baz" foo_wc/
+run_pass "$TEST_KEY" svn commit -q -m 't' --username=rosie foo_wc
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+svnlook changed repos/foo >"$TEST_KEY.changed"
+file_cmp "$TEST_KEY.changed" "$TEST_KEY.changed" <<'__CHANGED__'
+_U  /
+__CHANGED__
+rm -rf foo_wc
+#-------------------------------------------------------------------------------
+TEST_KEY=$TEST_KEY_BASE-modify-with-alias-good-1
+echo "vehicle=carriage" >>aa000/rose-suite.info
+REV1=$(svn info --show-item revision aa000/)
+run_pass "$TEST_KEY" svn commit -q -m 't' --username=daisynew aa000
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+svn update -q aa000
+REV2=$(svn info --show-item revision aa000/)
+run_pass "$TEST_KEY.rev" bash -c "(( $REV2 > $REV1 ))"
+svnlook changed repos/foo >"$TEST_KEY.changed"
+file_cmp "$TEST_KEY.changed" "$TEST_KEY.changed" <<'__CHANGED__'
+U   a/a/0/0/0/trunk/rose-suite.info
+__CHANGED__
+#-------------------------------------------------------------------------------
+TEST_KEY=$TEST_KEY_BASE-modify-with-alias-good-2
+svn update -q aa000
+sed -i "s/owner=daisy/owner=daisynew/" aa000/rose-suite.info
+touch aa000/extra-stuff
+svn add aa000/extra-stuff
+REV1=$(svn info --show-item revision aa000/)
+run_pass "$TEST_KEY" svn commit -q -m 't' --username=daisynew aa000
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+svn update -q aa000
+REV2=$(svn info --show-item revision aa000/)
+run_pass "$TEST_KEY.rev" bash -c "(( $REV2 > $REV1 ))"
+svnlook changed repos/foo >"$TEST_KEY.changed"
+file_cmp "$TEST_KEY.changed" "$TEST_KEY.changed" <<'__CHANGED__'
+A   a/a/0/0/0/trunk/extra-stuff
+U   a/a/0/0/0/trunk/rose-suite.info
+__CHANGED__
+#-------------------------------------------------------------------------------
+TEST_KEY=$TEST_KEY_BASE-modify-with-alias-bad-1
+echo "references=stretched" >>aa000/rose-suite.info
+run_fail "$TEST_KEY" svn commit -q -m 't' --username=hal aa000
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" <<'__ERR__'
+svn: E165001: Commit failed (details follow):
+svn: E165001: Commit blocked by pre-commit hook (exit code 1) with output:
+[FAIL] PERMISSION DENIED: U   a/a/0/0/0/trunk/rose-suite.info: User not in access list
+
+__ERR__
+#-------------------------------------------------------------------------------
+TEST_KEY=$TEST_KEY_BASE-delete-alias-ok
+svn checkout -q $SVN_URL/ foo_wc/
+svn propdel rosie:authoraliases foo_wc/
+run_pass "$TEST_KEY" svn commit -q -m 't' --username=rosie foo_wc
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+svnlook changed repos/foo >"$TEST_KEY.changed"
+file_cmp "$TEST_KEY.changed" "$TEST_KEY.changed" <<'__CHANGED__'
+_U  /
+__CHANGED__
+rm -rf foo_wc
+#-------------------------------------------------------------------------------
+TEST_KEY=$TEST_KEY_BASE-modify-no-alias-ok
+svn update -q aa000
+echo "plant=flower" >>aa000/rose-suite.info
+REV1=$(svn info --show-item revision aa000/)
+run_pass "$TEST_KEY" svn commit -q -m 't' --username=daisynew aa000
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+svn update -q aa000
+REV2=$(svn info --show-item revision aa000/)
+run_pass "$TEST_KEY.rev" bash -c "(( $REV2 > $REV1 ))"
+svnlook changed repos/foo >"$TEST_KEY.changed"
+file_cmp "$TEST_KEY.changed" "$TEST_KEY.changed" <<'__CHANGED__'
+U   a/a/0/0/0/trunk/rose-suite.info
+__CHANGED__
+#-------------------------------------------------------------------------------
+TEST_KEY=$TEST_KEY_BASE-create-single-alias-ok-1
+svn checkout -q $SVN_URL/ foo_wc/
+svn propset rosie:authoraliases "daisynew2:daisynew" foo_wc/
+run_pass "$TEST_KEY" svn commit -q -m 't' --username=rosie foo_wc
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+svnlook changed repos/foo >"$TEST_KEY.changed"
+file_cmp "$TEST_KEY.changed" "$TEST_KEY.changed" <<'__CHANGED__'
+_U  /
+__CHANGED__
+rm -rf foo_wc
+#-------------------------------------------------------------------------------
+TEST_KEY=$TEST_KEY_BASE-modify-with-single-alias-good-1
+svn update -q aa000
+echo "bicycle_for=two" >>aa000/rose-suite.info
+REV1=$(svn info --show-item revision aa000/)
+run_pass "$TEST_KEY" svn commit -q -m 't' --username=daisynew2 aa000
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+svn update -q aa000
+REV2=$(svn info --show-item revision aa000/)
+run_pass "$TEST_KEY.rev" bash -c "(( $REV2 > $REV1 ))"
+svnlook changed repos/foo >"$TEST_KEY.changed"
+file_cmp "$TEST_KEY.changed" "$TEST_KEY.changed" <<'__CHANGED__'
+U   a/a/0/0/0/trunk/rose-suite.info
+__CHANGED__
+#-------------------------------------------------------------------------------
+exit 0


### PR DESCRIPTION
Allow alternate usernames in order to support migrating a roses repository to a place with different auth.