### PR TITLE
rosie disco: change service root to 'rosie'

### DIFF
--- a/changes.d/3040.feat.md
+++ b/changes.d/3040.feat.md
@@ -1,0 +1,1 @@
+Change rosie disco service root to `rosie`.

--- a/metomi/rosie/ws.py
+++ b/metomi/rosie/ws.py
@@ -86,6 +86,10 @@ class RosieDiscoServiceApplication(tornado.web.Application):
                     ".", 1
                 )[0]
         self.props["rose_version"] = ROSE_VERSION
+        if self.service_root_mode:
+            self.props["static_url_prefix"] = "/%s/static/" % (self.NAMESPACE)
+        else:
+            self.props["static_url_prefix"] = "/static/"
 
         # Get location of HTML files from package
         rosie_lib = str(files('metomi.rosie').joinpath(
@@ -116,7 +120,7 @@ class RosieDiscoServiceApplication(tornado.web.Application):
         self.db_url_map = db_url_map
 
         # Specify the root URL for the handlers and template.
-        ROOT = "%s-%s" % (self.NAMESPACE, self.UTIL)
+        ROOT = "%s" % (self.NAMESPACE)
         service_root = r"/?"
         if self.service_root_mode:
             service_root = service_root.replace("?", ROOT + r"/?")
@@ -177,6 +181,7 @@ class RosieDiscoServiceApplication(tornado.web.Application):
             static_path=str(
                 Path(metomi.rosie.__file__).parent / 'lib/html/static'
             ),
+            static_url_prefix=self.props["static_url_prefix"]
         )
         super(RosieDiscoServiceApplication, self).__init__(
             handlers, **settings
@@ -218,7 +223,7 @@ class RosieDiscoServiceRoot(tornado.web.RequestHandler):
                 title=self.props["title"],
                 host=self.props["host_name"],
                 rose_version=self.props["rose_version"],
-                script="/static",
+                script=self.props["static_url_prefix"].rstrip("/"),
                 keys=sorted(self.db_url_map.keys()),
             )
         )
@@ -274,7 +279,7 @@ class RosieDiscoService(tornado.web.RequestHandler):
                 title=self.props["title"],
                 host=self.props["host_name"],
                 rose_version=self.props["rose_version"],
-                script="/static",
+                script=self.props["static_url_prefix"].rstrip("/"),
                 service_root=self.service_root,
                 prefix=self.prefix,
                 prefix_source_url=self.source_url,
@@ -560,7 +565,7 @@ def main():
         print("Started" + user_msg_end)
         append_url_root = ""
         if app.service_root_mode:
-            append_url_root = "%s-%s/" % (app.NAMESPACE, app.UTIL)
+            append_url_root = "%s/" % (app.NAMESPACE)
         # Also print the URL for quick access; 'http://' added so that the URL
         # is hyperlinked in the terminal stdout, but it is not required.
         print(

--- a/t/lib/bash/test_header
+++ b/t/lib/bash/test_header
@@ -402,7 +402,7 @@ rose_ws_init() {
     TEST_ROSE_WS_PORT="${PORT}"
     if port_is_busy "${TEST_ROSE_WS_PORT}"; then
         pass "${TEST_KEY}"
-        TEST_ROSE_WS_URL="http://$(hostname -f):${TEST_ROSE_WS_PORT}/${NS}-${UTIL}"
+        TEST_ROSE_WS_URL="http://$(hostname -f):${TEST_ROSE_WS_PORT}/${NS}"
     else
         fail "${TEST_KEY}"
         rose_ws_kill


### PR DESCRIPTION
- We have always used `/rosie` as the service root when hosting via Apache - this PR changes "service root mode" to match.
- The static content also needs to be served via the service root in order to run rosie disco as a service accessed via a proxy.