### PR TITLE
GH Actions: fix test workflow when testing `*.x` branch in workflow dispatch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -150,6 +150,7 @@ jobs:
       - name: Install Cylc
         uses: cylc/release-actions/install-cylc-components@v1
         with:
+          branch: ${{ inputs.rose_ref || '' }}
           cylc_flow: true
           cylc_flow_opts: ''
           cylc_flow_repo: ${{ inputs.cylc_flow_repo || 'cylc/cylc-flow' }}
@@ -258,6 +259,7 @@ jobs:
       - name: Install Cylc
         uses: cylc/release-actions/install-cylc-components@v1
         with:
+          branch: ${{ inputs.rose_ref || '' }}
           cylc_flow: true
           cylc_flow_opts: ''
           cylc_flow_repo: ${{ inputs.cylc_flow_repo || 'cylc/cylc-flow' }}


### PR DESCRIPTION
Needs:
- https://github.com/cylc/release-actions/pull/131

Tested here (although I missed the need to update docs job which failed as a result): https://github.com/MetRonnie/rose/actions/runs/19633941070