### PR TITLE
Fix unescaped content injection in rosie disco

### DIFF
--- a/metomi/rosie/lib/html/template/rosie-disco/prefix-index.html
+++ b/metomi/rosie/lib/html/template/rosie-disco/prefix-index.html
@@ -225,7 +225,7 @@
 {%- if "-list" in key %}
 {%- set value = value|join(" ") %}
 {%- endif %}
-{%- set info = info ~ "<strong>" ~ key ~ "</strong>" ~ ": " ~ value ~ "<br/>"  %}
+{%- set info = info ~ "<strong>" ~ key ~ "</strong>" ~ ": " ~ value|escape ~ "<br/>"  %}
 {%- endif %}
 {%- if loop.last %}
           <tr>


### PR DESCRIPTION
Rosie Disco is disabled but might as well cherry-pick fix from #2765