### PR TITLE
attempt to fix broken doc linkcheck

### DIFF
--- a/sphinx/conf.py
+++ b/sphinx/conf.py
@@ -224,6 +224,7 @@ texinfo_documents = [
 linkcheck_ignore = [
     # linux.die.net doesn't like our request headers
     'https?://linux.die.net/man/1/rsync',
+    'https?://stackoverflow.com.*',
 ]
 
 


### PR DESCRIPTION
Tried to use feature from https://github.com/sphinx-doc/sphinx/pull/7762/files, but couldn't get it working, even copying the headers straight out of my browser.
