### PR TITLE
actions: run main test CI on a schedule

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,8 @@ on:
       - 'pyproject.toml'  # check deps and project config
       - '.gitignore'
       - '.github/workflows/build.yml'
+  schedule:
+    - cron: '37 04 * * 1-5' # 04:37, Monday-Friday
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/test_rsync_test_script.yml
+++ b/.github/workflows/test_rsync_test_script.yml
@@ -11,6 +11,8 @@ on:
       rose_ref:
         description: The Rose branch to test against
         required: true
+  schedule:
+    - cron: '37 04 * */3 1-5' # 04:37 every 3 months
 
 jobs:
   test:


### PR DESCRIPTION
Run our main CI actions one a week in order to detect new failures caused by external factors.

This will help us to keep the project status page fresher: https://cylc.github.io/cylc-admin/status/status.html

Examples of external factors:

    New lint rules.
    New mypy improvements.
    Changes in an upstream Cylc repository.
    Changes in the [meta-release configuration](https://cylc.github.io/cylc-admin/status/status.html#branches).
    New releases of dependent software (incl. Python).
    Changes in GH actions (e.g, new runners, or removed support for old ones).
    Etc.