### PR TITLE
Add sphinx copybutton extension

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,9 +72,10 @@ docs = [
     "cylc-sphinx-extensions[all]>=1.2.0",
     "hieroglyph>=2.1.0",
     "sphinx",
+    "sphinx-copybutton",
     "sphinx_rtd_theme",
     "sphinxcontrib-httpdomain",
-    "sphinxcontrib-svg2pdfconverter"
+    "sphinxcontrib-svg2pdfconverter",
 ]
 graph = [
     "pygraphviz>1.0,!=1.8"

--- a/sphinx/conf.py
+++ b/sphinx/conf.py
@@ -30,6 +30,7 @@ sys.path.append(os.path.abspath('ext'))
 # Register extensions.
 extensions = [
     # sphinx built-in extensions
+    'sphinx_copybutton',
     'sphinx.ext.autodoc',
     'sphinx.ext.autosummary',
     'sphinx.ext.doctest',

--- a/sphinx/conf.py
+++ b/sphinx/conf.py
@@ -233,3 +233,6 @@ def setup(app):
     # set the html_static_path in an extension so as not to conflict with
     # cylc.sphinx_ext extensions
     app.config.html_static_path.append('_static')
+
+# Turn off copybutton for diffs
+copybutton_selector = "div:not(.highlight-diff) > div.highlight > pre"


### PR DESCRIPTION
Add a copy button to code snippets.

<img width="756" height="240" alt="image" src="https://github.com/user-attachments/assets/609f8058-f99f-442c-82c3-6e994d949256" />


I've wanted to do this for ages, but last time I looked this extension didn't exist. 

Built at https://-----------------------/doc/rose/rose%202.5.0/html/tutorial/rose/configurations.html#rose-configuration-format