### PR TITLE
replace smtpd with aiosmtpd to make tests work at Python 3.12

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -79,6 +79,7 @@ graph =
     pygraphviz>1.0,!=1.8
 rosa =
 tests =
+    aiosmtpd
     flake8>=4.0.0
     mypy>=0.800
     pytest

--- a/t/lib/bash/test_header
+++ b/t/lib/bash/test_header
@@ -327,10 +327,13 @@ mock_smtpd_init() {
     for SMTPD_PORT in 8025 8125 8225 8325 8425 8525 8625 8725 8825 8925; do
         local SMTPD_HOST=localhost:$SMTPD_PORT
         local SMTPD_LOG="$TEST_DIR/smtpd.log"
-        python3 -u -m smtpd -n -c DebuggingServer -d -n "$SMTPD_HOST" \
-            1>"$SMTPD_LOG" 2>&1 &
+        python3 -u -m 'aiosmtpd' \
+            --class aiosmtpd.handlers.Debugging stdout \
+            --debug --nosetuid \
+            --listen "${SMTPD_HOST}" \
+            1>"${SMTPD_LOG}" 2>&1 &  # Runs in background
         local SMTPD_PID=$!
-        while ! grep -q 'DebuggingServer started' "$SMTPD_LOG" 2>/dev/null; do
+        while ! grep -q 'is listening' "$SMTPD_LOG" 2>/dev/null; do
             if ps $SMTPD_PID 1>/dev/null 2>&1; then
                 sleep 1
             else


### PR DESCRIPTION
Equivelent of https://github.com/cylc/cylc-flow/pull/5794.

The standardlibrary module `smtpd` has been deprecated since 3.6 and will be removed at 3.12. ([citation](https://docs.python.org/3.11/library/smtpd.html))

To make this test work we need to replace use of `smtpd` with `aiosmtpd`.