### PR TITLE
actions: use mamba to provision Python environment

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ on:
 
 defaults:
   run:
-    shell: micromamba-shell {0}
+    shell: bash -c "exec $CONDA_PREFIX/bin/bash -elo pipefail {0}"
 
 jobs:
   lint:
@@ -52,12 +52,12 @@ jobs:
       - name: Configure Python
         uses: mamba-org/setup-micromamba@v2
         with:
-          generate-run-shell: true
           cache-environment: true
           post-cleanup: 'all'
           environment-name: rose-lint
           create-args: >-
             python=${{ matrix.python-version }}
+            bash
             shellcheck
 
       - name: Install Rose
@@ -101,12 +101,12 @@ jobs:
       - name: Configure Python
         uses: mamba-org/setup-micromamba@v2
         with:
-          generate-run-shell: true
           cache-environment: true
           post-cleanup: 'all'
           environment-name: rose-test
           create-args: >-
             python=${{ matrix.python-version }}
+            bash
             coreutils
             sed
             sqlite
@@ -120,12 +120,11 @@ jobs:
       - name: Brew Install
         if: startsWith(matrix.os, 'macos')
         run: |
-          # install a modern version of Bash (Mac OS uses zsh as default shell)
-          brew install bash subversion
+          brew install subversion
 
           # supress a mac os error
+          # see NOTE in t/rosie-lookup/00-basic.t
           cat >> "$HOME/.bashrc" <<__HERE__
-            # see NOTE in t/rosie-lookup/00-basic.t
           export OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES
           __HERE__
 
@@ -234,12 +233,12 @@ jobs:
       - name: Configure Python
         uses: mamba-org/setup-micromamba@v2
         with:
-          generate-run-shell: true
           cache-environment: true
           post-cleanup: 'all'
           environment-name: rose-docs
           create-args: >-
             python=${{ matrix.python-version }}
+            bash
             pygraphviz
 
       - name: Install Rose

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,10 +34,13 @@ on:
 
 defaults:
   run:
-    shell: bash  # macos default shell is zsh
+    shell: micromamba-shell {0}
 
 jobs:
   lint:
+    strategy:
+      matrix:
+        python-version: ['3.9']
     runs-on: ubuntu-latest
     timeout-minutes: 3
     steps:
@@ -47,14 +50,15 @@ jobs:
           ref: ${{ inputs.rose_ref || github.sha }}
 
       - name: Configure Python
-        uses: actions/setup-python@v5
+        uses: mamba-org/setup-micromamba@v2
         with:
-          python-version: 3.9
-
-      - name: Apt-Get Install
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y shellcheck
+          generate-run-shell: true
+          cache-environment: true
+          post-cleanup: 'all'
+          environment-name: rose-lint
+          create-args: >-
+            python=${{ matrix.python-version }}
+            shellcheck
 
       - name: Install Rose
         run: |
@@ -76,19 +80,17 @@ jobs:
 
 
   test:
-    needs: lint
     runs-on: ${{ matrix.os }}
     timeout-minutes: ${{ contains(matrix.os, 'macos') && 30 || 20 }}
     strategy:
       fail-fast: false
       matrix:
         os: ['ubuntu-latest']
-        python-version: ['3.8', '3.9', '3.x']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12', '3']
         include:
-          - os: ubuntu-22.04
-            python-version: '3.7'
           - os: 'macos-latest'
-            python-version: '3.8'
+            python-version: '3.8'  # oldest arm64 build on conda-forge
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -97,9 +99,20 @@ jobs:
           path: rose
 
       - name: Configure Python
-        uses: actions/setup-python@v5
+        uses: mamba-org/setup-micromamba@v2
         with:
-          python-version: ${{ matrix.python-version }}
+          generate-run-shell: true
+          cache-environment: true
+          post-cleanup: 'all'
+          environment-name: rose-test
+          create-args: >-
+            python=${{ matrix.python-version }}
+            coreutils
+            sed
+            sqlite
+            shellcheck
+            sqlite
+            pygraphviz
 
       - name: Patch DNS
         uses: cylc/release-actions/patch-dns@v1
@@ -107,38 +120,17 @@ jobs:
       - name: Brew Install
         if: startsWith(matrix.os, 'macos')
         run: |
-          # install system deps
-          brew install \
-            bash \
-            coreutils \
-            gnu-sed \
-            sqlite3 \
-            subversion
+          # install a modern version of Bash (Mac OS uses zsh as default shell)
+          brew install bash subversion
 
-          # add GNU coreutils and sed to the user PATH (for actions steps)
-          # (see instructions in brew install output)
-          echo "$(brew --prefix)/opt/coreutils/libexec/gnubin" >> "${GITHUB_PATH}"
-          echo "$(brew --prefix)/opt/gnu-sed/libexec/gnubin" >> "${GITHUB_PATH}"
-
-          # add GNU coreutils and sed to the user PATH (for Cylc jobs)
+          # supress a mac os error
           cat >> "$HOME/.bashrc" <<__HERE__
-          PATH="$(brew --prefix)/opt/coreutils/libexec/gnubin:$PATH"
-          PATH="$(brew --prefix)/opt/gnu-sed/libexec/gnubin:$PATH"
-          PATH="$pythonLocation:\$PATH"
-          export PATH
-          # see NOTE in t/rosie-lookup/00-basic.t
+            # see NOTE in t/rosie-lookup/00-basic.t
           export OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES
           __HERE__
-          cat "$HOME/.bashrc"
 
       - name: Configure git  # Configure Git for Git dependent tests.
         uses: cylc/release-actions/configure-git@v1
-
-      - name: Apt-Get Install
-        if: startsWith(matrix.os, 'ubuntu')
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y shellcheck sqlite3 at graphviz graphviz-dev
 
       - name: Install Rose
         working-directory: rose
@@ -170,6 +162,7 @@ jobs:
         if: startsWith(matrix.os, 'ubuntu')
         run: |
           # install FCM deps
+          sudo apt-get update
           sudo apt-get install -y \
             subversion \
             build-essential \
@@ -227,9 +220,11 @@ jobs:
           path: ~/cylc-run/
 
   docs:
-    needs: lint
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    strategy:
+      matrix:
+        python-version: ['3.9']
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -237,18 +232,19 @@ jobs:
           ref: ${{ inputs.rose_ref || github.sha }}
 
       - name: Configure Python
-        uses: actions/setup-python@v5
+        uses: mamba-org/setup-micromamba@v2
         with:
-          python-version: 3.9
-
-      - name: install graphviz
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y graphviz pkg-config libgraphviz-dev
+          generate-run-shell: true
+          cache-environment: true
+          post-cleanup: 'all'
+          environment-name: rose-docs
+          create-args: >-
+            python=${{ matrix.python-version }}
+            pygraphviz
 
       - name: Install Rose
         run: |
-          pip install -e .[docs,graph]
+          pip install -e .[docs,graph] --upgrade-strategy='only-if-needed'
 
       - name: Install Cylc
         uses: cylc/release-actions/install-cylc-components@v1

--- a/t/rose-config-diff/00-basic.t
+++ b/t/rose-config-diff/00-basic.t
@@ -338,28 +338,30 @@ file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
 TEST_KEY=$TEST_KEY_BASE-custom-diff-tool-config-graphical
 cat >conf/rose.conf <<__ROSE_CONF__
 [external]
-gdiff_tool=diff -y
+gdiff_tool=diff --unified --label=a --label=b
 __ROSE_CONF__
 run_fail "$TEST_KEY" rose config-diff -g $TEST_DIR/app{1,2}/rose-app.conf
-# Note: two column layout assumes 8 space tabs.
 file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<'__DIFF__'
-# description=Environment variable configuration		# description=Environment variable configuration
-[env]								[env]
-# description=The number of gears available.		      <
-# title=Gearbox Gears					      <
-# 1 reverse, 5 forward					      <
-GEARBOX_GEARS=6						      <
-# help=1  3  5						      <
-#     =|  |  |						      <
-#     =-------						      <
-#     =|  |  |						      <
-#     =2  4  R						      <
-GEARSTICK_DECORATION=golfball					GEARSTICK_DECORATION=golfball
-							      >
-							      >	# description=Different choices of locking methods, if availa
-							      >	[namelist:locking]
-							      >	# title=Air Locking?
-							      >	air_locking=.false.
+--- a
++++ b
+@@ -1,12 +1,8 @@
+ # description=Environment variable configuration
+ [env]
+-# description=The number of gears available.
+-# title=Gearbox Gears
+-# 1 reverse, 5 forward
+-GEARBOX_GEARS=6
+-# help=1  3  5
+-#     =|  |  |
+-#     =-------
+-#     =|  |  |
+-#     =2  4  R
+ GEARSTICK_DECORATION=golfball
++
++# description=Different choices of locking methods, if available.
++[namelist:locking]
++# title=Air Locking?
++air_locking=.false.
 __DIFF__
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
* Fixes test failures.
* Get Python from conda-forge rather than the OS vendor.
* Test with all supported Python versions.
* Requires https://github.com/cylc/release-actions/pull/100
* Fix the remaining Mac OS test failure by using a more stable `diff` output format.

Note, the Mamba environments are cached which should bring some speedup, but unfortunately, we won't feel this until we completely phase out the OS package managers (which I wasn't able to do).