### PR TITLE
Remove reference to UTC mode (setting now sensibly defaults to true i…

### DIFF
--- a/sphinx/tutorial/rose/furthertopics/command-keys.rst
+++ b/sphinx/tutorial/rose/furthertopics/command-keys.rst
@@ -25,8 +25,6 @@ looks like this:
 
 .. code-block:: cylc
 
-   [scheduler]
-       UTC mode = True # Ignore DST
    [scheduling]
        [[graph]]
            R1 = gather_ingredients => breadmaker

--- a/sphinx/tutorial/rose/furthertopics/polling.rst
+++ b/sphinx/tutorial/rose/furthertopics/polling.rst
@@ -23,8 +23,6 @@ file that looks like this:
 
 .. code-block:: cylc
 
-   [scheduler]
-       UTC mode = True # Ignore DST
    [scheduling]
        [[graph]]
            R1 = """

--- a/sphinx/tutorial/rose/furthertopics/rose-arch.rst
+++ b/sphinx/tutorial/rose/furthertopics/rose-arch.rst
@@ -24,7 +24,6 @@ file that looks like this:
 .. code-block:: cylc
 
    [scheduler]
-       UTC mode = True # Ignore DST
        [[events]]
            abort on workflow timeout = True
            workflow timeout = PT1H

--- a/sphinx/tutorial/rose/furthertopics/rose-bunch.rst
+++ b/sphinx/tutorial/rose/furthertopics/rose-bunch.rst
@@ -54,8 +54,6 @@ file that looks like this:
 
 .. code-block:: cylc
 
-   [scheduler]
-       UTC mode = True # Ignore DST
    [scheduling]
        [[graph]]
            R1 = lander

--- a/sphinx/tutorial/rose/furthertopics/rose-stem-tutorial.rst
+++ b/sphinx/tutorial/rose/furthertopics/rose-stem-tutorial.rst
@@ -134,9 +134,7 @@ The ``flow.cylc`` file
 
 Next we will look at the ``rose-stem/flow.cylc`` file.
 
-The ``flow.cylc`` file starts off with ``UTC mode = True``, which you
-should already be :ref:`familiar with <tutorial-cylc-datetime-utc>`.
-The next part is a Jinja2 block which links the group names the user
+The section is a Jinja2 block which links the group names the user
 can specify with the :term:`graph <graph>` for that group. In this
 case, the group ``command_spaceship`` gives you the graph:
 

--- a/sphinx/tutorial/rose/suites.rst
+++ b/sphinx/tutorial/rose/suites.rst
@@ -193,8 +193,6 @@ Using a Rose workflow configuration with Cylc 8
       .. code-block:: diff
 
          + #!jinja2
-         [scheduler]
-             UTC mode = True
 
    #. **Write suite metadata**
 
@@ -255,8 +253,6 @@ Using a Rose workflow configuration with Cylc 8
 
       .. code-block:: diff
 
-          [scheduler]
-              UTC mode = True
           [task parameters]
              # A list of the weather stations we will be fetching observations from.
          -   station = camborne, heathrow, shetland, aldergrove


### PR DESCRIPTION
…n Cylc) from workflows.

Compliments #2835