### PR TITLE
docs: fix warning

### DIFF
--- a/metomi/rose/config.py
+++ b/metomi/rose/config.py
@@ -65,15 +65,17 @@ Synopsis:
 
 Classes:
     .. autosummary::
-        metomi.rose.config.ConfigNode
-        metomi.rose.config.ConfigNodeDiff
-        metomi.rose.config.ConfigDumper
-        metomi.rose.config.ConfigLoader
+
+       ConfigNode
+       ConfigNodeDiff
+       ConfigDumper
+       ConfigLoader
 
 Functions:
     .. autosummary::
-       metomi.rose.config.load
-       metomi.rose.config.dump
+
+       load
+       dump
 
 Limitations:
     - The loader does not handle trailing comments.


### PR DESCRIPTION
This fixes a newly added Sphinx warning which has been causing the docs to fail.

This code gets auto-documented here: https://metomi.github.io/rose/doc/html/api/configuration/api.html#python

The presentation of those two tables will change as expected, but everything else seems to work fine.