### PR TITLE
Tutorial: Change `title` to `description` in `metadata.rst`

### DIFF
--- a/sphinx/tutorial/rose/metadata.rst
+++ b/sphinx/tutorial/rose/metadata.rst
@@ -69,7 +69,7 @@ The Metadata Format
    values=Mercury, Venus, Earth, Mars, Jupiter,
          =Saturn, Uranus, Neptune
 
-This example gives the ``WORLD`` variable a title and a list of allowed values.
+This example gives the ``WORLD`` variable a description and a list of allowed values.
 
 
 Metadata Commands


### PR DESCRIPTION
In the example above, a `description` is set rather than a `title`. Since, according to the page, `title` and `description` are both valid keys, maybe it's a bit confused to use `description` in the code but `title` in the text.

I suggest being consistent, one way or the other.