### PR TITLE
Updating tutorials to match config consolidation tutorials in cylc

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -40,3 +40,4 @@ Joe Marsh Rossney    <17361029+jmarshrossney@users.noreply.github.com> <17361029
 Joseph Abram         <joseph.abram@metoffice.gov.uk>      J-J-Abram            <joseph.abram@metoffice.gov.uk>
 Joseph Abram         <joseph.abram@metoffice.gov.uk>      J-J-Abram            <98320699+J-J-Abram@users.noreply.github.com>
 Christopher Bennett  <christopher.bennett@metoffice.gov.uk> christopher.bennett  <christopher.bennett@metoffice.gov.uk>
+Samuel Denton        <samuel.denton@metoffice.gov.uk>     samuel-denton         <samuel.denton@metoffice.gov.uk>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,6 +74,7 @@ below:
  - Joseph Abram (Met Office, UK)
  - James Frost (Met Office, UK)
  - Christopher Bennett (Met Office, UK)
+ - Samuel Denton (Met Office, UK)
 <!-- end-shortlog -->
 
 (All contributors are identifiable with email addresses in the version control

--- a/metomi/rose/etc/tutorial/cylc-forecasting-workflow/flow.cylc
+++ b/metomi/rose/etc/tutorial/cylc-forecasting-workflow/flow.cylc
@@ -1,9 +1,14 @@
 #!jinja2
+
+{# Generate 5 forecasts at 60 minute intervals. #}
+{% set FORECAST_LENGTH = 60 %}
+{% set FORECAST_COUNT = 5 %}
+
 [task parameters]
     # A list of the weather stations we will be fetching observations from.
-    station = camborne, heathrow, shetland, aldergrove
+    station = aldergrove, camborne, heathrow, shetland
     # A list of the sites we will be generating forecasts for.
-    site = exeter
+    site = exeter, edinburgh
 
 [scheduling]
     # Start the workflow 7 hours before now ignoring minutes and seconds
@@ -67,7 +72,7 @@
         script = get-rainfall
 
     [[forecast]]
-        script = forecast 60 5  # Generate 5 forecasts at 60 minute intervals.
+        script = forecast {{ FORECAST_LENGTH }} {{ FORECAST_COUNT }}  # Generate 5 forecasts at 60 minute intervals.
         [[[environment]]]
             # The path to the files containing wind data (the {variables} will
             # get substituted in the forecast script).
@@ -82,7 +87,7 @@
             MAP_TEMPLATE = "$CYLC_WORKFLOW_RUN_DIR/lib/template/map.html"
 
     [[post_process<site>]]
-        # Generate a forecast for the location <site> 60 minutes in the future.
-        script = post-process $CYLC_TASK_PARAM_site 60
+        #  Generate a forecast {{ FORECAST_LENGTH * FORECAST_COUNT }} minutes in the future for <site>
+        script = post-process $CYLC_TASK_PARAM_site {{ FORECAST_LENGTH * FORECAST_COUNT }}
 
 {% include 'etc/python-job.settings' %}

--- a/metomi/rose/etc/tutorial/cylc-forecasting-workflow/flow.cylc
+++ b/metomi/rose/etc/tutorial/cylc-forecasting-workflow/flow.cylc
@@ -87,7 +87,7 @@
             MAP_TEMPLATE = "$CYLC_WORKFLOW_RUN_DIR/lib/template/map.html"
 
     [[post_process<site>]]
-        #  Generate a forecast {{ FORECAST_LENGTH * FORECAST_COUNT }} minutes in the future for <site>
+        #  Generate a forecast [length * count] minutes in the future for <site>
         script = post-process $CYLC_TASK_PARAM_site {{ FORECAST_LENGTH * FORECAST_COUNT }}
 
 {% include 'etc/python-job.settings' %}

--- a/sphinx/tutorial/rose/applications.rst
+++ b/sphinx/tutorial/rose/applications.rst
@@ -152,7 +152,7 @@ An application can be run using the :ref:`command-rose-app-run` command:
       come later).
    .. note::
       :class: hint
-      
+
       This practical can stand on it's own, but it will be easier to follow if
       you have already completed the
       :ref:`Cylc tutorials <tutorial-cylc-runtime-forecasting-workflow>`.
@@ -245,9 +245,9 @@ An application can be run using the :ref:`command-rose-app-run` command:
       * ``MAP_TEMPLATE``
 
       We will now add these into the application. This way, all of the
-      configuration specific to the application live within it.  The variable names
+      configuration specific to the application live within it. The variable names
       and values are provided here in case you have not completed the previous Cylc
-      tutorial.  We also adjust some of the values to point at the test data files
+      tutorial. We also adjust some of the values to point at the test data files
       so ensure you copy these values rather than from the previous tutorial.
 
       Add the following lines to the :rose:conf:`rose-app.conf[env]` section:

--- a/sphinx/tutorial/rose/applications.rst
+++ b/sphinx/tutorial/rose/applications.rst
@@ -176,7 +176,7 @@ An application can be run using the :ref:`command-rose-app-run` command:
 
       * The ``bin/forecast`` script.
       * The ``bin/util.py`` Python library.
-      * The ``file/map.html`` HTML template.
+      * The ``file/map-template.html`` HTML template.
 
       We will move all these resources into a single application directory.
 

--- a/sphinx/tutorial/rose/applications.rst
+++ b/sphinx/tutorial/rose/applications.rst
@@ -245,10 +245,7 @@ An application can be run using the :ref:`command-rose-app-run` command:
       * ``MAP_TEMPLATE``
 
       We will now add these into the application. This way, all of the
-      configuration specific to the application live within it. The variable names
-      and values are provided here in case you have not completed the previous Cylc
-      tutorial. We also adjust some of the values to point at the test data files
-      so ensure you copy these values rather than from the previous tutorial.
+      configuration specific to the application live within it.
 
       Add the following lines to the :rose:conf:`rose-app.conf[env]` section:
 
@@ -268,6 +265,12 @@ An application can be run using the :ref:`command-rose-app-run` command:
          MAP_FILE=map.html
          # The path to the HTML map template file.
          MAP_TEMPLATE=map-template.html
+
+      .. note::
+         :class: hint
+
+         The values given here are slightly different to those in the previous
+         Cylc tutorial; use these values.
 
       Note that the ``WIND_FILE_TEMPLATE`` and ``RAINFALL_FILE`` environment
       variables are pointing at files in the ``test-data`` directory.

--- a/sphinx/tutorial/rose/applications.rst
+++ b/sphinx/tutorial/rose/applications.rst
@@ -151,10 +151,16 @@ An application can be run using the :ref:`command-rose-app-run` command:
       the application standalone (running it as a task in the workflow will
       come later).
 
-   #. **Create a directory on your filesystem called ``rose-tutorial``::**
+      This practical can stand on it's own, but it will be easier to follow if
+      you have already completed the
+      :ref:`Cylc tutorials <tutorial-cylc-runtime-forecasting-workflow>`.
 
-      mkdir ~/rose-tutorial
-      cd ~/rose-tutorial
+   #. **Create a directory on your filesystem called** ``rose-tutorial``::
+
+      This directory will be used for multiple Rose tutorials.
+
+        mkdir ~/rose-tutorial
+        cd ~/rose-tutorial
 
    #. **Create a Rose application**
 
@@ -170,8 +176,8 @@ An application can be run using the :ref:`command-rose-app-run` command:
       The application gets three resources from different places:
 
       * The ``bin/forecast`` script.
-      * The ``lib/python/util.py`` Python library.
-      * The ``lib/template/map.html`` HTML template.
+      * The ``bin/util.py`` Python library.
+      * The ``file/map.html`` HTML template.
 
       We will move all these resources into a single application directory.
 
@@ -227,7 +233,8 @@ An application can be run using the :ref:`command-rose-app-run` command:
    #. **Move environment variables defined in the** ``flow.cylc`` **file.**
 
       In the ``[runtime][forecast][environment]`` section of the ``flow.cylc``
-      file in the weather-forecasting workflow we set a few environment variables:
+      file in the :ref:`Cylc tutorials <tutorial-cylc-runtime-forecasting-workflow>`
+      we set a few environment variables:
 
       * ``WIND_FILE_TEMPLATE``
       * ``WIND_CYCLES``
@@ -236,7 +243,10 @@ An application can be run using the :ref:`command-rose-app-run` command:
       * ``MAP_TEMPLATE``
 
       We will now add these into the application. This way, all of the
-      configuration specific to the application live within it.
+      configuration specific to the application live within it.  The variable names
+      and values are provided here in case you have not completed the previous Cylc
+      tutorial.  We also adjust some of the values to point at the test data files
+      so ensure you copy these values rather than from the previous tutorial.
 
       Add the following lines to the :rose:conf:`rose-app.conf[env]` section:
 
@@ -267,7 +277,7 @@ An application can be run using the :ref:`command-rose-app-run` command:
       file as well as the ``CYLC_TASK_CYCLE_POINT`` environment variable
       provided by Cylc when it runs a task.
 
-      Add the following lines to the :rose:file:`rose-app.conf`:
+      Add the following lines to the :rose:conf:`rose-app.conf[env]` section:
 
       .. code-block:: rose
 
@@ -293,5 +303,7 @@ An application can be run using the :ref:`command-rose-app-run` command:
          cd run
          rose app-run -C ../
 
+      ../ here is the path to the application directory, assuming you created
+      the run directory inside the application directory.
       The application should run successfully, leaving behind some files. Try
       opening the ``map.html`` file in a web browser.

--- a/sphinx/tutorial/rose/applications.rst
+++ b/sphinx/tutorial/rose/applications.rst
@@ -305,7 +305,10 @@ An application can be run using the :ref:`command-rose-app-run` command:
          cd run
          rose app-run -C ../
 
-      ../ here is the path to the application directory, assuming you created
-      the run directory inside the application directory.
+      .. note::
+         :class: hint
+
+         ``../`` is the path to the Rose application directory.
+
       The application should run successfully, leaving behind some files. Try
       opening the ``map.html`` file in a web browser.

--- a/sphinx/tutorial/rose/applications.rst
+++ b/sphinx/tutorial/rose/applications.rst
@@ -181,8 +181,7 @@ An application can be run using the :ref:`command-rose-app-run` command:
       * The ``lib/python/util.py`` Python library.
       * The ``lib/template/map.html`` HTML template.
 
-      We will now create a Rose application which bundles all of these resources into
-      a single directory.
+      We will now bundle these resources into our Rose Application.
 
       This makes a rose application easier to maintain by keeping all the
       files required in the same place.

--- a/sphinx/tutorial/rose/applications.rst
+++ b/sphinx/tutorial/rose/applications.rst
@@ -236,7 +236,7 @@ An application can be run using the :ref:`command-rose-app-run` command:
 
       In the ``[runtime][forecast][environment]`` section of the ``flow.cylc``
       file in the :ref:`Cylc tutorials <tutorial-cylc-runtime-forecasting-workflow>`
-      we set a few environment variables:
+      we had set a few environment variables:
 
       * ``WIND_FILE_TEMPLATE``
       * ``WIND_CYCLES``

--- a/sphinx/tutorial/rose/applications.rst
+++ b/sphinx/tutorial/rose/applications.rst
@@ -175,13 +175,14 @@ An application can be run using the :ref:`command-rose-app-run` command:
    #. **Provide the required resources in the** ``application-tutorial``
       **application.**
 
-      The application gets three resources from different places:
+      The `forecast` task from the Cylc workflow used resources in three locations:
 
       * The ``bin/forecast`` script.
-      * The ``bin/util.py`` Python library.
-      * The ``file/map-template.html`` HTML template.
+      * The ``lib/python/util.py`` Python library.
+      * The ``lib/template/map.html`` HTML template.
 
-      We will move all these resources into a single application directory.
+      We will now create a Rose application which bundles all of these resources into
+      a single directory.
 
       This makes a rose application easier to maintain by keeping all the
       files required in the same place.

--- a/sphinx/tutorial/rose/applications.rst
+++ b/sphinx/tutorial/rose/applications.rst
@@ -150,6 +150,9 @@ An application can be run using the :ref:`command-rose-app-run` command:
       into a standalone Rose application. By the end you will be able to run
       the application standalone (running it as a task in the workflow will
       come later).
+   .. note::
+      :class: hint
+      
       This practical can stand on it's own, but it will be easier to follow if
       you have already completed the
       :ref:`Cylc tutorials <tutorial-cylc-runtime-forecasting-workflow>`.

--- a/sphinx/tutorial/rose/applications.rst
+++ b/sphinx/tutorial/rose/applications.rst
@@ -150,14 +150,13 @@ An application can be run using the :ref:`command-rose-app-run` command:
       into a standalone Rose application. By the end you will be able to run
       the application standalone (running it as a task in the workflow will
       come later).
-
       This practical can stand on it's own, but it will be easier to follow if
       you have already completed the
       :ref:`Cylc tutorials <tutorial-cylc-runtime-forecasting-workflow>`.
 
-   #. **Create a directory on your filesystem called** ``rose-tutorial``::
+   #. **Create a directory on your filesystem called** ``rose-tutorial``
 
-      This directory will be used for multiple Rose tutorials.
+      This directory will be used for multiple Rose tutorials.::
 
         mkdir ~/rose-tutorial
         cd ~/rose-tutorial

--- a/sphinx/tutorial/rose/applications.rst
+++ b/sphinx/tutorial/rose/applications.rst
@@ -151,7 +151,7 @@ An application can be run using the :ref:`command-rose-app-run` command:
       the application standalone (running it as a task in the workflow will
       come later).
 
-   Create a directory on your filesystem called ``rose-tutorial``::
+   #. **Create a directory on your filesystem called ``rose-tutorial``::**
 
       mkdir ~/rose-tutorial
       cd ~/rose-tutorial

--- a/sphinx/tutorial/rose/metadata.rst
+++ b/sphinx/tutorial/rose/metadata.rst
@@ -172,6 +172,9 @@ Metadata Items
          configuration in the current directory. Use the ``-C`` option
          to specify another directory.
 
+         The ``&`` at the end of the command runs it in the background so that
+         you can continue to use the terminal.
+
       In the panel on the left you will see the different sections of the
       :rose:file:`rose-app.conf` file.
 
@@ -224,6 +227,8 @@ Metadata Items
       Next reload the metadata in the :ref:`command-rose-config-edit` window
       using the :menuselection:`Metadata --> Refresh Metadata` menu item.
       The descriptions should now display under each environment variable.
+      Comments removed from the :rose:file:`rose-app.conf` file may not disappear
+      on the refresh so you may need to close and reopen the window.
 
       .. tip::
 

--- a/sphinx/tutorial/rose/metadata.rst
+++ b/sphinx/tutorial/rose/metadata.rst
@@ -227,8 +227,12 @@ Metadata Items
       Next reload the metadata in the :ref:`command-rose-config-edit` window
       using the :menuselection:`Metadata --> Refresh Metadata` menu item.
       The descriptions should now display under each environment variable.
-      Comments removed from the :rose:file:`rose-app.conf` file may not disappear
-      on the refresh so you may need to close and reopen the window.
+
+      .. note::
+         :class: hint
+
+         The comments are part of the configuration rather than the metadata,
+         so they won't disappear from the GUI until it is closed/reopened.
 
       .. tip::
 

--- a/sphinx/tutorial/rose/suites.rst
+++ b/sphinx/tutorial/rose/suites.rst
@@ -250,10 +250,10 @@ Using a Rose workflow configuration with Cylc 8
 
           [task parameters]
              # A list of the weather stations we will be fetching observations from.
-         -   station = camborne, heathrow, shetland, aldergrove
+         -   station = aldergrove, camborne, heathrow, shetland
          +   station = {{ station | join(", ") }}
              # A list of the sites we will be generating forecasts for.
-             site = exeter
+             site = exeter, edinburgh
 
    #. **Install the workflow**
 

--- a/sphinx/tutorial/rose/suites.rst
+++ b/sphinx/tutorial/rose/suites.rst
@@ -167,8 +167,8 @@ Using a Rose workflow configuration with Cylc 8
       You now have a Rose suite configuration. A :rose:file:`rose-suite.conf`
       file does not need to have anything in it.
 
-      There are three things defined in the ``flow.cylc`` file which it might be
-      useful to be able to configure:
+      There are a few things defined in the ``flow.cylc`` file which it might be
+      useful to be able to configure, we are going to focus on:
 
       ``station``
          The list of weather stations to gather observations from.
@@ -183,7 +183,7 @@ Using a Rose workflow configuration with Cylc 8
       .. code-block:: rose
 
          [template variables]
-         station="camborne", "heathrow", "shetland", "aldergrove"
+         station="aldergrove", "camborne", "heathrow", "shetland"
          RESOLUTION=0.2
          DOMAIN=-12,46,12,61
 
@@ -476,6 +476,13 @@ Rose Applications In Rose Suite Configurations
          WIND_CYCLES=0, -3, -6
          RAINFALL_FILE=$CYLC_WORKFLOW_WORK_DIR/$CYLC_TASK_CYCLE_POINT/get_rainfall/rainfall.csv
          MAP_FILE=${CYLC_TASK_LOG_ROOT}-map.html
+
+      .. note::
+
+          We have removed the ``CYLC_TASK_CYCLE_POINT``, ``RESOLUTION`` and ``DOMAIN`` environment
+          variables; the ``RESOLUTION`` and ``DOMAIN`` are provided by the suite configuration and
+          since we are not using the test data, we want the ``CYLC_TASK_CYCLE_POINT`` variable to
+          be provided by Cylc rather than hard coded.
 
       Finally we need to change the ``forecast`` task to run
       :ref:`command-rose-task-run`. The ``[runtime]forecast`` section of the

--- a/sphinx/tutorial/rose/suites.rst
+++ b/sphinx/tutorial/rose/suites.rst
@@ -480,8 +480,9 @@ Rose Applications In Rose Suite Configurations
       .. tip::
 
           Note the env vars ``CYLC_TASK_CYCLE_POINT``, ``RESOLUTION`` and ``DOMAIN`` should no
-          longer be set in :rose:file:`rose-app.conf`. The ``RESOLUTION`` and ``DOMAIN`` are provided
-          by the suite configuration, and the ``CYLC_TASK_CYCLE_POINT`` should be provided by Cylc.
+          longer be set in`rose-app.conf`. The ``RESOLUTION`` and ``DOMAIN`` are provided by
+          `rose-suite.conf` and overwritten in `rose-app-test.conf`, and the ``CYLC_TASK_CYCLE_POINT``
+          should be provided by Cylc.
 
       Finally we need to change the ``forecast`` task to run
       :ref:`command-rose-task-run`. The ``[runtime]forecast`` section of the

--- a/sphinx/tutorial/rose/suites.rst
+++ b/sphinx/tutorial/rose/suites.rst
@@ -477,7 +477,7 @@ Rose Applications In Rose Suite Configurations
          RAINFALL_FILE=$CYLC_WORKFLOW_WORK_DIR/$CYLC_TASK_CYCLE_POINT/get_rainfall/rainfall.csv
          MAP_FILE=${CYLC_TASK_LOG_ROOT}-map.html
 
-      .. note::
+      .. tip::
 
           We have removed the ``CYLC_TASK_CYCLE_POINT``, ``RESOLUTION`` and ``DOMAIN`` environment
           variables; the ``RESOLUTION`` and ``DOMAIN`` are provided by the suite configuration and

--- a/sphinx/tutorial/rose/suites.rst
+++ b/sphinx/tutorial/rose/suites.rst
@@ -479,10 +479,9 @@ Rose Applications In Rose Suite Configurations
 
       .. tip::
 
-          We have removed the ``CYLC_TASK_CYCLE_POINT``, ``RESOLUTION`` and ``DOMAIN`` environment
-          variables; the ``RESOLUTION`` and ``DOMAIN`` are provided by the suite configuration and
-          since we are not using the test data, we want the ``CYLC_TASK_CYCLE_POINT`` variable to
-          be provided by Cylc rather than hard coded.
+          Note the env vars ``CYLC_TASK_CYCLE_POINT``, ``RESOLUTION`` and ``DOMAIN`` should no
+          longer be set in :rose:file:`rose-app.conf`. The ``RESOLUTION`` and ``DOMAIN`` are provided
+          by the suite configuration, and the ``CYLC_TASK_CYCLE_POINT`` should be provided by Cylc.
 
       Finally we need to change the ``forecast`` task to run
       :ref:`command-rose-task-run`. The ``[runtime]forecast`` section of the


### PR DESCRIPTION
https://wwwspice/~samuel.denton/rose-doc/consolidation_tutorial_update/html/tutorial/rose/applications.html
Few small changes to diff text and example code to realign with the cylc tutorial it follows on from.