### PR TITLE
Docs: fix misleading tip

### DIFF
--- a/sphinx/tutorial/rose/metadata.rst
+++ b/sphinx/tutorial/rose/metadata.rst
@@ -357,8 +357,11 @@ Metadata Items
 
       .. tip::
 
-         The :rose:conf:`rose-meta.conf[SETTING]value-hints` metadata option
-         can be used to provide a longer description of each option.
+         Longer descriptions can be included:
+
+         * :rose:conf:`rose-meta.conf[SETTING]description` provides a tooltip.
+         * :rose:conf:`rose-meta.conf[SETTING]help` will appear in a separate
+           window accessible in the GUI.
 
    #. **Validate with** ``rose macro``.
 


### PR DESCRIPTION
Value hints gives a list of possible values, like a non-exclusive version of `value-titles`.

Served locally at <my-domain>/rose-doc/rose 2.2.0/html/tutorial/rose/metadata.html#admonition-4

[Reference for `value-titles`](https://metomi.github.io/rose/doc/html/api/configuration/metadata.html#rose:conf:rose-meta.conf[SETTING]value-hints)

P.S. Slide-builder is broken.