### PR TITLE
GH Actions: bump MacOS Python version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,7 +86,7 @@ jobs:
         python-version: ['3.7', '3.8', '3.9']
         include:
           - os: 'macos-latest'
-            python-version: '3.7'
+            python-version: '3.8'
 
     steps:
       - name: Checkout

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -109,8 +109,7 @@ jobs:
             coreutils \
             gnu-sed \
             sqlite3 \
-            subversion \
-            graphviz
+            subversion
 
           # add GNU coreutils and sed to the user PATH (for actions steps)
           # (see instructions in brew install output)
@@ -141,7 +140,7 @@ jobs:
       - name: Install Rose
         working-directory: rose
         run: |
-          pip install ."[all]"
+          pip install ."[${{ (startsWith(matrix.os, 'ubuntu') && 'all') || 'tests,docs' }}]"
           yarn install
 
       - name: Install Cylc


### PR DESCRIPTION
Python 3.7 no longer supported on latest MacOS runner