### PR TITLE
actions: fix rose installation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -144,13 +144,12 @@ jobs:
       - name: Configure git  # Configure Git for Git dependent tests.
         uses: cylc/release-actions/configure-git@v1
 
-      - name: Install Rose
+      - name: Install Node Packages
         working-directory: rose
         run: |
-          pip install ."[tests,docs,rose-edit,graph,rosa,disco]"
           yarn install
 
-      - name: Install Cylc
+      - name: Install
         uses: cylc/release-actions/install-cylc-components@v1
         with:
           branch: ${{ inputs.rose_ref || '' }}
@@ -162,6 +161,7 @@ jobs:
           cylc_rose_opts: ''
           cylc_rose_repo: ${{ inputs.cylc_rose_repo || 'cylc/cylc-rose' }}
           cylc_rose_tag: ${{ inputs.cylc_rose_tag }}
+          local_source: ./rose[tests,docs,rose-edit,graph,rosa,disco]
 
       - name: Checkout FCM
         if: startsWith(matrix.os, 'ubuntu')
@@ -250,11 +250,7 @@ jobs:
             pygobject>=3.50.0
             gtk3>=3.24.43
 
-      - name: Install Rose
-        run: |
-          pip install -e .[docs,graph,edit,disco] --upgrade-strategy='only-if-needed'
-
-      - name: Install Cylc
+      - name: Install
         uses: cylc/release-actions/install-cylc-components@v1
         with:
           branch: ${{ inputs.rose_ref || '' }}
@@ -266,6 +262,7 @@ jobs:
           cylc_rose_opts: ''
           cylc_rose_repo: ${{ inputs.cylc_rose_repo || 'cylc/cylc-rose' }}
           cylc_rose_tag: ${{ inputs.cylc_rose_tag }}
+          local_source: .[docs,graph,edit,disco]
 
       - name: build (html)
         run: |


### PR DESCRIPTION
Install Python packages in a single operation to avoid the risk of up/down-grading components or entering erroneous pip-backtracking loops.

Should fix this problem: https://github.com/metomi/rose/pull/3058#issuecomment-4789807210

And get the tests passing on master again.