### PR TITLE
actions: remove obsolete wandisco stuff

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -185,13 +185,6 @@ jobs:
             libdbi-perl \
             libdbd-sqlite3-perl
 
-          # install wandisco
-          sudo sh -c 'echo "deb http://opensource.wandisco.com/ubuntu \
-            `lsb_release -cs` svn19" \
-            >> /etc/apt/sources.list.d/subversion19.list'
-          sudo wget -q http://opensource.wandisco.com/wandisco-debian.gpg -O- \
-            | sudo apt-key add -
-
           # prepend FCM bin to $PATH
           FCM_PATH="$GITHUB_WORKSPACE/fcm/bin"
           # the github actions way (needed for cylc jobs)


### PR DESCRIPTION
From Dave:

>    I don't think those lines do anything (I think they would have be run before Subversion is installed to take effect).
>
>    I think they date back to a time when the version of Subversion that came with Ubuntu was too old.
>    They shouldn't be needed now - just remove them.

Should get tests passing again :crossed_fingers: 

See also: https://github.com/cylc/cylc-rose/pull/433