### PR TITLE
linux.die.net anti crawler settings cause linkcheck failure

### DIFF
--- a/sphinx/conf.py
+++ b/sphinx/conf.py
@@ -213,6 +213,11 @@ texinfo_documents = [
 # How to display URL addresses: 'footnote', 'no', or 'inline'.
 # texinfo_show_urls = 'footnote'
 
+linkcheck_ignore = [
+    # linux.die.net doesn't like our request headers
+    'https?://linux.die.net/man/1/bash',
+]
+
 
 def setup(app):
     # set the html_static_path in an extension so as not to conflict with


### PR DESCRIPTION
Copy of a "fix"* from https://github.com/cylc/cylc-doc/pull/653.

\* The fix is to ignore the link.