### PR TITLE
Fix traceback when git is not installed

### DIFF
--- a/metomi/rose/popen.py
+++ b/metomi/rose/popen.py
@@ -268,7 +268,7 @@ class RosePopener:
         except OSError as exc:
             if exc.filename is None and args:
                 exc.filename = args[0]
-            raise RosePopenError(args, 1, "", str(exc))
+            raise RosePopenError(args, exc.errno, "", str(exc)) from None
         return proc
 
     def run_nohup_gui(self, cmd):

--- a/metomi/rose/tests/test_git.py
+++ b/metomi/rose/tests/test_git.py
@@ -1,0 +1,45 @@
+# Copyright (C) British Crown (Met Office) & Contributors.
+# This file is part of Rose, a framework for meteorological suites.
+#
+# Rose is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Rose is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Rose. If not, see <http://www.gnu.org/licenses/>.
+
+
+import shutil
+import pytest
+from secrets import token_hex
+
+from metomi.rose.config_processors.fileinstall import (
+    PullableLocHandlersManager,
+)
+from metomi.rose.loc_handlers.git import GitLocHandler
+
+
+require_git = pytest.mark.skipif(
+    shutil.which('git') is None,
+    reason="git is not installed"
+)
+
+
+@require_git
+def test_init_ok():
+    handler = GitLocHandler(PullableLocHandlersManager())
+    assert len(handler.git_version) > 1
+    assert all(isinstance(i, int) for i in handler.git_version)
+
+
+def test_init_no_git(monkeypatch: pytest.MonkeyPatch):
+    """Test the handler doesn't throw a tantrum if git is not installed."""
+    monkeypatch.setattr(GitLocHandler, 'GIT', token_hex(8))
+    handler = GitLocHandler(PullableLocHandlersManager())
+    assert handler.git_version is None


### PR DESCRIPTION
Closes #2809 - fixes `rose app-run` and `rose task-run` crashing if git is not installed