### PR TITLE
cylc 8.6.x changes

### DIFF
--- a/metomi/rose/rose.py
+++ b/metomi/rose/rose.py
@@ -96,11 +96,11 @@ DEAD_ENDS = {
     ('rose', 'task-hook'):
         'Command obsolete, use Cylc event handlers',
     ('rose', 'suite-log-view'):
-        'This command has been removed: use cylc review at Cylc 7 instead.',
+        'This command has been removed: use cylc review instead.',
     ('rose', 'suite-log'):
-        'This command has been removed: use cylc review at Cylc 7 instead.',
+        'This command has been removed: use cylc review instead.',
     ('rose', 'slv'):
-        'This command has been removed: use cylc review at Cylc 7 instead.',
+        'This command has been removed: use cylc review instead.',
     ('rose', 'suite-restart'):
         'This command has been replaced by: "cylc restart".',
     ('rose', 'suite-run'):

--- a/sphinx/tutorial/rose/suites.rst
+++ b/sphinx/tutorial/rose/suites.rst
@@ -524,12 +524,13 @@ Rose Applications In Rose Suite Configurations
 
       .. note:: Manually starting Cylc Review
 
-         ``cylc review`` is a Cylc 7 utility which can view Cylc 8 workflows.
+         Cylc Review is part of the cylc-uiserver package
+         (see the :external+cylc:ref:`Cylc installation <installation>`
+         docs).
 
-         If you have Cylc 7 installed you can start a Cylc Review server by
-         running the following command and opening the printed URL::
+         To start a server, run::
 
-            CYLC_VERSION=7 cylc review start
+            cylc review start
 
 
       Navigate to your latest rose-suite-tutorial run and click


### PR DESCRIPTION
* Cylc Review has been moved to the 8.6 meta-release.
* ~The tutorial workflow has been updated on 8.6.x.~ (now handled on Sam's branch)

There are further tutorial changes to come, but can update what we've got so far.