### PR TITLE
rosie ls: fix command breakage

### DIFF
--- a/metomi/rosie/ws_client_cli.py
+++ b/metomi/rosie/ws_client_cli.py
@@ -398,7 +398,7 @@ def _display_maps(opts, ws_client, dict_rows, url=None):
 
     dict_rows = _align(dict_rows, keylist)
 
-    if opts.no_pretty_mode:
+    if getattr(opts, 'no_pretty_mode', True):
         for dict_row in dict_rows:
             out = opts.print_format
             for key, value in dict_row.items():


### PR DESCRIPTION
Fix breakage caused by https://github.com/metomi/rose/pull/2903

Turns out this code is called by other command(s).