### PR TITLE
Fix.orphan

### DIFF
--- a/sphinx/conf.py
+++ b/sphinx/conf.py
@@ -83,7 +83,7 @@ intersphinx_mapping = {
     'python': ('https://docs.python.org/', None),
 }
 
-rst_epilog = open('hyperlinks.rst', 'r').read()
+rst_epilog = open('hyperlinks.txt', 'r').read()
 
 # Slide (hieroglyph) settings.
 slide_theme = 'single-level'

--- a/sphinx/hyperlinks.txt
+++ b/sphinx/hyperlinks.txt
@@ -1,5 +1,3 @@
-:orphan:
-
 .. This document contains hyperlink references to be used throughout the
    documentation.
 

--- a/sphinx/tutorial/rose/configurations.rst
+++ b/sphinx/tutorial/rose/configurations.rst
@@ -1,4 +1,4 @@
- .. include:: ../../hyperlinks.rst
+
     :start-line: 1
 
 

--- a/sphinx/tutorial/rose/furthertopics/failif-warnif.rst
+++ b/sphinx/tutorial/rose/furthertopics/failif-warnif.rst
@@ -1,4 +1,4 @@
-.. include:: ../../../hyperlinks.rst
+
    :start-line: 1
 
 .. _tutorial-rose-fail-if-warn-if:

--- a/sphinx/tutorial/rose/furthertopics/rose-stem-tutorial.rst
+++ b/sphinx/tutorial/rose/furthertopics/rose-stem-tutorial.rst
@@ -1,4 +1,4 @@
-.. include:: ../../../hyperlinks.rst
+
    :start-line: 1
 
 .. _Rose Stem Tutorial:

--- a/sphinx/tutorial/rose/furthertopics/rose-stem.rst
+++ b/sphinx/tutorial/rose/furthertopics/rose-stem.rst
@@ -1,4 +1,4 @@
-.. include:: ../../../hyperlinks.rst
+
    :start-line: 1
 
 .. _Rose Stem:


### PR DESCRIPTION
* Avoid displaying `:orphan:` directive in built pages.
* Remove unecessary includes for `hyperlinks.rst`.

Built copy at: https://wwwspice/~tim.pillinger/doc/rose/rose%202.4.0.dev/html/tutorial/rose/configurations.html


### Background

According to [this thread](https://github.com/readthedocs/readthedocs.org/issues/809) on readthedocs this is a problem with including RST metadata.
