### PR TITLE
Sync PR: Support alternate usernames in pre-commit

### DIFF
--- a/changes.d/3038.feat.md
+++ b/changes.d/3038.feat.md
@@ -1,0 +1,1 @@
+Support alternate usernames in pre-commit

--- a/metomi/rosie/svn_pre_commit.py
+++ b/metomi/rosie/svn_pre_commit.py
@@ -76,6 +76,20 @@ class RosieSvnPreCommitHook(RosieSvnHook):
         access_list.sort()
         return owner, access_list
 
+    def _get_author_aliases(self, repos):
+        """Return the current author alternative name map."""
+        try:
+            text = self._svnlook(
+                "cat", repos, "/R/O/S/I/E/trunk/author_aliases"
+            )
+        except Exception:
+            return {}
+        return dict([element.split(":") for element in text.split()])
+
+    def _get_author(self, txn, repos):
+        """Retrieve the author of the transaction."""
+        return self._svnlook("author", "-t", txn, repos).strip()
+
     def _verify_users(
         self, status, path, txn_owner, txn_access_list, bad_changes
     ):
@@ -114,10 +128,9 @@ class RosieSvnPreCommitHook(RosieSvnHook):
             status, path = line.split(None, 1)
             changes.add((status, path))
         bad_changes = []
-        author = None
-        super_users = None
         rev_info_map = {}
         txn_info_map = {}
+        found_author_info = False
 
         conf = ResourceLocator.default().get_conf()
         ignores_str = conf.get_value(["rosa-svn", "ignores"], self.IGNORES)
@@ -272,20 +285,27 @@ class RosieSvnPreCommitHook(RosieSvnHook):
             if (self.ST_ADDED, path_head + "trunk/") in changes:
                 continue
 
-            # See whether author has permission to make changes
-            if author is None:
-                author = self._svnlook("author", "-t", txn, repos).strip()
-            if super_users is None:
+            if not found_author_info:
+                author = self._get_author(txn, repos)
+                author_aliases = self._get_author_aliases(repos)
                 super_users = []
                 for s_key in ["rosa-svn", "rosa-svn-pre-commit"]:
                     value = conf.get_value([s_key, "super-users"])
                     if value is not None:
                         super_users = shlex.split(value)
                         break
+                found_author_info = True
+
+            # See whether author has permission to make changes
             if sid not in rev_info_map:
                 rev_info_map[sid] = self._load_info(repos, sid, branch=branch)
             owner, access_list = self._get_access_info(rev_info_map[sid])
             admin_users = super_users + [owner]
+
+            if author in author_aliases and author_aliases[author] == owner:
+                # If an author alias username is the owner, allow the new
+                # username owner privileges.
+                admin_users += [author]
 
             # Only admin users can remove the suite
             if author not in admin_users and not path_tail:
@@ -295,7 +315,11 @@ class RosieSvnPreCommitHook(RosieSvnHook):
 
             # Admin users and those in access list can modify everything in
             # trunk apart from specific entries in the trunk info file
-            if "*" in access_list or author in admin_users + access_list:
+            if (
+                "*" in access_list
+                or author in admin_users + access_list
+                or author_aliases.get(author) in access_list
+            ):
                 if path_tail != self.TRUNK_INFO_FILE:
                     continue
             else:
@@ -303,11 +327,22 @@ class RosieSvnPreCommitHook(RosieSvnHook):
                 bad_changes.append(BadChange(status, path, content=msg))
                 continue
 
-            # Only the admin users can change owner and access list
+            # Only the admin users can change owner and access list except
+            # that access list users can change them to aliases.
+
             if owner == txn_owner and access_list == txn_access_list:
+                # No substantive change made, fine.
                 continue
+
+            if owner == author_aliases.get(txn_owner) and (
+                set(access_list)
+                == {author_aliases.get(i) for i in txn_access_list}
+            ):
+                # The change has purely been an aliased one, fine.
+                continue
+
             if author not in admin_users:
-                if owner != txn_owner:
+                if owner not in {txn_owner, author_aliases.get(txn_owner)}:
                     bad_changes.append(
                         BadChange(
                             status, path, BadChange.PERM, "owner=" + txn_owner

--- a/sphinx/installation.rst
+++ b/sphinx/installation.rst
@@ -389,6 +389,24 @@ ID will end with ``ROSIE`` - e.g. ``foo-ROSIE``.
 
 This can be created by running ``rosie create --meta-suite``.
 
+User aliases
+^^^^^^^^^^^^
+
+If you need to map usernames from old to new, for example after
+migrating a Rosie repository from one platform to another with
+different authentication, you can create an ``author_aliases``
+file within the ``ROSIE`` special suite's trunk with whitespace
+separated key-value pairs e.g.::
+
+   newalice:oldalice
+   newbob:oldbob
+
+This will allow users to authenticate as owners of the suites and
+transition their owner and access-list entries over to the new
+usernames. Users on the access-list may also map old owner and
+access-list usernames over to the new ones using these aliases,
+but any incomplete or imprecise mapping will be disallowed.
+
 Creating a Known Keys File
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/t/rosa-svn-pre-commit/05-aliases.t
+++ b/t/rosa-svn-pre-commit/05-aliases.t
@@ -1,0 +1,303 @@
+#!/bin/bash
+#-------------------------------------------------------------------------------
+# Copyright (C) 2012-2020 British Crown (Met Office) & Contributors.
+#
+# This file is part of Rose, a framework for meteorological suites.
+#
+# Rose is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Rose is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Rose. If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Tests for "rosa svn-pre-commit" with username aliasing behaviour.
+#-------------------------------------------------------------------------------
+. $(dirname $0)/test_header
+export ROSE_CONF_PATH=
+mkdir conf
+cat >conf/rose.conf <<'__ROSE_CONF__'
+[rosa-svn-pre-commit]
+super-users=rosie
+__ROSE_CONF__
+#-------------------------------------------------------------------------------
+tests 70
+#-------------------------------------------------------------------------------
+mkdir repos
+svnadmin create repos/foo
+SVN_URL=file://$PWD/repos/foo
+ROSE_BIN=$(dirname $(command -v rose))
+ROSE_LIB=$(dirname $(python -c "import metomi.rose; print(metomi.rose.__file__)"))
+export ROSE_LIB ROSE_BIN
+cat > repos/foo/hooks/pre-commit << __PRE_COMMIT__
+#!/bin/bash
+export ROSE_CONF_PATH=$PWD/conf
+export PATH=$PATH:${ROSE_BIN}
+export ROSE_LIB=${ROSE_LIB}
+rosa svn-pre-commit "\$@"
+__PRE_COMMIT__
+chmod +x repos/foo/hooks/pre-commit
+export LANG=C
+#-------------------------------------------------------------------------------
+TEST_KEY=$TEST_KEY_BASE-create-good
+cat >rose-suite.info <<__ROSE_SUITE_INFO__
+access-list=frank dave
+owner=daisy
+project=rose
+title=${TEST_KEY}
+__ROSE_SUITE_INFO__
+run_pass "$TEST_KEY" \
+    svn import rose-suite.info -q -m 't' --non-interactive \
+    $SVN_URL/a/a/0/0/0/trunk/rose-suite.info
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+svnlook changed repos/foo >"$TEST_KEY.changed"
+file_cmp "$TEST_KEY.changed" "$TEST_KEY.changed" <<'__CHANGED__'
+A   a/
+A   a/a/
+A   a/a/0/
+A   a/a/0/0/
+A   a/a/0/0/0/
+A   a/a/0/0/0/trunk/
+A   a/a/0/0/0/trunk/rose-suite.info
+__CHANGED__
+#-------------------------------------------------------------------------------
+TEST_KEY=$TEST_KEY_BASE-modify-good
+svn checkout -q $SVN_URL/a/a/0/0/0/trunk/ aa000/
+echo "vehicle=bicycle" >>aa000/rose-suite.info
+REV1=$(svn info --show-item revision aa000/)
+run_pass "$TEST_KEY" svn commit -q -m 't' --username=daisy aa000
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+svn update -q aa000
+REV2=$(svn info --show-item revision aa000/)
+run_pass "$TEST_KEY.rev" bash -c "(( $REV2 > $REV1 ))"
+svnlook changed repos/foo >"$TEST_KEY.changed"
+file_cmp "$TEST_KEY.changed" "$TEST_KEY.changed" <<'__CHANGED__'
+U   a/a/0/0/0/trunk/rose-suite.info
+__CHANGED__
+#-------------------------------------------------------------------------------
+TEST_KEY=$TEST_KEY_BASE-modify-bad
+svn update -q aa000
+echo "subtitle=answer" >>aa000/rose-suite.info
+run_fail "$TEST_KEY" svn commit -q -m 't' --username=hal aa000
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" <<'__ERR__'
+svn: E165001: Commit failed (details follow):
+svn: E165001: Commit blocked by pre-commit hook (exit code 1) with output:
+[FAIL] PERMISSION DENIED: U   a/a/0/0/0/trunk/rose-suite.info: User not in access list
+
+__ERR__
+#-------------------------------------------------------------------------------
+TEST_KEY=$TEST_KEY_BASE-create-alias-ok
+cat >rose-suite.info <<__ROSE_SUITE_INFO__
+owner=rosie_member0
+project=Rosie admin
+title=${TEST_KEY}
+__ROSE_SUITE_INFO__
+run_pass "$TEST_KEY" \
+    svn import rose-suite.info -q -m 't' --non-interactive \
+    $SVN_URL/R/O/S/I/E/trunk/rose-suite.info
+svn checkout -q $SVN_URL/R/O/S/I/E/trunk/ ROSIE/
+cat >ROSIE/author_aliases <<'__TEXT__'
+daisynew:daisy
+franknew:frank
+davenew:dave
+__TEXT__
+svn add -q ROSIE/author_aliases
+run_pass "$TEST_KEY" svn commit -q -m 't' --username=rosie_member0 ROSIE/
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+svnlook changed repos/foo >"$TEST_KEY.changed"
+file_cmp "$TEST_KEY.changed" "$TEST_KEY.changed" <<'__CHANGED__'
+A   R/O/S/I/E/trunk/author_aliases
+__CHANGED__
+rm -rf ROSIE
+#-------------------------------------------------------------------------------
+TEST_KEY=$TEST_KEY_BASE-modify-with-alias-good-1
+svn update -q aa000
+svn revert -R aa000
+echo "vehicle=carriage" >>aa000/rose-suite.info
+REV1=$(svn info --show-item revision aa000/)
+run_pass "$TEST_KEY" svn commit -q -m 't' --username=daisynew aa000
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+svn update -q aa000
+REV2=$(svn info --show-item revision aa000/)
+run_pass "$TEST_KEY.rev" bash -c "(( $REV2 > $REV1 ))"
+svnlook changed repos/foo >"$TEST_KEY.changed"
+file_cmp "$TEST_KEY.changed" "$TEST_KEY.changed" <<'__CHANGED__'
+U   a/a/0/0/0/trunk/rose-suite.info
+__CHANGED__
+#-------------------------------------------------------------------------------
+TEST_KEY=$TEST_KEY_BASE-modify-with-alias-good-2
+svn update -q aa000
+sed -i "s/owner=daisy/owner=daisynew/" aa000/rose-suite.info
+sed -i "s/access-list=frank dave/access-list=franknew davenew/" aa000/rose-suite.info
+touch aa000/extra-stuff
+svn add aa000/extra-stuff
+REV1=$(svn info --show-item revision aa000/)
+run_pass "$TEST_KEY" svn commit -q -m 't' --username=daisynew aa000
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+svn update -q aa000
+REV2=$(svn info --show-item revision aa000/)
+run_pass "$TEST_KEY.rev" bash -c "(( $REV2 > $REV1 ))"
+svnlook changed repos/foo >"$TEST_KEY.changed"
+file_cmp "$TEST_KEY.changed" "$TEST_KEY.changed" <<'__CHANGED__'
+A   a/a/0/0/0/trunk/extra-stuff
+U   a/a/0/0/0/trunk/rose-suite.info
+__CHANGED__
+#-------------------------------------------------------------------------------
+TEST_KEY=$TEST_KEY_BASE-modify-with-alias-bad
+echo "references=stretched" >>aa000/rose-suite.info
+run_fail "$TEST_KEY" svn commit -q -m 't' --username=hal aa000
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" <<'__ERR__'
+svn: E165001: Commit failed (details follow):
+svn: E165001: Commit blocked by pre-commit hook (exit code 1) with output:
+[FAIL] PERMISSION DENIED: U   a/a/0/0/0/trunk/rose-suite.info: User not in access list
+
+__ERR__
+#-------------------------------------------------------------------------------
+TEST_KEY=$TEST_KEY_BASE-modify-with-alias-access-list-good
+# Restore the state without aliases.
+svn update -q aa000
+sed -i "s/new//g" aa000/rose-suite.info
+REV1=$(svn info --show-item revision aa000/)
+run_pass "$TEST_KEY-setup" svn commit -q -m 't' --username=daisynew aa000
+file_cmp "$TEST_KEY-setup.out" "$TEST_KEY-setup.out" </dev/null
+file_cmp "$TEST_KEY-setup.err" "$TEST_KEY-setup.err" </dev/null
+svn update -q aa000
+REV2=$(svn info --show-item revision aa000/)
+run_pass "$TEST_KEY-setup.rev" bash -c "(( $REV2 > $REV1 ))"
+svnlook changed repos/foo >"$TEST_KEY-setup.changed"
+file_cmp "$TEST_KEY-setup.changed" "$TEST_KEY-setup.changed" <<'__CHANGED__'
+U   a/a/0/0/0/trunk/rose-suite.info
+__CHANGED__
+# Now change the owner and access-list but only to aliases.
+sed -i "s/owner=daisy/owner=daisynew/" aa000/rose-suite.info
+sed -i "s/access-list=frank dave/access-list=franknew davenew/" aa000/rose-suite.info
+REV1=$(svn info --show-item revision aa000/)
+run_pass "$TEST_KEY" svn commit -q -m 't' --username=franknew aa000
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+svn update -q aa000
+REV2=$(svn info --show-item revision aa000/)
+run_pass "$TEST_KEY.rev" bash -c "(( $REV2 > $REV1 ))"
+svnlook changed repos/foo >"$TEST_KEY.changed"
+file_cmp "$TEST_KEY.changed" "$TEST_KEY.changed" <<'__CHANGED__'
+U   a/a/0/0/0/trunk/rose-suite.info
+__CHANGED__
+#-------------------------------------------------------------------------------
+TEST_KEY=$TEST_KEY_BASE-modify-with-alias-access-list-bad-1
+# Restore the state without aliases.
+svn update -q aa000
+sed -i "s/new//g" aa000/rose-suite.info
+REV1=$(svn info --show-item revision aa000/)
+run_pass "$TEST_KEY-setup" svn commit -q -m 't' --username=daisynew aa000
+file_cmp "$TEST_KEY-setup.out" "$TEST_KEY-setup.out" </dev/null
+file_cmp "$TEST_KEY-setup.err" "$TEST_KEY-setup.err" </dev/null
+svn update -q aa000
+REV2=$(svn info --show-item revision aa000/)
+run_pass "$TEST_KEY-setup.rev" bash -c "(( $REV2 > $REV1 ))"
+svnlook changed repos/foo >"$TEST_KEY-setup.changed"
+file_cmp "$TEST_KEY-setup.changed" "$TEST_KEY-setup.changed" <<'__CHANGED__'
+U   a/a/0/0/0/trunk/rose-suite.info
+__CHANGED__
+# Access-list user trying to change the owner, should be blocked.
+sed -i "s/owner=daisy/owner=franknew/" aa000/rose-suite.info
+sed -i "s/access-list=frank dave/access-list=franknew davenew/" aa000/rose-suite.info
+REV1=$(svn info --show-item revision aa000/)
+run_fail "$TEST_KEY" svn commit -q -m 't' --username=franknew aa000
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" <<'__ERR__'
+svn: E165001: Commit failed (details follow):
+svn: E165001: Commit blocked by pre-commit hook (exit code 1) with output:
+[FAIL] PERMISSION DENIED: U   a/a/0/0/0/trunk/rose-suite.info: owner=franknew
+
+__ERR__
+#-------------------------------------------------------------------------------
+TEST_KEY=$TEST_KEY_BASE-modify-with-alias-access-list-bad-2
+svn revert -q -R aa000
+# Access-list user trying to change the access-list, should be blocked.
+sed -i "s/owner=daisy/owner=daisynew/" aa000/rose-suite.info
+sed -i "s/access-list=frank dave/access-list=franknew davenew heywood/" aa000/rose-suite.info
+REV1=$(svn info --show-item revision aa000/)
+run_fail "$TEST_KEY" svn commit -q -m 't' --username=franknew aa000
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" <<'__ERR__'
+svn: E165001: Commit failed (details follow):
+svn: E165001: Commit blocked by pre-commit hook (exit code 1) with output:
+[FAIL] PERMISSION DENIED: U   a/a/0/0/0/trunk/rose-suite.info: access-list=davenew franknew heywood
+
+__ERR__
+svn revert -q -R aa000
+svn update -q aa000
+REV2=$(svn info --show-item revision aa000/)
+run_pass "$TEST_KEY.rev" bash -c "(( $REV2 == $REV1 ))"
+#-------------------------------------------------------------------------------
+TEST_KEY=$TEST_KEY_BASE-delete-alias-ok
+svn checkout -q $SVN_URL/R/O/S/I/E/trunk/ ROSIE/
+svn delete ROSIE/author_aliases
+run_pass "$TEST_KEY" svn commit -q -m 't' --username=rosie ROSIE
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+svnlook changed repos/foo >"$TEST_KEY.changed"
+file_cmp "$TEST_KEY.changed" "$TEST_KEY.changed" <<'__CHANGED__'
+D   R/O/S/I/E/trunk/author_aliases
+__CHANGED__
+rm -rf ROSIE
+#-------------------------------------------------------------------------------
+TEST_KEY=$TEST_KEY_BASE-modify-no-alias-ok
+svn update -q aa000
+echo "plant=flower" >>aa000/rose-suite.info
+REV1=$(svn info --show-item revision aa000/)
+run_pass "$TEST_KEY" svn commit -q -m 't' --username=daisy aa000
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+svn update -q aa000
+REV2=$(svn info --show-item revision aa000/)
+run_pass "$TEST_KEY.rev" bash -c "(( $REV2 > $REV1 ))"
+svnlook changed repos/foo >"$TEST_KEY.changed"
+file_cmp "$TEST_KEY.changed" "$TEST_KEY.changed" <<'__CHANGED__'
+U   a/a/0/0/0/trunk/rose-suite.info
+__CHANGED__
+#-------------------------------------------------------------------------------
+TEST_KEY=$TEST_KEY_BASE-create-single-alias-ok
+svn checkout -q $SVN_URL/R/O/S/I/E/trunk ROSIE/
+cat >ROSIE/author_aliases <<'__TEXT__'
+daisynew2:daisy
+__TEXT__
+svn add -q ROSIE/author_aliases
+run_pass "$TEST_KEY" svn commit -q -m 't' --username=rosie_member0 ROSIE
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+svnlook changed repos/foo >"$TEST_KEY.changed"
+file_cmp "$TEST_KEY.changed" "$TEST_KEY.changed" <<'__CHANGED__'
+A   R/O/S/I/E/trunk/author_aliases
+__CHANGED__
+rm -rf ROSIE
+#-------------------------------------------------------------------------------
+TEST_KEY=$TEST_KEY_BASE-modify-with-single-alias-good
+svn update -q aa000
+echo "bicycle_for=two" >>aa000/rose-suite.info
+REV1=$(svn info --show-item revision aa000/)
+run_pass "$TEST_KEY" svn commit -q -m 't' --username=daisynew2 aa000
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+svn update -q aa000
+REV2=$(svn info --show-item revision aa000/)
+run_pass "$TEST_KEY.rev" bash -c "(( $REV2 > $REV1 ))"
+svnlook changed repos/foo >"$TEST_KEY.changed"
+file_cmp "$TEST_KEY.changed" "$TEST_KEY.changed" <<'__CHANGED__'
+U   a/a/0/0/0/trunk/rose-suite.info
+__CHANGED__
+#-------------------------------------------------------------------------------
+exit 0


### PR DESCRIPTION
Closes #3036

Copies changes from #2732, with minor modifications to pass flake8

> Allow alternate usernames in order to support migrating a roses repository to a place with different auth.