### PR TITLE
Docs: correct options for possible location of `rose.conf`

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -35,4 +35,5 @@ Thomas Coleman       <thomas.coleman@bom.gov.au>          Tom Coleman          <
 Tim Pillinger        <tim.pillinger@metoffice.gov.uk>     wxtim                <tim.pillinger@metoffice.gov.uk>
 Tim Pillinger        <26465611+wxtim@users.noreply.github.com>
 Tomasz Trzeciak      <tomasz.trzeciak@metoffice.gov.uk>   TomekTrzeciak        <tomasz.trzeciak@metoffice.gov.uk>
-Joe Marsh Rossney    <17361029+marshrossney@users.noreply.github.com>
+Joe Marsh Rossney    <17361029+jmarshrossney@users.noreply.github.com>
+Joe Marsh Rossney    <17361029+jmarshrossney@users.noreply.github.com> <17361029+marshrossney@users.noreply.github.com>

--- a/.mailmap
+++ b/.mailmap
@@ -35,3 +35,4 @@ Thomas Coleman       <thomas.coleman@bom.gov.au>          Tom Coleman          <
 Tim Pillinger        <tim.pillinger@metoffice.gov.uk>     wxtim                <tim.pillinger@metoffice.gov.uk>
 Tim Pillinger        <26465611+wxtim@users.noreply.github.com>
 Tomasz Trzeciak      <tomasz.trzeciak@metoffice.gov.uk>   TomekTrzeciak        <tomasz.trzeciak@metoffice.gov.uk>
+Joe Marsh Rossney    <17361029+marshrossney@users.noreply.github.com>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,6 +53,7 @@ below:
  - Ronnie Dutta (Met Office, UK)
  - Roddy Sharp (Met Office UK)
  - Mark Dawson (Met Office UK)
+ - Joe Marsh Rossney (UK Centre for Ecology & Hydrology)
 <!-- end-shortlog -->
 
 (All contributors are identifiable with email addresses in the version control

--- a/sphinx/installation.rst
+++ b/sphinx/installation.rst
@@ -76,8 +76,8 @@ Configuring Rose
 
 Rose configuration files can be located in the following places:
 
-* ``/etc/.metomi/rose.conf``
-* ``$ROSE_SITE_CONF_PATH/.metomi/rose.conf``
+* ``/etc/rose.conf``
+* ``$ROSE_SITE_CONF_PATH/rose.conf``
 * ``$HOME/.metomi/rose.conf``
 
 See :rose:file:`rose.conf` in the API reference for more information.


### PR DESCRIPTION
Changed 2 lines in [the docs](https://metomi.github.io/rose/doc/html/installation.html#configuring-rose) for configuring rose:

`/etc/.metomi/rose.conf` --> `/etc/rose.conf` \
`$ROSE_SITE_CONF_PATH/.metomi/rose.conf` --> `$ROSE_SITE_CONF_PATH/rose.conf`

The [docstring](https://metomi.github.io/rose/doc/html/api/configuration/site-and-user.html#rose:file:rose.conf) is correct.

Cheers!