### PR TITLE
Tutorial: Update value of `MAP_TEMPLATE` in a practical step of `rose-app.conf`

### DIFF
--- a/sphinx/tutorial/rose/suites.rst
+++ b/sphinx/tutorial/rose/suites.rst
@@ -470,7 +470,7 @@ Rose Applications In Rose Suite Configurations
          INTERVAL=60
          N_FORECASTS=5
          WEIGHTING=1
-         MAP_TEMPLATE=map-template.html
+         MAP_TEMPLATE=$CYLC_WORKFLOW_RUN_DIR/lib/template/map.html
          SPLINE_LEVEL=0
          WIND_FILE_TEMPLATE=$CYLC_WORKFLOW_WORK_DIR/{cycle}/consolidate_observations/wind_{xy}.csv
          WIND_CYCLES=0, -3, -6


### PR DESCRIPTION
The lines a little above say:

>    Copy the remaining environment variables defined in the `forecast`
>      task within the `flow.cylc` file into the `rose-app.conf`
>      file of the `forecast` application, replacing any values already
>      specified if necessary. Remove the lines from the `flow.cylc` file
>      when you are done.

And `MAP_TEMPLATE` has a new value in `flow.cylc` for me, so shouldn't the answer look like I've indicated in the diff?