### PR TITLE
ConfigNodeDiff.get_as_opt_config: preserve parent attributes

### DIFF
--- a/metomi/rose/macro.py
+++ b/metomi/rose/macro.py
@@ -1586,9 +1586,11 @@ def apply_macro_to_config_map(
             # Always the first item.
             new_config_map[conf_key] = new_config
         else:
+            # the diff between the modified config and the modified base config
             diff = new_config - new_config_map[None]
-            new_opt_config = diff.get_as_opt_config()
+            new_opt_config = diff.get_as_opt_config(base_config=new_config)
             new_config_map[conf_key] = new_opt_config
+
     return new_config_map, changes_map
 
 

--- a/t/rose-app-upgrade/14-same-transformation-applied-to-opt-config.t
+++ b/t/rose-app-upgrade/14-same-transformation-applied-to-opt-config.t
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+#-------------------------------------------------------------------------------
+# Copyright (C) British Crown (Met Office) & Contributors.
+#
+# This file is part of Rose, a framework for meteorological suites.
+#
+# Rose is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Rose is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Rose. If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test to ensure that the state of parent nodes is not lost during the
+# generation of optional configs.
+# See https://github.com/metomi/rose/issues/2853
+#-------------------------------------------------------------------------------
+. $(dirname $0)/test_header
+#-------------------------------------------------------------------------------
+tests 4
+rsync -vr "$TEST_SOURCE_DIR/$TEST_KEY_BASE/" .
+run_pass "${TEST_KEY_BASE}-init" git init '.'; git add '.'; git commit -m '.'
+run_pass "${TEST_KEY_BASE}-upgrade" \
+  rose app-upgrade \
+    -a -y --debug --verbose \
+    -M rose-meta/ \
+    -C app/example_app/ \
+    vn1.0_t999
+run_pass "${TEST_KEY_BASE}-diff" git diff
+
+file_cmp "${TEST_KEY_BASE}-kgo" "${TEST_KEY_BASE}-diff.out" <<__HERE__
+diff --git a/app/example_app/opt/rose-app-demo.conf b/app/example_app/opt/rose-app-demo.conf
+index ec076f4..087a01d 100644
+--- a/app/example_app/opt/rose-app-demo.conf
++++ b/app/example_app/opt/rose-app-demo.conf
+@@ -1,2 +1,5 @@
++[!!namelist:namelist_2]
++!!new_value=10.0
++
+ [namelist:namelist_3]
+ existing_value=10.0
+diff --git a/app/example_app/rose-app.conf b/app/example_app/rose-app.conf
+index 4a4a5c6..7f34d78 100644
+--- a/app/example_app/rose-app.conf
++++ b/app/example_app/rose-app.conf
+@@ -1,4 +1,4 @@
+-meta=example_meta/vn1.0
++meta=example_meta/vn1.0_t999
+ 
+ [command]
+ default=true
+@@ -7,6 +7,7 @@ default=true
+ use_namelist_2=.false.
+ 
+ [!!namelist:namelist_2]
++!!new_value=5.0
+ !!other_value=1.0
+ 
+ [namelist:namelist_3]
+__HERE__
+
+exit 0

--- a/t/rose-app-upgrade/14-same-transformation-applied-to-opt-config/app/example_app/opt/rose-app-demo.conf
+++ b/t/rose-app-upgrade/14-same-transformation-applied-to-opt-config/app/example_app/opt/rose-app-demo.conf
@@ -1,0 +1,2 @@
+[namelist:namelist_3]
+existing_value=10.0

--- a/t/rose-app-upgrade/14-same-transformation-applied-to-opt-config/app/example_app/rose-app.conf
+++ b/t/rose-app-upgrade/14-same-transformation-applied-to-opt-config/app/example_app/rose-app.conf
@@ -1,0 +1,13 @@
+meta=example_meta/vn1.0
+
+[command]
+default=true
+
+[namelist:namelist_1]
+use_namelist_2=.false.
+
+[!!namelist:namelist_2]
+!!other_value=1.0
+
+[namelist:namelist_3]
+existing_value=5.0

--- a/t/rose-app-upgrade/14-same-transformation-applied-to-opt-config/rose-meta/example_meta/HEAD/rose-meta.conf
+++ b/t/rose-app-upgrade/14-same-transformation-applied-to-opt-config/rose-meta/example_meta/HEAD/rose-meta.conf
@@ -1,0 +1,34 @@
+[namelist:namelist_1]
+compulsory=true
+title=Namelist 1
+
+[namelist:namelist_1=use_namelist_2]
+compulsory=true
+description=logical to trigger namelist_2
+trigger=namelist:namelist_2: .true. ;
+       =namelist:namelist_2=other_value: .true. ;
+       =namelist:namelist_2=new_value: .true. ;
+type=logical
+
+[namelist:namelist_2]
+compulsory=true
+title=Namelist 2
+
+[namelist:namelist_2=other_value]
+compulsory=true
+description=other nml2 value, not used
+type=real
+
+[namelist:namelist_2=new_value]
+compulsory=true
+description=new value from upgrade macro. Is equal to nml3:existing_values
+type=real
+
+[namelist:namelist_3]
+compulsory=true
+title=Namelist 3
+
+[namelist:namelist_3=existing_value]
+compulsory=true
+description=existing value to set nml2:new_value
+type=real

--- a/t/rose-app-upgrade/14-same-transformation-applied-to-opt-config/rose-meta/example_meta/versions.py
+++ b/t/rose-app-upgrade/14-same-transformation-applied-to-opt-config/rose-meta/example_meta/versions.py
@@ -1,0 +1,34 @@
+import sys
+
+from metomi.rose.upgrade import MacroUpgrade
+
+
+class UpgradeError(Exception):
+    """Exception created when an upgrade fails."""
+
+    def __init__(self, msg):
+        self.msg = msg
+
+    def __repr__(self):
+        sys.tracebacklimit = 0
+        return self.msg
+
+    __str__ = __repr__
+
+
+class vn10_t999(MacroUpgrade):
+
+    BEFORE_TAG = "vn1.0"
+    AFTER_TAG = "vn1.0_t999"
+
+    def upgrade(self, config, meta_config=None):
+        existing_value = self.get_setting_value(
+            config,
+            ["namelist:namelist_3", "existing_value"]
+        )
+        self.add_setting(
+            config,
+            ["namelist:namelist_2", "new_value"],
+            existing_value
+        )
+        return config, self.reports

--- a/t/rose-app-upgrade/14-same-transformation-applied-to-opt-config/rose-meta/example_meta/vn1.0/rose-meta.conf
+++ b/t/rose-app-upgrade/14-same-transformation-applied-to-opt-config/rose-meta/example_meta/vn1.0/rose-meta.conf
@@ -1,0 +1,29 @@
+[namelist:namelist_1]
+compulsory=true
+title=Namelist 1
+
+[namelist:namelist_1=use_namelist_2]
+compulsory=true
+description=logical to trigger namelist_2
+trigger=namelist:namelist_2: .true. ;
+       =namelist:namelist_2=other_value: .true. ;
+       =namelist:namelist_2=new_value: .true. ;
+type=logical
+
+[namelist:namelist_2]
+compulsory=true
+title=Namelist 2
+
+[namelist:namelist_2=other_value]
+compulsory=true
+description=other nml2 value, not used
+type=real
+
+[namelist:namelist_3]
+compulsory=true
+title=Namelist 3
+
+[namelist:namelist_3=existing_value]
+compulsory=true
+description=existing value to set nml2:new_value
+type=real


### PR DESCRIPTION
* If a setting (e.g. `namelist:a=b`) is present in a ConfigNodeDiff, but its parent (e.g. `namelist:a`) is not. Then the state and comments of parent node may not be present in the diff if they have not changed.
* As a result the state and comments of the parent node may be incorrect in the output generated by `get_as_opt_config`.
* This commit detects parent nodes that are not present in the diff and adds an option to transfer them from a provided node.
* closes https://github.com/metomi/rose/issues/2853