### PR TITLE
Explicitly include testing Python 3.7 on legacy Ubuntu

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -96,10 +96,12 @@ jobs:
       fail-fast: false
       matrix:
         os: ['ubuntu-latest']
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12', '3']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3']
         include:
           - os: 'macos-latest'
             python-version: '3.8'  # oldest arm64 build on conda-forge
+          - os: 'ubuntu-22.04'
+            python-version: '3.7'  # Support dropped on later Ubuntu versions
 
     steps:
       - name: Checkout

--- a/sphinx/conf.py
+++ b/sphinx/conf.py
@@ -224,6 +224,9 @@ texinfo_documents = [
 linkcheck_ignore = [
     # linux.die.net doesn't like our request headers
     'https?://linux.die.net/man/1/rsync',
+    # ... nor does stackoverflow
+    'https?://stackoverflow.com',
+    'https?://www.gnu.org',
 ]
 
 


### PR DESCRIPTION
Python 3.7 is no longer supported on Ubuntu latest.

A couple more websites are resisisting automatic link checks. 😞 