### PR TITLE
macro: fix return code

### DIFF
--- a/changes.d/3022.fix.md
+++ b/changes.d/3022.fix.md
@@ -1,0 +1,1 @@
+The `rose macro` command will now exit 1 in an error scenario it previously exited 0 in.

--- a/changes.d/3022.fix.md
+++ b/changes.d/3022.fix.md
@@ -1,1 +1,1 @@
-The `rose macro` command will now exit 1 in an error scenario it previously exited 0 in.
+The `rose macro` command will now exit 1 instead of 0 in an error scenario.

--- a/metomi/rose/macro.py
+++ b/metomi/rose/macro.py
@@ -1081,7 +1081,7 @@ def pretty_format_config(config, ignore_error=False):
                             keylist[1], new_keylist[1]
                         )
                     )
-                    sys.exit(0)
+                    sys.exit(1)
 
 
 def standard_format_config(config):

--- a/metomi/rose/tests/test_macro.py
+++ b/metomi/rose/tests/test_macro.py
@@ -1,0 +1,40 @@
+# Copyright (C) British Crown (Met Office) & Contributors.
+# This file is part of Rose, a framework for meteorological suites.
+#
+# Rose is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Rose is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Rose. If not, see <http://www.gnu.org/licenses/>.
+
+import pytest
+
+from metomi.rose.config import ConfigNode
+from metomi.rose.macro import pretty_format_config
+
+
+def test_pretty_format_config(capsys):
+    """It should exit 1 on config format issue.
+
+    See https://github.com/metomi/rose/pull/3022
+    """
+    # NOTE: there's a rule that namelist keys should be lowercase
+    node = ConfigNode()
+    node.set(['namelist:a', 'Foo'], 'bar')
+
+    # which should cause this call to exit 1
+    with pytest.raises(SystemExit) as exc_ctx:
+        pretty_format_config(node)
+
+    assert exc_ctx.value.code == 1
+
+    # and output a message to stderr
+    _out, err = capsys.readouterr()
+    assert 'Foo does not match foo' in err

--- a/t/rose-app-upgrade/13-bad-upgrade-macro.t
+++ b/t/rose-app-upgrade/13-bad-upgrade-macro.t
@@ -56,7 +56,7 @@ class Upgrade01to02(metomi.rose.upgrade.MacroUpgrade):
         return config, self.reports
 __MACRO__
 
-run_pass "$TEST_KEY" rose app-upgrade -y \
+run_fail "$TEST_KEY" rose app-upgrade -y \
 --meta-path=../rose-meta/ -C ../config/ 0.2
 file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<'__OUTPUT__'
 [U] Upgrade_0.1-0.2: changes: 2


### PR DESCRIPTION
Fix a return code reported as a bug.

This was reported as a bug in a situation where an upgrader macro was exiting `0` despite aborting before the upgrade could be performed.

This appears to be a situation where a critical error is handled with `sys.exit(0)`. The macro makes it no further through the code, but the return code doesn't suggest that anything went wrong.