### PR TITLE
Remove rosie go from the list of entry points

### DIFF
--- a/metomi/rose/rose.py
+++ b/metomi/rose/rose.py
@@ -249,13 +249,19 @@ def load_entry_point(entry_point: 'EntryPoint'):
 
 
 def _get_sub_cmds(ns):
-    for ns_, sub_cmd in set(PYTHON_SUB_CMDS) | BASH_SUB_CMDS:
+    for ns_, sub_cmd in (
+        set(PYTHON_SUB_CMDS) | BASH_SUB_CMDS
+    ) - set(DEAD_ENDS):
         if ns_ == ns:
             yield sub_cmd
 
 
 def get_arg_parser(description, sub_cmds, ns):
+    # Add alias names in brackets to sub commands in the help text.
+    aliases = {v[1]: f'({k[1]})' for k, v in ALIASES.items()}
+    sub_cmds = [f'{i} {aliases.get(i, "")}' for i in sub_cmds]
     epilog = f'Commands:\n  {ns} ' + f'\n  {ns} '.join(sorted(sub_cmds))
+
     parser = argparse.ArgumentParser(
         add_help=False,
         description=description,

--- a/setup.cfg
+++ b/setup.cfg
@@ -128,7 +128,6 @@ rosie.commands =
     create = metomi.rosie.vc:create
     delete = metomi.rosie.vc:delete
     disco = metomi.rosie.ws:main [disco]
-    go = metomi.rosie.browser:main
     graph = metomi.rosie.graph:main [graph]
     hello = metomi.rosie.ws_client_cli:hello
     id = metomi.rosie.suite_id:main


### PR DESCRIPTION
* Remove `rosie go` and `rosie disco` from the list of entry points so that they don't appear in the help docs.
  * Both commands still return messages about being dead end-points.ls 
  * `rosie disco`'s code remains unchanged at `metomi.rosie.ws`. Removing the entry point just removes it from the list show by `rosie help`.
  * `rosie go` points to a file (`lib/python/rosie/browser/main.py`) which [I removed in 2018](https://github.com/metomi/rose/pull/2286)!
* Make the help docs show where commands have aliases.