### PR TITLE
actions: run shortlog on a schedule

### DIFF
--- a/.github/workflows/shortlog.yml
+++ b/.github/workflows/shortlog.yml
@@ -5,6 +5,8 @@ on:
   pull_request:
     paths:
       - 'CONTRIBUTING.md'
+  schedule:
+    - cron: '37 06 * * 1' # 06:37, Monday
 
 jobs:
   test:


### PR DESCRIPTION
We should run this check every now and again so we don't spot the problem at release time.

@wxtim, would you mind copying this change to the other repos?